### PR TITLE
ci: Bump and pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -123,7 +123,7 @@ runs:
           echo "test_targets_count=${test_targets_count}" >> "${GITHUB_OUTPUT}"
         shell: bash
       - name: Archive test target JSON
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.platform }}_test_targets_json
           path: cobalt/src/out/${{ matrix.platform }}_${{ matrix.config }}/test_targets.json
@@ -157,7 +157,7 @@ runs:
         shell: bash
       - name: Archive Android APKs
         if: (startsWith(matrix.platform, 'android') || startsWith(matrix.platform, 'aosp')) && matrix.config == 'qa'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.platform }} APKs
           path: |

--- a/.github/actions/docker/action.yaml
+++ b/.github/actions/docker/action.yaml
@@ -65,7 +65,7 @@ runs:
       shell: bash
 
     - name: Login to GitHub Docker Registry
-      uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
       with:
         registry: ghcr.io
         username: ${{ github.actor }}

--- a/.github/actions/linux_browser_tests/action.yaml
+++ b/.github/actions/linux_browser_tests/action.yaml
@@ -21,7 +21,7 @@ runs:
   using: "composite"
   steps:
     - name: Download Artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{ inputs.test_artifacts_key }}
         path: artifacts
@@ -77,7 +77,7 @@ runs:
 
     - name: Archive Browser Test Results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.test_results_key }}
         path: results/*

--- a/.github/actions/on_device_tests/action.yaml
+++ b/.github/actions/on_device_tests/action.yaml
@@ -154,7 +154,7 @@ runs:
         exit ${exit_code}
       shell: bash
     - name: Archive Test Results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
       with:
         name: ${{ inputs.test_results_key }}

--- a/.github/actions/on_host_tests/action.yaml
+++ b/.github/actions/on_host_tests/action.yaml
@@ -35,7 +35,7 @@ runs:
         git sparse-checkout add --skip-checks testing build third_party/catapult third_party/logdog
         git submodule update --init third_party/catapult
     - name: Download Artifacts
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{ inputs.test_artifacts_key }}
     - name: Extract Artifacts
@@ -200,7 +200,7 @@ runs:
         fi
     - name: Archive Test Results
       if: success() || failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.test_results_key }}
         path: ${{ env.results_dir }}/*

--- a/.github/actions/process_test_results/action.yaml
+++ b/.github/actions/process_test_results/action.yaml
@@ -21,7 +21,7 @@ runs:
   steps:
     - name: Create Test Summary
       id: test-summary
-      uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86
+      uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # v2.6
       with:
         paths: ${{ inputs.results_glob }}
         output: test-report-summary.md

--- a/.github/actions/test_targets_json/action.yaml
+++ b/.github/actions/test_targets_json/action.yaml
@@ -18,7 +18,7 @@ runs:
   steps:
     - name: Download Test Targets Json
       if: inputs.test_targets_json_file == 'test_targets.json'
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{ matrix.platform }}_test_targets_json
         path:

--- a/.github/actions/upload_test_artifacts/action.yaml
+++ b/.github/actions/upload_test_artifacts/action.yaml
@@ -144,7 +144,7 @@ runs:
       shell: bash
     - name: Upload On-Host Test Artifacts Archive
       if: inputs.upload_on_host_test_artifacts == 'true'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.test_artifacts_key }}
         path: artifacts/*

--- a/.github/actions/web_tests/action.yaml
+++ b/.github/actions/web_tests/action.yaml
@@ -11,7 +11,7 @@ runs:
   using: "composite"
   steps:
     - name: Download Artifacts
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{ inputs.test_artifacts_key }}
     - name: Extract Artifacts
@@ -47,7 +47,7 @@ runs:
         echo "Finished running tests..."
     - name: Archive Test Results
       if: always() && contains(fromJson('["success", "failed"]'), steps.run-tests.outcome)
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.test_results_key }}
         path: cobalt/src/${{ env.RESULTS_DIR }}/*

--- a/.github/workflows/autoroll_chromium.yaml
+++ b/.github/workflows/autoroll_chromium.yaml
@@ -36,7 +36,7 @@ jobs:
         ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: src
           ref: main

--- a/.github/workflows/autoroll_main.yaml
+++ b/.github/workflows/autoroll_main.yaml
@@ -36,7 +36,7 @@ jobs:
         ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: src
           ref: main

--- a/.github/workflows/deflake_tests.yml
+++ b/.github/workflows/deflake_tests.yml
@@ -1,5 +1,9 @@
+# Disable dangerous-triggers rule because this workflow uses workflow_run
+# strictly to check job results and rerun failed test jobs without executing
+# untrusted code.
+# actionlint: disable dangerous-triggers
 name: Deflake Tests
-on:
+on: # zizmor: ignore[dangerous-triggers]
   workflow_run:
     workflows: [android, raspi-2-modular, evergreen, linux, tvos]
     types:
@@ -18,6 +22,7 @@ jobs:
       - name: Checkout .github Files
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 1
           filter: blob:none
           sparse-checkout: .github

--- a/.github/workflows/deflake_tests.yml
+++ b/.github/workflows/deflake_tests.yml
@@ -20,7 +20,7 @@ jobs:
       actions: write
     steps:
       - name: Checkout .github Files
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: 1

--- a/.github/workflows/diff_chromium_branches.yaml
+++ b/.github/workflows/diff_chromium_branches.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
           filter: blob:none
@@ -102,7 +102,7 @@ jobs:
       matrix:
         upstream_branch: ${{ fromJson(needs.initialize.outputs.upstream_branches) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: chromium/${{ matrix.upstream_branch.milestone }}
           filter: blob:none

--- a/.github/workflows/gemini-commit-message.yml
+++ b/.github/workflows/gemini-commit-message.yml
@@ -152,7 +152,7 @@ jobs:
 
       # --- Step 3: Post Comment ---
       - name: 'Post Commit Message as Comment'
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           COMMENT_BODY: |
             ### 🤖 Gemini Suggested Commit Message

--- a/.github/workflows/gemini-commit-message.yml
+++ b/.github/workflows/gemini-commit-message.yml
@@ -1,6 +1,10 @@
+# Disable dangerous-triggers rule because this workflow uses pull_request_target
+# strictly to generate commit messages from the PR diff and comment on PRs
+# without checking out or executing untrusted code from PR branches.
+# actionlint: disable dangerous-triggers
 name: 'Gemini Commit Message Generator'
 
-on:
+on: # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types: [opened, reopened]
   issue_comment:
@@ -110,8 +114,12 @@ jobs:
           GEMINI_SECRET: ${{ secrets.GEMINI_ACTIONS_API_KEY }}
         run: |
           set -eux
-          # Keep only what is after the first space in the comment body.
-          COMMENT=${COMMENT_BODY#* }
+          # Keep only what is after the first space in the comment body if a comment was provided.
+          if [[ -n "${COMMENT}" && "${COMMENT}" == *" "* ]]; then
+            COMMENT="${COMMENT#* }"
+          else
+            COMMENT=""
+          fi
 
           # Use jq to safely combine the instructions with the variables.
           json_payload=$(jq -n \
@@ -120,7 +128,7 @@ jobs:
             --arg title "${PR_TITLE}" \
             --arg body "${PR_BODY}" \
             --arg diff "${PR_DIFF}" \
-            --arg comment "$COMMENT}" \
+            --arg comment "${COMMENT}" \
             '{
               contents: [{
                 parts: [{

--- a/.github/workflows/label-cherry-pick.yaml
+++ b/.github/workflows/label-cherry-pick.yaml
@@ -25,7 +25,7 @@ jobs:
       target_branch: ${{ steps.set-branches.outputs.target_branch }}
     steps:
       - name: Auto-label PR
-        uses: actions/labeler@v5
+        uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
         if: github.event.pull_request.merged == true && github.base_ref == 'main'
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
@@ -80,7 +80,7 @@ jobs:
       CHERRY_PICK_BRANCH: cherry-pick-${{ matrix.target_branch }}-${{ github.event.pull_request.number }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         timeout-minutes: 30
         with:
           ref: ${{ matrix.target_branch }}
@@ -121,7 +121,7 @@ jobs:
       - name: Create Pull Request
         id: create-pr
         continue-on-error: true
-        uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 # v4.2.3
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.CHERRY_PICK_TOKEN }}
           draft: ${{ steps.cherry-pick.outcome == 'failure' }}
@@ -138,7 +138,7 @@ jobs:
             ${{ github.event.pull_request.body }}
 
       - name: Comment on failure
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
           CHERRY_PICK_OUTCOME: ${{ steps.cherry-pick.outcome }}

--- a/.github/workflows/label-cherry-pick.yaml
+++ b/.github/workflows/label-cherry-pick.yaml
@@ -1,6 +1,10 @@
+# Disable dangerous-triggers rule because this workflow uses pull_request_target
+# strictly to label and create cherry-pick PRs for merged pull requests
+# without executing untrusted code from PR branches.
+# actionlint: disable dangerous-triggers
 name: Label Cherry Pick
 
-on:
+on: # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types:
       - labeled

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -28,7 +28,7 @@ jobs:
       docker_content_sha: ${{ steps.set-docker-hash.outputs.docker_content_sha }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
           filter: blob:none
@@ -57,7 +57,7 @@ jobs:
       packages: write
     steps:
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
           filter: blob:none
@@ -89,7 +89,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 2
           filter: blob:none
@@ -114,8 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Bug ID Check
-        # v2
-        uses: gsactions/commit-message-checker@16fa2d5de096ae0d35626443bcd24f1e756cafee
+        uses: gsactions/commit-message-checker@16fa2d5de096ae0d35626443bcd24f1e756cafee # v2.0.0
         with:
           accessToken: ${{ secrets.GITHUB_TOKEN }}
           pattern: '^(Bug|Fix|Fixed|Fixes|Issue): \d+$'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -66,7 +66,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
           filter: blob:none
@@ -386,7 +386,7 @@ jobs:
     runs-on: [self-hosted, chrobalt-linux-runner]
     steps:
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
           filter: blob:none
@@ -410,7 +410,7 @@ jobs:
     runs-on: [self-hosted, chrobalt-linux-runner]
     steps:
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
           filter: blob:none
@@ -433,7 +433,7 @@ jobs:
     runs-on: [self-hosted, chrobalt-linux-runner]
     steps:
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
           filter: blob:none
@@ -486,7 +486,7 @@ jobs:
             echo "TMPDIR=${RUNNER_TEMP}" >> "${GITHUB_ENV}"
           fi
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
           filter: blob:none
@@ -579,7 +579,7 @@ jobs:
       TEST_RESULTS_KEY: ${{ matrix.platform }}_${{ matrix.name }}_test_results
     steps:
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
           filter: blob:none
@@ -624,7 +624,7 @@ jobs:
         config: [devel]
     steps:
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
           filter: blob:none
@@ -659,7 +659,7 @@ jobs:
         config: [devel]
     steps:
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
           filter: blob:none
@@ -689,7 +689,7 @@ jobs:
         config: [devel]
     steps:
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
           filter: blob:none
@@ -715,7 +715,7 @@ jobs:
         config: [devel]
     steps:
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
           filter: blob:none
@@ -749,7 +749,7 @@ jobs:
         config: [devel]
     steps:
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
           filter: blob:none
@@ -780,7 +780,7 @@ jobs:
       TEST_RESULTS_KEY: ${{ matrix.platform }}_${{ matrix.name }}_test_results-${{ matrix.shard }}
     steps:
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
           filter: blob:none
@@ -844,7 +844,7 @@ jobs:
       TEST_ARTIFACTS_KEY: ${{ matrix.platform }}_${{ matrix.name }}_test_artifacts
     steps:
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
           filter: blob:none
@@ -901,7 +901,7 @@ jobs:
         test_info: ${{ fromJson(needs.initialize.outputs.expected_tests_json) }}
     steps:
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
           filter: blob:none
@@ -935,7 +935,7 @@ jobs:
         shell: bash
       - name: Download Test Results
         if: steps.filter.outputs.skipped != 'true'
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: ${{ env.TEST_RESULTS_KEY }}*
           path: results/
@@ -984,7 +984,7 @@ jobs:
         test_target: ${{ fromJson(needs.initialize.outputs.browser_test_targets_json || '[]') }}
     steps:
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
           filter: blob:none
@@ -996,7 +996,7 @@ jobs:
         run: echo "test_target=${test_target_with_path#*:}" >> "${GITHUB_OUTPUT}"
         shell: bash
       - name: Download Test Results
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
         with:
           pattern: ${{ env.TEST_RESULTS_KEY }}
@@ -1039,20 +1039,20 @@ jobs:
         config: [devel]
     steps:
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
           filter: blob:none
           sparse-checkout: ${{ env.CI_ESSENTIALS }}
       - name: Download Unit Test Results
         if: needs.test-results.result != 'skipped' && needs.test-results.result != ''
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: ${{ env.TEST_RESULTS_KEY }}*
           path: results/
       - name: Download Browser Test Results
         if: needs.initialize.outputs.run_browser_tests == 'true' && needs.browser-test-results.result != 'skipped' && needs.browser-test-results.result != ''
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
         with:
           pattern: ${{ matrix.platform }}_${{ matrix.name }}_browsertest_results

--- a/.github/workflows/outside_collaborator.yaml
+++ b/.github/workflows/outside_collaborator.yaml
@@ -1,6 +1,10 @@
+# Disable dangerous-triggers rule because this workflow uses pull_request_target
+# strictly to assign labels to PRs from outside collaborators
+# without checking out or executing untrusted code from PR branches.
+# actionlint: disable dangerous-triggers
 name: Outside Collaborator
 
-on:
+on: # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types:
       - opened

--- a/.github/workflows/scorecards.yaml
+++ b/.github/workflows/scorecards.yaml
@@ -36,12 +36,12 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif
@@ -66,7 +66,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif
@@ -75,6 +75,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: results.sarif

--- a/.github/workflows/sync_chromium_branches.yaml
+++ b/.github/workflows/sync_chromium_branches.yaml
@@ -28,7 +28,7 @@ jobs:
       MILESTONE: ${{ matrix.branch.milestone }}
     steps:
       # Attempt to checkout our Chromium reference, if missing, create a new branch
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         id: checkout
         continue-on-error: true
         with:
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 1
           filter: blob:none
       - name: Run fallback actions/checkout@v4
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: steps.checkout.outcome == 'failure'
         with:
           ref: main

--- a/.github/workflows/tvos.yaml
+++ b/.github/workflows/tvos.yaml
@@ -41,7 +41,7 @@ jobs:
       targets: ${{ steps.short-targets.outputs.targets }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: |
             .github/actions/test_targets_json
@@ -138,7 +138,7 @@ jobs:
           done
 
       - name: Upload to GitHub Actions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tvos-test-artifacts
           path: "*.tar.gz"
@@ -155,7 +155,7 @@ jobs:
         target: ${{ fromJSON(needs.get-targets.outputs.targets) }}
     steps:
       - name: Checkout Cobalt (Sparse)
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: |
             cobalt/testing/filters
@@ -163,7 +163,7 @@ jobs:
             cobalt/tools
 
       - name: Download from GitHub Actions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: tvos-test-artifacts
 
@@ -238,7 +238,7 @@ jobs:
 
       - name: Archive Test Results
         if: always() && steps.filter.outputs.skipped != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tvos_${{ matrix.target }}_test_results
           path: results/*


### PR DESCRIPTION
## Summary

Update all external GitHub Actions across workflows and composite actions in `.github` to their latest release versions and pin them to full 40-character commit hashes, complying with security policy.

Stacked on top of: #11921

## Pinned Actions in Use

| Action | Pinned Commit SHA | Version |
| :--- | :--- | :--- |
| `actions/checkout` | `3d3c42e5aac5ba805825da76410c181273ba90b1` | `v7.0.1` |
| `actions/download-artifact` | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` | `v8.0.1` |
| `actions/github-script` | `3a2844b7e9c422d3c10d287c895573f7108da1b3` | `v9.0.0` |
| `actions/labeler` | `bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13` | `v7.0.0` |
| `actions/upload-artifact` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` | `v7.0.1` |
| `docker/login-action` | `dbcb813823bdd20940b903addbd779551569679f` | `v4.6.0` |
| `github/codeql-action/upload-sarif` | `ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd` | `v4.37.7` |
| `gsactions/commit-message-checker` | `16fa2d5de096ae0d35626443bcd24f1e756cafee` | `v2.0.0` |
| `ossf/scorecard-action` | `2d1146689b8cda280b9bc96326124645441f03bc` | `v2.4.4` |
| `peter-evans/create-pull-request` | `5f6978faf089d4d20b00c7766989d076bb2fc7f1` | `v8.1.1` |
| `test-summary/action` | `37b508cfee6d4d080eedd00b5bb240a6a784a6a5` | `v2.6` |

Tag: agy
Conv: c3a2a510-69c4-4ff1-9634-f3c00bdcba86

Bug: 546190339