### PR TITLE
Pass through pid in process_stubs.cc

### DIFF
--- a/base/process/process_stubs.cc
+++ b/base/process/process_stubs.cc
@@ -14,7 +14,12 @@ static constexpr ProcessHandle kCurrentProcessHandle =
     std::numeric_limits<ProcessHandle>::max();
 
 Process::Process(ProcessHandle handle) : process_(handle) {
+#if BUILDFLAG(IS_COBALT)
+  DCHECK(handle == kNullProcessHandle || handle == kCurrentProcessHandle ||
+         handle == GetCurrentProcId());
+#else
   DCHECK(handle == kNullProcessHandle || handle == kCurrentProcessHandle);
+#endif
 }
 
 Process::Process(Process&& other) : process_(other.process_) {
@@ -36,9 +41,11 @@ Process Process::Current() {
 
 // static
 Process Process::Open(ProcessId pid) {
+#if !BUILDFLAG(IS_COBALT)
   if (pid == GetCurrentProcId()) {
     return Current();
   }
+#endif
   return Process(pid);
 }
 
@@ -85,7 +92,11 @@ Time Process::CreationTime() const {
 }
 
 bool Process::is_current() const {
-  return Handle() == kCurrentProcessHandle;
+#if BUILDFLAG(IS_COBALT)
+  return process_ == kCurrentProcessHandle || process_ == GetCurrentProcId();
+#else
+  return process_ == kCurrentProcessHandle;
+#endif
 }
 
 void Process::Close() {


### PR DESCRIPTION
This fixes memory metrics generation on Evergreen.

When CobaltMemoryMetricsEmitter requests a memory dump, it calls the same code as upstream Chromium, which gathers all the process IDs of the running instance and gathers dumps for each of them. Cobalt is single process, so there's just one pid. Cobalt-specific metrics like those in //cobalt/browser/performance simply request the ProcessHandle of the current process. But the Chromium memory dump passes each pid to `base::Process::Open(pid).Handle()`. On Cobalt this is directed to a stub which returns pid_t_max. The dump then fails to find anything related to that invalid pid.

This changes that behavior to simply pass through the actual pid, resolving the file-not-found issue.

Bug: 546200615