### PR TITLE
Cobalt: Revert disable v8 optimizing compilers

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
@@ -96,10 +96,6 @@ public final class CommandLineOverrideHelper {
     // Disable v8 concurrent marking by default.
     paramOverrides.add("--no-concurrent-marking");
 
-    // Disable v8 optimizing compilers (maglev, turbofan, sparkplug).
-    paramOverrides.add("--disable-optimizing-compilers");
-    paramOverrides.add("--no-sparkplug");
-
     return paramOverrides;
   }
 

--- a/cobalt/app/cobalt_switch_defaults_starboard.cc
+++ b/cobalt/app/cobalt_switch_defaults_starboard.cc
@@ -129,9 +129,6 @@ CommandLinePreprocessor::GetCobaltParamSwitchDefaults() {
        // Set initial old space size to 16MB and max old space size to 512MB.
        "--initial-old-space-size=16 "
        "--max-old-space-size=512 "
-       // Disable v8 optimizing compilers (turbofan, maglev, sparkplug).
-       "--disable-optimizing-compilers "
-       "--no-sparkplug "
        // Disable v8 concurrent marking by default.
        "--no-concurrent-marking"},
       // Limit GPU memory available to 64MB.

--- a/cobalt/build/configs/common.gn
+++ b/cobalt/build/configs/common.gn
@@ -50,7 +50,6 @@ v8_enable_atomic_object_field_writes = true
 # This will force V8 to embed snapshot blob in binary.
 v8_use_external_startup_data = false
 
-
 # Disable hls_demuxer so that enable_mse_mpeg2ts_stream_parser=false
 enable_hls_demuxer = false
 

--- a/cobalt/build/configs/common.gn
+++ b/cobalt/build/configs/common.gn
@@ -50,8 +50,6 @@ v8_enable_atomic_object_field_writes = true
 # This will force V8 to embed snapshot blob in binary.
 v8_use_external_startup_data = false
 
-# Disable Maglev in binary.
-v8_enable_maglev = false
 
 # Disable hls_demuxer so that enable_mse_mpeg2ts_stream_parser=false
 enable_hls_demuxer = false


### PR DESCRIPTION
Revert both #11156 and #11186

Enabling --disable-optimizing-compilers and --no-sparkplug 
introduces significant regression in Kabuki latency despite 
memory savings. 

Bug: 512163617