### PR TITLE
ci: Bump and pin GitHub Actions to full commit SHAs (27.lts)

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -123,7 +123,7 @@ runs:
           echo "test_targets_count=${test_targets_count}" >> "${GITHUB_OUTPUT}"
         shell: bash
       - name: Archive test target JSON
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: ${{ matrix.platform }}_test_targets_json
           path: cobalt/src/out/${{ matrix.platform }}_${{ matrix.config }}/test_targets.json
@@ -157,7 +157,7 @@ runs:
         shell: bash
       - name: Archive Android APKs
         if: (startsWith(matrix.platform, 'android') || startsWith(matrix.platform, 'aosp')) && matrix.config == 'qa'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: ${{ matrix.platform }} APKs
           path: |

--- a/.github/actions/docker/action.yaml
+++ b/.github/actions/docker/action.yaml
@@ -21,7 +21,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Cloud SDK
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
+      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
       if: inputs.is_pr == 'true'
 
     - name: Set Docker Build Vars

--- a/.github/actions/internal_tests/action.yaml
+++ b/.github/actions/internal_tests/action.yaml
@@ -32,7 +32,7 @@ runs:
             ${GITHUB_WORKSPACE}/cobalt/tools/on_device_tests_gateway.proto
       shell: bash
     - name: Set Up Cloud SDK
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
+      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
     - name: Set GCS Project Name
       run: |
         echo "PROJECT_NAME=$(gcloud config get-value project)" >> "${GITHUB_ENV}"

--- a/.github/actions/linux_browser_tests/action.yaml
+++ b/.github/actions/linux_browser_tests/action.yaml
@@ -21,7 +21,7 @@ runs:
   using: "composite"
   steps:
     - name: Download Artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
       with:
         name: ${{ inputs.test_artifacts_key }}
         path: artifacts
@@ -77,7 +77,7 @@ runs:
 
     - name: Archive Browser Test Results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
       with:
         name: ${{ inputs.test_results_key }}
         path: results/*

--- a/.github/actions/on_device_tests/action.yaml
+++ b/.github/actions/on_device_tests/action.yaml
@@ -38,7 +38,7 @@ runs:
             ${GITHUB_WORKSPACE}/cobalt/tools/on_device_tests_gateway.proto
       shell: bash
     - name: Set Up Cloud SDK
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
+      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
     - name: Set GCS Project Name
       run: |
         echo "PROJECT_NAME=$(gcloud config get-value project)" >> "${GITHUB_ENV}"

--- a/.github/actions/on_device_tests/action.yaml
+++ b/.github/actions/on_device_tests/action.yaml
@@ -154,7 +154,7 @@ runs:
         exit ${exit_code}
       shell: bash
     - name: Archive Test Results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
       if: always()
       with:
         name: ${{ inputs.test_results_key }}

--- a/.github/actions/on_host_tests/action.yaml
+++ b/.github/actions/on_host_tests/action.yaml
@@ -35,7 +35,7 @@ runs:
         git sparse-checkout add --skip-checks testing build third_party/catapult third_party/logdog
         git submodule update --init third_party/catapult
     - name: Download Artifacts
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
       with:
         name: ${{ inputs.test_artifacts_key }}
     - name: Extract Artifacts
@@ -200,7 +200,7 @@ runs:
         fi
     - name: Archive Test Results
       if: success() || failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
       with:
         name: ${{ inputs.test_results_key }}
         path: ${{ env.results_dir }}/*

--- a/.github/actions/print_logs/action.yaml
+++ b/.github/actions/print_logs/action.yaml
@@ -17,7 +17,7 @@ runs:
   steps:
     - name: Set Up Cloud SDK
       if: inputs.symbolize == 'true'
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
+      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
     - name: Set GCS Project Name
       if: inputs.symbolize == 'true'
       id: gcs-project

--- a/.github/actions/process_test_results/action.yaml
+++ b/.github/actions/process_test_results/action.yaml
@@ -21,7 +21,7 @@ runs:
   steps:
     - name: Create Test Summary
       id: test-summary
-      uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86
+      uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # v2.6
       with:
         paths: ${{ inputs.results_glob }}
         output: test-report-summary.md

--- a/.github/actions/test_targets_json/action.yaml
+++ b/.github/actions/test_targets_json/action.yaml
@@ -18,7 +18,7 @@ runs:
   steps:
     - name: Download Test Targets Json
       if: inputs.test_targets_json_file == 'test_targets.json'
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
       with:
         name: ${{ matrix.platform }}_test_targets_json
         path:

--- a/.github/actions/upload_test_artifacts/action.yaml
+++ b/.github/actions/upload_test_artifacts/action.yaml
@@ -144,7 +144,7 @@ runs:
       shell: bash
     - name: Upload On-Host Test Artifacts Archive
       if: inputs.upload_on_host_test_artifacts == 'true'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
       with:
         name: ${{ inputs.test_artifacts_key }}
         path: artifacts/*

--- a/.github/actions/web_tests/action.yaml
+++ b/.github/actions/web_tests/action.yaml
@@ -11,7 +11,7 @@ runs:
   using: "composite"
   steps:
     - name: Download Artifacts
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
       with:
         name: ${{ inputs.test_artifacts_key }}
     - name: Extract Artifacts
@@ -47,7 +47,7 @@ runs:
         echo "Finished running tests..."
     - name: Archive Test Results
       if: always() && contains(fromJson('["success", "failed"]'), steps.run-tests.outcome)
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
       with:
         name: ${{ inputs.test_results_key }}
         path: cobalt/src/${{ env.RESULTS_DIR }}/*

--- a/.github/workflows/auto_label_kokoro.yaml
+++ b/.github/workflows/auto_label_kokoro.yaml
@@ -16,6 +16,7 @@ on:
       - main
       - staging
       - experimental/*
+      - 27.lts
 
 concurrency:
   group: '${{ github.workflow }}-${{ github.event_name }} @ ${{ github.event.pull_request.number || github.sha }}'

--- a/.github/workflows/autoroll_main.yaml
+++ b/.github/workflows/autoroll_main.yaml
@@ -36,7 +36,7 @@ jobs:
         ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           path: src
           ref: main

--- a/.github/workflows/lint_27.lts.yaml
+++ b/.github/workflows/lint_27.lts.yaml
@@ -21,7 +21,7 @@ jobs:
       docker_content_sha: ${{ steps.set-docker-hash.outputs.docker_content_sha }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
           filter: blob:none
@@ -50,7 +50,7 @@ jobs:
       packages: write
     steps:
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
           filter: blob:none
@@ -82,7 +82,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 2
           filter: blob:none
@@ -99,7 +99,7 @@ jobs:
     steps:
       - name: Bug ID Check
         # v2
-        uses: gsactions/commit-message-checker@16fa2d5de096ae0d35626443bcd24f1e756cafee
+        uses: gsactions/commit-message-checker@16fa2d5de096ae0d35626443bcd24f1e756cafee # v2.0.0
         with:
           accessToken: ${{ secrets.GITHUB_TOKEN }}
           pattern: '^(Bug|Fix|Fixed|Fixes|Issue): \d+$'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -66,7 +66,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
           filter: blob:none
@@ -395,7 +395,7 @@ jobs:
     runs-on: [self-hosted, chrobalt-linux-runner]
     steps:
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
           filter: blob:none
@@ -419,7 +419,7 @@ jobs:
     runs-on: [self-hosted, chrobalt-linux-runner]
     steps:
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
           filter: blob:none
@@ -442,7 +442,7 @@ jobs:
     runs-on: [self-hosted, chrobalt-linux-runner]
     steps:
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
           filter: blob:none
@@ -495,7 +495,7 @@ jobs:
             echo "TMPDIR=${RUNNER_TEMP}" >> "${GITHUB_ENV}"
           fi
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
           filter: blob:none
@@ -588,7 +588,7 @@ jobs:
       TEST_RESULTS_KEY: ${{ matrix.platform }}_${{ matrix.name }}_test_results
     steps:
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
           filter: blob:none
@@ -634,7 +634,7 @@ jobs:
         config: [devel]
     steps:
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
           filter: blob:none
@@ -670,7 +670,7 @@ jobs:
         config: [devel]
     steps:
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
           filter: blob:none
@@ -698,7 +698,7 @@ jobs:
         config: [devel]
     steps:
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
           filter: blob:none
@@ -724,7 +724,7 @@ jobs:
         config: [devel]
     steps:
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
           filter: blob:none
@@ -758,7 +758,7 @@ jobs:
         config: [devel]
     steps:
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
           filter: blob:none
@@ -789,7 +789,7 @@ jobs:
       TEST_RESULTS_KEY: ${{ matrix.platform }}_${{ matrix.name }}_test_results-${{ matrix.shard }}
     steps:
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
           filter: blob:none
@@ -853,7 +853,7 @@ jobs:
       TEST_ARTIFACTS_KEY: ${{ matrix.platform }}_${{ matrix.name }}_test_artifacts
     steps:
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
           filter: blob:none
@@ -910,7 +910,7 @@ jobs:
         test_info: ${{ fromJson(needs.initialize.outputs.expected_tests_json) }}
     steps:
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
           filter: blob:none
@@ -944,7 +944,7 @@ jobs:
         shell: bash
       - name: Download Test Results
         if: steps.filter.outputs.skipped != 'true'
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
           pattern: ${{ env.TEST_RESULTS_KEY }}*
           path: results/
@@ -993,7 +993,7 @@ jobs:
         test_target: ${{ fromJson(needs.initialize.outputs.browser_test_targets_json || '[]') }}
     steps:
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
           filter: blob:none
@@ -1005,7 +1005,7 @@ jobs:
         run: echo "test_target=${test_target_with_path#*:}" >> "${GITHUB_OUTPUT}"
         shell: bash
       - name: Download Test Results
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         continue-on-error: true
         with:
           pattern: ${{ env.TEST_RESULTS_KEY }}
@@ -1056,13 +1056,13 @@ jobs:
         config: [devel]
     steps:
       - name: Restore CI Essentials
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
           filter: blob:none
           sparse-checkout: ${{ env.CI_ESSENTIALS }}
       - name: Download Unit Test Results
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         continue-on-error: true
         with:
           pattern: ${{ env.TEST_RESULTS_KEY }}*

--- a/.github/workflows/tvos_27.lts.yaml
+++ b/.github/workflows/tvos_27.lts.yaml
@@ -39,7 +39,7 @@ jobs:
       targets: ${{ steps.short-targets.outputs.targets }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           sparse-checkout: |
             .github/actions/test_targets_json
@@ -136,7 +136,7 @@ jobs:
           done
 
       - name: Upload to GitHub Actions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: tvos-test-artifacts
           path: "*.tar.gz"
@@ -153,7 +153,7 @@ jobs:
         target: ${{ fromJSON(needs.get-targets.outputs.targets) }}
     steps:
       - name: Checkout Cobalt (Sparse)
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           sparse-checkout: |
             cobalt/testing/filters
@@ -161,7 +161,7 @@ jobs:
             cobalt/tools
 
       - name: Download from GitHub Actions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
           name: tvos-test-artifacts
 
@@ -236,7 +236,7 @@ jobs:
 
       - name: Archive Test Results
         if: always() && steps.filter.outputs.skipped != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: tvos_${{ matrix.target }}_test_results
           path: results/*

--- a/.github/workflows/workflow_dispatcher.yaml
+++ b/.github/workflows/workflow_dispatcher.yaml
@@ -44,16 +44,16 @@ jobs:
             }
 
             const PLATFORM_WORKFLOWS = [
-              'android.yaml',
-              'aosp.yaml',
-              'evergreen.yaml',
-              'linux.yaml',
-              'tvos.yaml'
+              'android_27.lts.yaml',
+              'aosp_27.lts.yaml',
+              'evergreen_27.lts.yaml',
+              'linux_27.lts.yaml',
+              'tvos_27.lts.yaml'
             ];
 
             let workflows = [];
             if (labelName === 'kokoro:run' || labelName === 'kokoro:force-run') {
-              workflows = ['tvos.yaml'];
+              workflows = ['tvos_27.lts.yaml'];
             } else {
               workflows = PLATFORM_WORKFLOWS;
             }


### PR DESCRIPTION
Update external GitHub Actions in .github to pinned commit hashes.

Tag: agy
Conv: c3a2a510-69c4-4ff1-9634-f3c00bdcba86

Bug: 546190339
