### PR TITLE
ci: Bump and pin GitHub Actions to full commit SHAs (25.lts.1+)

### DIFF
--- a/.github/actions/on_host_test/action.yaml
+++ b/.github/actions/on_host_test/action.yaml
@@ -122,6 +122,6 @@ runs:
     #     path: ${{env.COVERAGE_DIR}}/html
     - name: Upload to Codecov
       if: success() && matrix.shard == 'coverage'
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         files: ${{env.COVERAGE_DIR}}/report.txt

--- a/.github/actions/pre_commit/action.yaml
+++ b/.github/actions/pre_commit/action.yaml
@@ -11,7 +11,7 @@ runs:
       shell: bash
     - run: python -m pip freeze --local
       shell: bash
-    - uses: actions/cache@v3
+    - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.cache/pre-commit
         key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/android_25.lts.1+.yaml
+++ b/.github/workflows/android_25.lts.1+.yaml
@@ -58,37 +58,37 @@ jobs:
       contents: write
     steps:
       - name: Download arm-gold apk
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: android-arm-gold
           path: arm-gold
       - name: Download arm-qa apk
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: android-arm-qa
           path: arm-qa
       - name: Download arm64-gold apk
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: android-arm64-gold
           path: arm64-gold
       - name: Download arm64-qa apk
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: android-arm64-gold
           path: arm64-qa
       - name: Download x86-gold apk
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: android-x86-gold
           path: x86-gold
       - name: Download x86-qa apk
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: android-x86-qa
           path: x86-qa
       - name: 'Upload Android APKs'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Android APKs
           path: ./*

--- a/.github/workflows/gradle_25.lts.1+.yaml
+++ b/.github/workflows/gradle_25.lts.1+.yaml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: kaidokert/checkout@v3.5.999
+      - uses: kaidokert/checkout@1bf7689f6bce800f108fa5e9f0885fbfcb14ffd6 # v3.5.999
         timeout-minutes: 30
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'zulu'
           java-version: 11

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -79,7 +79,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - id: checkout
-        uses: kaidokert/checkout@v3.5.999
+        uses: kaidokert/checkout@1bf7689f6bce800f108fa5e9f0885fbfcb14ffd6 # v3.5.999
         timeout-minutes: 30
         with:
           fetch-depth: 1
@@ -154,13 +154,13 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout files
-        uses: kaidokert/checkout@v3.5.999
+        uses: kaidokert/checkout@1bf7689f6bce800f108fa5e9f0885fbfcb14ffd6 # v3.5.999
         timeout-minutes: 30
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Login to Docker Registry ${{env.REGISTRY}}
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -191,13 +191,13 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout files
-        uses: kaidokert/checkout@v3.5.999
+        uses: kaidokert/checkout@1bf7689f6bce800f108fa5e9f0885fbfcb14ffd6 # v3.5.999
         timeout-minutes: 30
         with:
           fetch-depth: 2
           persist-credentials: false
       - name: Login to Docker Registry ${{env.REGISTRY}}
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -239,14 +239,14 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: kaidokert/checkout@v3.5.999
+        uses: kaidokert/checkout@1bf7689f6bce800f108fa5e9f0885fbfcb14ffd6 # v3.5.999
         timeout-minutes: 30
         with:
           # Use fetch depth of 0 to get full history for a valid build id.
           fetch-depth: 0
           persist-credentials: false
       - name: Cache Gradle
-        uses: actions/cache@v3
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         if: startsWith( matrix.target_platform , 'android')
         with:
           key: gradle-cache-${{ hashFiles('starboard/android/apk/**/*gradle*') }}
@@ -258,7 +258,7 @@ jobs:
       - name: Build Cobalt
         uses: ./.github/actions/build
       - name: 'Upload Artifact'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: inputs.keep_artifacts
         with:
           name: ${{ matrix.platform }}-${{ matrix.config }}
@@ -343,7 +343,7 @@ jobs:
       MODULAR_BUILD: ${{ inputs.modular && 1 || 0 }}
     steps:
       - name: Checkout
-        uses: kaidokert/checkout@v3.5.999
+        uses: kaidokert/checkout@1bf7689f6bce800f108fa5e9f0885fbfcb14ffd6 # v3.5.999
         timeout-minutes: 30
         with:
           fetch-depth: 1
@@ -376,7 +376,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout
-        uses: kaidokert/checkout@v3.5.999
+        uses: kaidokert/checkout@1bf7689f6bce800f108fa5e9f0885fbfcb14ffd6 # v3.5.999
         timeout-minutes: 30
         with:
           fetch-depth: 1

--- a/.github/workflows/main_win.yaml
+++ b/.github/workflows/main_win.yaml
@@ -64,7 +64,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - id: Checkout
-        uses: kaidokert/checkout@v3.5.999 # Temporary version
+        uses: kaidokert/checkout@1bf7689f6bce800f108fa5e9f0885fbfcb14ffd6 # v3.5.999
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -137,12 +137,12 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout files
-        uses: kaidokert/checkout@v3.5.999
+        uses: kaidokert/checkout@1bf7689f6bce800f108fa5e9f0885fbfcb14ffd6 # v3.5.999
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Login to Docker Registry ${{env.REGISTRY}}
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -172,7 +172,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout
-        uses: kaidokert/checkout@v3.5.999
+        uses: kaidokert/checkout@1bf7689f6bce800f108fa5e9f0885fbfcb14ffd6 # v3.5.999
         with:
           # Use fetch depth of 0 to get full history for a valid build id.
           fetch-depth: 0
@@ -210,7 +210,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout
-        uses: kaidokert/checkout@v3.5.999
+        uses: kaidokert/checkout@1bf7689f6bce800f108fa5e9f0885fbfcb14ffd6 # v3.5.999
         with:
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/pytest_25.lts.1+.yaml
+++ b/.github/workflows/pytest_25.lts.1+.yaml
@@ -23,12 +23,12 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: kaidokert/checkout@v3.5.999
+        uses: kaidokert/checkout@1bf7689f6bce800f108fa5e9f0885fbfcb14ffd6 # v3.5.999
         with:
           fetch-depth: 1
           persist-credentials: false
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'


### PR DESCRIPTION
Update external GitHub Actions in .github to pinned commit hashes.

Tag: agy
Conv: c3a2a510-69c4-4ff1-9634-f3c00bdcba86

Bug: 546190339
