### PR TITLE
cobalt: Remove unused content shell toolbar UI and JNI stubs

### DIFF
--- a/cobalt/app/cobalt_switch_defaults_starboard.cc
+++ b/cobalt/app/cobalt_switch_defaults_starboard.cc
@@ -51,8 +51,6 @@ CommandLinePreprocessor::GetCobaltToggleSwitches() {
       ::switches::kForceVideoOverlays,
       // Disable multiprocess mode.
       ::switches::kSingleProcess,
-      // Hide content shell toolbar.
-      ::switches::kContentShellHideToolbar,
       // Accelerated GL is blanket disabled for Linux. Ignore the GPU
       // blocklist to enable it.
       ::switches::kIgnoreGpuBlocklist,

--- a/cobalt/app/cobalt_switch_defaults_tvos.cc
+++ b/cobalt/app/cobalt_switch_defaults_tvos.cc
@@ -30,8 +30,6 @@ CommandLinePreprocessor::GetCobaltToggleSwitches() {
       ::switches::kForceVideoOverlays,
       // Disable multiprocess mode.
       ::switches::kSingleProcess,
-      // Hide content shell toolbar.
-      ::switches::kContentShellHideToolbar,
       // Accelerated GL is blanket disabled for Linux. Ignore the GPU blocklist
       // to enable it.
       ::switches::kIgnoreGpuBlocklist,

--- a/cobalt/shell/android/java/src/dev/cobalt/shell/Shell.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/shell/Shell.java
@@ -51,13 +51,6 @@ public class Shell {
   public static final String TAG = "cobalt";
   private static final long COMPLETED_PROGRESS_TIMEOUT_MS = 200;
 
-  // Stylus handwriting: Setting this ime option instructs stylus writing service to restrict
-  // capturing writing events slightly outside the Url bar area. This is needed to prevent stylus
-  // handwriting in inputs in web content area that are very close to url bar area, from being
-  // committed to Url bar's Edit text. Ex: google.com search field.
-  private static final String IME_OPTION_RESTRICT_STYLUS_WRITING_AREA =
-      "restrictDirectWritingArea=true";
-
   private WebContents mWebContents;
   private WebContents mSplashScreenWebContents;
   private NavigationController mNavigationController;
@@ -68,7 +61,6 @@ public class Shell {
   private @Nullable WindowAndroid mWindow;
   private @Nullable ShellViewAndroidDelegate mViewAndroidDelegate;
 
-  private boolean mLoading;
   private boolean mIsFullscreen;
   private boolean mIsActivityVisible;
 
@@ -168,9 +160,6 @@ public class Shell {
   }
 
   @CalledByNative
-  private void onUpdateUrl(String url) {}
-
-  @CalledByNative
   private void onLoadProgressChanged(double progress) {}
 
   @CalledByNative
@@ -179,11 +168,6 @@ public class Shell {
   @CalledByNative
   private boolean isFullscreenForTabOrPending() {
     return mIsFullscreen;
-  }
-
-  @CalledByNative
-  private void setIsLoading(boolean loading) {
-    mLoading = loading;
   }
 
   /**
@@ -269,16 +253,6 @@ public class Shell {
     mOverlayModeChangedCallbackForTesting = callback;
     ResettersForTesting.register(() -> mOverlayModeChangedCallbackForTesting = null);
   }
-
-  /**
-   * Enable/Disable navigation(Prev/Next) button if navigation is allowed/disallowed in respective
-   * direction.
-   *
-   * @param controlId Id of button to update
-   * @param enabled enable/disable value
-   */
-  @CalledByNative
-  private void enableUiControl(int controlId, boolean enabled) {}
 
   /**
    * @return The {@link WebContents} currently managing the content shown by this Shell.

--- a/cobalt/shell/browser/shell.cc
+++ b/cobalt/shell/browser/shell.cc
@@ -415,12 +415,6 @@ void Shell::SetShellCreatedCallback(
 }
 
 // static
-bool Shell::ShouldHideToolbar() {
-  return base::CommandLine::ForCurrentProcess()->HasSwitch(
-      switches::kContentShellHideToolbar);
-}
-
-// static
 Shell* Shell::FromWebContents(WebContents* web_contents) {
   for (Shell* window : windows_) {
     if (window->web_contents() && window->web_contents() == web_contents) {
@@ -779,19 +773,6 @@ void Shell::Stop() {
   web_contents_->Stop();
 }
 
-void Shell::UpdateNavigationControls(bool should_show_loading_ui) {
-  int current_index = web_contents_->GetController().GetCurrentEntryIndex();
-  int max_index = web_contents_->GetController().GetEntryCount() - 1;
-
-  g_platform->EnableUIControl(this, ShellPlatformDelegate::BACK_BUTTON,
-                              current_index > 0);
-  g_platform->EnableUIControl(this, ShellPlatformDelegate::FORWARD_BUTTON,
-                              current_index < max_index);
-  g_platform->EnableUIControl(
-      this, ShellPlatformDelegate::STOP_BUTTON,
-      should_show_loading_ui && web_contents_->IsLoading());
-}
-
 void Shell::ShowDevTools() {
   if (!devtools_frontend_) {
     auto* devtools_frontend = ShellDevToolsFrontend::Show(web_contents());
@@ -884,12 +865,6 @@ WebContents* Shell::OpenURLFromTab(
   return target;
 }
 
-void Shell::LoadingStateChanged(WebContents* source,
-                                bool should_show_loading_ui) {
-  UpdateNavigationControls(should_show_loading_ui);
-  g_platform->SetIsLoading(this, source->IsLoading());
-}
-
 void Shell::EnterFullscreenModeForTab(
     RenderFrameHost* requesting_frame,
     const blink::mojom::FullscreenOptions& options) {
@@ -969,13 +944,6 @@ bool Shell::CanOverscrollContent() {
 #else
   return false;
 #endif
-}
-
-void Shell::NavigationStateChanged(WebContents* source,
-                                   InvalidateTypes changed_flags) {
-  if (changed_flags & INVALIDATE_TYPE_URL) {
-    g_platform->SetAddressBarURL(this, source->GetVisibleURL());
-  }
 }
 
 JavaScriptDialogManager* Shell::GetJavaScriptDialogManager(

--- a/cobalt/shell/browser/shell.h
+++ b/cobalt/shell/browser/shell.h
@@ -85,7 +85,6 @@ class Shell : public WebContentsDelegate, public WebContentsObserver {
   void Reload();
   void ReloadBypassingCache();
   void Stop();
-  void UpdateNavigationControls(bool should_show_loading_ui);
   void Close();
   void ShowDevTools();
   void CloseDevTools();
@@ -140,8 +139,6 @@ class Shell : public WebContentsDelegate, public WebContentsObserver {
   static void SetShellCreatedCallback(
       base::OnceCallback<void(Shell*)> shell_created_callback);
 
-  static bool ShouldHideToolbar();
-
   WebContents* web_contents() const { return web_contents_.get(); }
 
   void Focus();
@@ -171,8 +168,6 @@ class Shell : public WebContentsDelegate, public WebContentsObserver {
       const blink::mojom::WindowFeatures& window_features,
       bool user_gesture,
       bool* was_blocked) override;
-  void LoadingStateChanged(WebContents* source,
-                           bool should_show_loading_ui) override;
   void EnterFullscreenModeForTab(
       RenderFrameHost* requesting_frame,
       const blink::mojom::FullscreenOptions& options) override;
@@ -185,8 +180,6 @@ class Shell : public WebContentsDelegate, public WebContentsObserver {
                           bool last_unlocked_by_target) override;
   void CloseContents(WebContents* source) override;
   bool CanOverscrollContent() override;
-  void NavigationStateChanged(WebContents* source,
-                              InvalidateTypes changed_flags) override;
   JavaScriptDialogManager* GetJavaScriptDialogManager(
       WebContents* source) override;
   bool DidAddMessageToConsole(WebContents* source,

--- a/cobalt/shell/browser/shell_platform_delegate.h
+++ b/cobalt/shell/browser/shell_platform_delegate.h
@@ -56,8 +56,6 @@ class WebContents;
 
 class ShellPlatformDelegate : public cobalt::CobaltLifecycleManagerObserver {
  public:
-  enum UIControl { BACK_BUTTON, FORWARD_BUTTON, STOP_BUTTON };
-
   ShellPlatformDelegate();
   virtual ~ShellPlatformDelegate();
 
@@ -111,17 +109,6 @@ class ShellPlatformDelegate : public cobalt::CobaltLifecycleManagerObserver {
 
   // Resize the web contents in the shell window to the given size.
   virtual void ResizeWebContent(Shell* shell, const gfx::Size& content_size);
-
-  // Enable/disable a button.
-  virtual void EnableUIControl(Shell* shell,
-                               UIControl control,
-                               bool is_enabled);
-
-  // Updates the url in the url bar.
-  virtual void SetAddressBarURL(Shell* shell, const GURL& url);
-
-  // Sets whether the spinner is spinning.
-  virtual void SetIsLoading(Shell* shell, bool loading);
 
   // Set the title of shell window
   virtual void SetTitle(Shell* shell, const std::u16string& title);

--- a/cobalt/shell/browser/shell_platform_delegate_android.cc
+++ b/cobalt/shell/browser/shell_platform_delegate_android.cc
@@ -16,7 +16,6 @@
 
 #include <jni.h>
 
-#include "base/android/jni_string.h"
 #include "base/android/scoped_java_ref.h"
 #include "base/command_line.h"
 #include "base/containers/contains.h"
@@ -29,7 +28,6 @@
 #include "content/public/common/content_switches.h"
 
 using base::android::AttachCurrentThread;
-using base::android::ConvertUTF8ToJavaString;
 using base::android::JavaParamRef;
 using base::android::ScopedJavaLocalRef;
 
@@ -109,36 +107,6 @@ void ShellPlatformDelegate::UpdateContents(Shell* shell) {
 void ShellPlatformDelegate::ResizeWebContent(Shell* shell,
                                              const gfx::Size& content_size) {
   shell->web_contents()->GetRenderWidgetHostView()->SetSize(content_size);
-}
-
-void ShellPlatformDelegate::EnableUIControl(Shell* shell,
-                                            UIControl control,
-                                            bool is_enabled) {
-  JNIEnv* env = AttachCurrentThread();
-  DCHECK(base::Contains(shell_data_map_, shell));
-  ShellData& shell_data = shell_data_map_[shell];
-
-  if (shell_data.java_object.is_null()) {
-    return;
-  }
-  Java_Shell_enableUiControl(env, shell_data.java_object, control, is_enabled);
-}
-
-void ShellPlatformDelegate::SetAddressBarURL(Shell* shell, const GURL& url) {
-  JNIEnv* env = AttachCurrentThread();
-  DCHECK(base::Contains(shell_data_map_, shell));
-  ShellData& shell_data = shell_data_map_[shell];
-
-  ScopedJavaLocalRef<jstring> j_url = ConvertUTF8ToJavaString(env, url.spec());
-  Java_Shell_onUpdateUrl(env, shell_data.java_object, j_url);
-}
-
-void ShellPlatformDelegate::SetIsLoading(Shell* shell, bool loading) {
-  JNIEnv* env = AttachCurrentThread();
-  DCHECK(base::Contains(shell_data_map_, shell));
-  ShellData& shell_data = shell_data_map_[shell];
-
-  Java_Shell_setIsLoading(env, shell_data.java_object, loading);
 }
 
 void ShellPlatformDelegate::SetTitle(Shell* shell,

--- a/cobalt/shell/browser/shell_platform_delegate_aura.cc
+++ b/cobalt/shell/browser/shell_platform_delegate_aura.cc
@@ -143,14 +143,6 @@ void ShellPlatformDelegate::ResizeWebContent(Shell* shell,
   shell->web_contents()->GetRenderWidgetHostView()->SetSize(content_size);
 }
 
-void ShellPlatformDelegate::EnableUIControl(Shell* shell,
-                                            UIControl control,
-                                            bool is_enabled) {}
-
-void ShellPlatformDelegate::SetAddressBarURL(Shell* shell, const GURL& url) {}
-
-void ShellPlatformDelegate::SetIsLoading(Shell* shell, bool loading) {}
-
 void ShellPlatformDelegate::SetTitle(Shell* shell,
                                      const std::u16string& title) {}
 

--- a/cobalt/shell/browser/shell_platform_delegate_ios.mm
+++ b/cobalt/shell/browser/shell_platform_delegate_ios.mm
@@ -23,10 +23,8 @@
 #include "base/files/file.h"
 #include "base/functional/callback_helpers.h"
 #include "base/strings/sys_string_conversions.h"
-#include "base/trace_event/trace_config.h"
 #include "cobalt/browser/on_screen_keyboard/platform_on_screen_keyboard.h"
 #include "cobalt/browser/on_screen_keyboard/public/mojom/on_screen_keyboard.mojom.h"
-#include "cobalt/shell/app/resource.h"
 #import "cobalt/shell/browser/on_screen_keyboard/tvos/cobalt_search_container_view_controller.h"
 #import "cobalt/shell/browser/on_screen_keyboard/tvos/cobalt_search_controller.h"
 #import "cobalt/shell/browser/on_screen_keyboard/tvos/cobalt_search_results_controller.h"
@@ -34,11 +32,7 @@
 #include "content/public/browser/render_widget_host_view.h"
 #include "content/public/browser/visibility.h"
 #include "content/public/browser/web_contents.h"
-#include "services/tracing/public/cpp/perfetto/perfetto_config.h"
-#include "services/tracing/public/mojom/constants.mojom.h"
 #import "starboard/tvos/shared/starboard_application.h"
-#include "third_party/perfetto/include/perfetto/tracing/core/trace_config.h"
-#include "third_party/perfetto/include/perfetto/tracing/tracing.h"
 #include "third_party/skia/include/core/SkColor.h"
 #include "ui/display/screen.h"
 #include "ui/gfx/geometry/rect.h"
@@ -47,42 +41,6 @@
 #if !defined(__has_feature) || !__has_feature(objc_arc)
 #error "This file requires ARC support."
 #endif
-
-namespace {
-
-const char kGraphicsTracingCategories[] =
-    "-*,blink,cc,gpu,renderer.scheduler,sequence_manager,v8,toplevel,viz,evdev,"
-    "input,benchmark";
-
-const char kDetailedGraphicsTracingCategories[] =
-    "-*,blink,cc,gpu,renderer.scheduler,sequence_manager,v8,toplevel,viz,evdev,"
-    "input,benchmark,disabled-by-default-skia,disabled-by-default-skia.gpu,"
-    "disabled-by-default-skia.gpu.cache,disabled-by-default-skia.shaders";
-
-const char kNavigationTracingCategories[] =
-    "-*,benchmark,toplevel,ipc,base,browser,navigation,omnibox,ui,shutdown,"
-    "safe_browsing,loading,startup,mojom,renderer_host,"
-    "disabled-by-default-system_stats,disabled-by-default-cpu_profiler,dwrite,"
-    "fonts,ServiceWorker,passwords,disabled-by-default-file,sql,"
-    "disabled-by-default-user_action_samples,disk_cache";
-
-const char kAllTracingCategories[] = "*";
-
-}  // namespace
-
-@interface TracingHandler : NSObject {
- @private
-  std::unique_ptr<perfetto::TracingSession> _tracingSession;
-  NSFileHandle* _traceFileHandle;
-}
-
-- (void)startWithHandler:(void (^)())startHandler
-             stopHandler:(void (^)())stopHandler
-              categories:(const char*)categories;
-- (void)stop;
-- (BOOL)isTracing;
-
-@end
 
 // Protocol used by ContentShellWindowDelegate to notify that certain on-screen
 // keyboard events have occurred.
@@ -147,8 +105,7 @@ const char kAllTracingCategories[] = "*";
 @end
 
 @interface ContentShellWindowDelegate
-    : UIViewController <UITextFieldDelegate,
-                        UISearchResultsUpdating,
+    : UIViewController <UISearchResultsUpdating,
                         CobaltSearchControllerPressesDelegate,
                         CobaltSearchResultsControllerFocusDelegate,
                         CobaltSearchContainerViewControllerDelegate> {
@@ -169,73 +126,21 @@ const char kAllTracingCategories[] = "*";
   void (^_showOnScreenKeyboardCompletionHandler)(void);
   void (^_focusOnScreenKeyboardCompletionHandler)(void);
 }
-// Toolbar containing navigation buttons and |urlField|.
-@property(nonatomic, strong) UIStackView* toolbarBackgroundView;
-// Toolbar containing navigation buttons and |urlField|.
-@property(nonatomic, strong) UIStackView* toolbarContentView;
-// Button to navigate backwards.
-@property(nonatomic, strong) UIButton* backButton;
-// Button to navigate forwards.
-@property(nonatomic, strong) UIButton* forwardButton;
-// Button that either refresh the page or stops the page load.
-@property(nonatomic, strong) UIButton* reloadOrStopButton;
-// Button that shows the menu
-@property(nonatomic, strong) UIButton* menuButton;
-// Text field used for navigating to URLs.
-@property(nonatomic, strong) UITextField* urlField;
 // Container for the native search UI elements.
 @property(nonatomic, strong) UIView* searchView;
 // Container for |webView|.
 @property(nonatomic, strong) UIView* contentView;
-// Manages tracing and tracing state.
-@property(nonatomic, strong) TracingHandler* tracingHandler;
 // PlatformOnScreenKeyboardDelegate implementation.
 @property(nonatomic, weak) id<PlatformOnScreenKeyboardDelegate>
     platformOnScreenKeyboardDelegate;
 
-+ (UIColor*)backgroundColorDefault;
-+ (UIColor*)backgroundColorTracing;
 - (id)initWithShell:(content::Shell*)shell;
 - (content::Shell*)shell;
-- (UIStackView*)createToolbarBackgroundView;
-- (UIStackView*)createToolbarContentView;
-- (UIButton*)makeButton:(NSString*)imageName action:(SEL)action;
-- (UITextField*)makeURLBar;
-- (void)back;
-- (void)forward;
-- (void)reloadOrStop;
-- (void)setURL:(NSString*)url;
-- (void)stopTracing;
-- (void)startTracingWithCategories:(const char*)categories;
-- (UIAlertController*)actionSheetWithTitle:(nullable NSString*)title
-                                   message:(nullable NSString*)message;
 @end
 
 @implementation ContentShellWindowDelegate
-@synthesize backButton = _backButton;
 @synthesize searchView = _searchView;
 @synthesize contentView = _contentView;
-@synthesize urlField = _urlField;
-@synthesize forwardButton = _forwardButton;
-@synthesize reloadOrStopButton = _reloadOrStopButton;
-@synthesize menuButton = _menuButton;
-@synthesize toolbarBackgroundView = _toolbarBackgroundView;
-@synthesize toolbarContentView = _toolbarContentView;
-@synthesize tracingHandler = _tracingHandler;
-
-+ (UIColor*)backgroundColorDefault {
-  return [UIColor colorWithRed:66.0 / 255.0
-                         green:133.0 / 255.0
-                          blue:244.0 / 255.0
-                         alpha:1.0];
-}
-
-+ (UIColor*)backgroundColorTracing {
-  return [UIColor colorWithRed:234.0 / 255.0
-                         green:67.0 / 255.0
-                          blue:53.0 / 255.0
-                         alpha:1.0];
-}
 
 #if BUILDFLAG(IS_IOS_TVOS)
 // Intercept UIPressTypeMenu event and do not forward it to the
@@ -282,65 +187,10 @@ const char kAllTracingCategories[] = "*";
   self.contentView = [[UIView alloc] init];
   [self.view addSubview:_contentView];
 
-  // Create a toolbar.
-  if (!content::Shell::ShouldHideToolbar()) {
-    self.toolbarBackgroundView = [self createToolbarBackgroundView];
-    self.toolbarContentView = [self createToolbarContentView];
-
-    self.backButton = [self makeButton:@"ic_back" action:@selector(back)];
-    self.forwardButton = [self makeButton:@"ic_forward"
-                                   action:@selector(forward)];
-    self.reloadOrStopButton = [self makeButton:@"ic_reload"
-                                        action:@selector(reloadOrStop)];
-    self.menuButton = [self makeButton:@"ic_menu"
-                                action:@selector(showMainMenu)];
-    self.urlField = [self makeURLBar];
-    self.tracingHandler = [[TracingHandler alloc] init];
-
-    [self.view addSubview:_toolbarBackgroundView];
-    [_toolbarBackgroundView addArrangedSubview:_toolbarContentView];
-
-    [_toolbarContentView addArrangedSubview:_backButton];
-    [_toolbarContentView addArrangedSubview:_forwardButton];
-    [_toolbarContentView addArrangedSubview:_reloadOrStopButton];
-    [_toolbarContentView addArrangedSubview:_menuButton];
-    [_toolbarContentView addArrangedSubview:_urlField];
-
-    self.view.accessibilityElements = @[ _toolbarBackgroundView, _contentView ];
-    self.view.isAccessibilityElement = NO;
-
-    // Constraint the toolbar background view.
-    _toolbarBackgroundView.translatesAutoresizingMaskIntoConstraints = NO;
-    [NSLayoutConstraint activateConstraints:@[
-      [_toolbarBackgroundView.topAnchor
-          constraintEqualToAnchor:self.view.topAnchor],
-      [_toolbarBackgroundView.leadingAnchor
-          constraintEqualToAnchor:self.view.leadingAnchor],
-      [_toolbarBackgroundView.trailingAnchor
-          constraintEqualToAnchor:self.view.trailingAnchor],
-    ]];
-
-    // Constraint the toolbar content view.
-    _toolbarContentView.translatesAutoresizingMaskIntoConstraints = NO;
-    [NSLayoutConstraint activateConstraints:@[
-      // This height constraint is somewhat arbitrary: the idea is that it gives
-      // us enough space to centralize the buttons inside |_toolbarContentView|
-      // while having enough top and bottom margins.
-      // Twice the size of a button also accounts for platforms such as tvOS,
-      // where focused buttons are larger and have a drop shadow.
-      [_toolbarContentView.heightAnchor
-          constraintEqualToAnchor:_backButton.heightAnchor
-                       multiplier:2.0],
-    ]];
-  }  // if (!content::Shell::ShouldHideToolbar())
-
   // Constraint the web content view.
   _contentView.translatesAutoresizingMaskIntoConstraints = NO;
   [NSLayoutConstraint activateConstraints:@[
-    [_contentView.topAnchor
-        constraintEqualToAnchor:content::Shell::ShouldHideToolbar()
-                                    ? self.view.topAnchor
-                                    : _toolbarBackgroundView.bottomAnchor],
+    [_contentView.topAnchor constraintEqualToAnchor:self.view.topAnchor],
     [_contentView.leadingAnchor
         constraintEqualToAnchor:self.view.leadingAnchor],
     [_contentView.trailingAnchor
@@ -384,195 +234,6 @@ const char kAllTracingCategories[] = "*";
 
 - (content::Shell*)shell {
   return _shell;
-}
-
-- (UIButton*)makeButton:(NSString*)imageName action:(SEL)action {
-  UIButton* button = [UIButton buttonWithType:UIButtonTypeSystem];
-  [button setImage:[UIImage imageNamed:imageName]
-          forState:UIControlStateNormal];
-  button.tintColor = [UIColor whiteColor];
-  [button addTarget:self
-                action:action
-      forControlEvents:UIControlEventTouchUpInside |
-                       UIControlEventPrimaryActionTriggered];
-  return button;
-}
-
-- (UITextField*)makeURLBar {
-  UITextField* field = [[UITextField alloc] init];
-  field.placeholder = @"Search or type URL";
-  field.tintColor = _toolbarBackgroundView.backgroundColor;
-  [field setContentHuggingPriority:UILayoutPriorityDefaultLow - 1
-                           forAxis:UILayoutConstraintAxisHorizontal];
-  field.delegate = self;
-  field.borderStyle = UITextBorderStyleRoundedRect;
-  field.keyboardType = UIKeyboardTypeWebSearch;
-  field.autocapitalizationType = UITextAutocapitalizationTypeNone;
-  field.clearButtonMode = UITextFieldViewModeWhileEditing;
-  field.autocorrectionType = UITextAutocorrectionTypeNo;
-  return field;
-}
-
-- (UIStackView*)createToolbarBackgroundView {
-  UIStackView* toolbarBackgroundView = [[UIStackView alloc] init];
-
-  // |toolbarBackgroundView| is a 1-item UIStackView. We use a UIStackView so
-  // that we can:
-  // 1. Easily hide |toolbarContentView| when entering fullscreen mode in a
-  // way that removes it from the layout.
-  // 2. Let UIStackView figure out most constraints for |toolbarContentView|
-  // so that we do not have to do it manually.
-  toolbarBackgroundView.backgroundColor =
-      [ContentShellWindowDelegate backgroundColorDefault];
-  toolbarBackgroundView.alignment = UIStackViewAlignmentBottom;
-  toolbarBackgroundView.axis = UILayoutConstraintAxisHorizontal;
-
-  // Use the root view's layout margins (which account for safe areas and the
-  // system's minimum margins).
-  toolbarBackgroundView.layoutMarginsRelativeArrangement = YES;
-  toolbarBackgroundView.preservesSuperviewLayoutMargins = YES;
-
-  return toolbarBackgroundView;
-}
-
-- (UIStackView*)createToolbarContentView {
-  UIStackView* toolbarContentView = [[UIStackView alloc] init];
-
-#if BUILDFLAG(IS_IOS_TVOS)
-  // On tvOS, make it impossible to focus `_toolbarContentView` by simply
-  // swiping up on the remote control since this behavior is not intuitive.
-  toolbarContentView.userInteractionEnabled = NO;
-#endif
-
-  toolbarContentView.alignment = UIStackViewAlignmentCenter;
-  toolbarContentView.axis = UILayoutConstraintAxisHorizontal;
-  toolbarContentView.spacing = 16.0;
-
-  return toolbarContentView;
-}
-
-- (void)back {
-  _shell->GoBackOrForward(-1);
-}
-
-- (void)forward {
-  _shell->GoBackOrForward(1);
-}
-
-- (void)reloadOrStop {
-  if (_shell->web_contents()->IsLoading()) {
-    _shell->Stop();
-  } else {
-    _shell->Reload();
-  }
-}
-
-- (void)showMainMenu {
-  UIAlertController* alertController = [self actionSheetWithTitle:@"Main menu"
-                                                          message:nil];
-
-  [alertController
-      addAction:[UIAlertAction actionWithTitle:@"Cancel"
-                                         style:UIAlertActionStyleCancel
-                                       handler:nil]];
-
-  __weak ContentShellWindowDelegate* weakSelf = self;
-
-  if ([_tracingHandler isTracing]) {
-    [alertController
-        addAction:[UIAlertAction actionWithTitle:@"End Tracing"
-                                           style:UIAlertActionStyleDefault
-                                         handler:^(UIAlertAction* action) {
-                                           [weakSelf stopTracing];
-                                         }]];
-  } else {
-    [alertController
-        addAction:[UIAlertAction actionWithTitle:@"Begin Graphics Tracing"
-                                           style:UIAlertActionStyleDefault
-                                         handler:^(UIAlertAction* action) {
-                                           [weakSelf
-                                               startTracingWithCategories:
-                                                   kGraphicsTracingCategories];
-                                         }]];
-    [alertController
-        addAction:[UIAlertAction
-                      actionWithTitle:@"Begin Detailed Graphics Tracing"
-                                style:UIAlertActionStyleDefault
-                              handler:^(UIAlertAction* action) {
-                                [weakSelf
-                                    startTracingWithCategories:
-                                        kDetailedGraphicsTracingCategories];
-                              }]];
-    [alertController
-        addAction:[UIAlertAction
-                      actionWithTitle:@"Begin Navigation Tracing"
-                                style:UIAlertActionStyleDefault
-                              handler:^(UIAlertAction* action) {
-                                [weakSelf startTracingWithCategories:
-                                              kNavigationTracingCategories];
-                              }]];
-    [alertController
-        addAction:[UIAlertAction actionWithTitle:@"Begin Tracing All Categories"
-                                           style:UIAlertActionStyleDefault
-                                         handler:^(UIAlertAction* action) {
-                                           [weakSelf startTracingWithCategories:
-                                                         kAllTracingCategories];
-                                         }]];
-  }
-
-  [self presentViewController:alertController animated:YES completion:nil];
-}
-
-- (void)updateBackground {
-  _toolbarBackgroundView.backgroundColor =
-      [_tracingHandler isTracing]
-          ? [ContentShellWindowDelegate backgroundColorTracing]
-          : [ContentShellWindowDelegate backgroundColorDefault];
-}
-
-- (void)stopTracing {
-  [_tracingHandler stop];
-}
-
-- (void)startTracingWithCategories:(const char*)categories {
-  __weak ContentShellWindowDelegate* weakSelf = self;
-  [_tracingHandler
-      startWithHandler:^{
-        [weakSelf updateBackground];
-      }
-      stopHandler:^{
-        [weakSelf updateBackground];
-      }
-      categories:categories];
-}
-
-- (void)setURL:(NSString*)url {
-  _urlField.text = url;
-}
-
-- (BOOL)textFieldShouldReturn:(UITextField*)field {
-  std::string field_value = base::SysNSStringToUTF8(field.text);
-  GURL url(field_value);
-  if (!url.has_scheme()) {
-    // TODOD(dtapuska): Fix this to URL encode the query.
-    std::string search_url = "https://www.google.com/search?q=" + field_value;
-    url = GURL(search_url);
-  }
-  _shell->LoadURL(url);
-  return YES;
-}
-
-- (UIAlertController*)actionSheetWithTitle:(nullable NSString*)title
-                                   message:(nullable NSString*)message {
-  UIAlertController* alertController = [UIAlertController
-      alertControllerWithTitle:title
-                       message:message
-                preferredStyle:UIAlertControllerStyleActionSheet];
-  alertController.popoverPresentationController.sourceView = _menuButton;
-  alertController.popoverPresentationController.sourceRect =
-      CGRectMake(CGRectGetWidth(_menuButton.bounds) / 2,
-                 CGRectGetHeight(_menuButton.bounds), 1, 1);
-  return alertController;
 }
 
 #pragma mark - SBDOnScreenKeyboardManager
@@ -925,87 +586,6 @@ const char kAllTracingCategories[] = "*";
 
 @end
 
-@implementation TracingHandler
-
-- (void)startWithHandler:(void (^)())startHandler
-             stopHandler:(void (^)())stopHandler
-              categories:(const char*)categories {
-  int i = 0;
-  NSString* filename;
-  NSFileManager* fileManager = [NSFileManager defaultManager];
-  NSString* path = NSSearchPathForDirectoriesInDomains(
-      NSDocumentDirectory, NSUserDomainMask, YES)[0];
-
-  do {
-    filename =
-        [path stringByAppendingPathComponent:
-                  [NSString stringWithFormat:@"trace_%d.pftrace.gz", i++]];
-  } while ([fileManager fileExistsAtPath:filename]);
-
-  if (![fileManager createFileAtPath:filename contents:nil attributes:nil]) {
-    NSLog(@"Failed to create tracefile: %@", filename);
-    return;
-  }
-
-  _traceFileHandle = [NSFileHandle fileHandleForWritingAtPath:filename];
-  if (_traceFileHandle == nil) {
-    NSLog(@"Failed to open tracefile: %@", filename);
-    return;
-  }
-
-  NSLog(@"Will trace to file: %@", filename);
-
-  perfetto::TraceConfig perfetto_config = tracing::GetDefaultPerfettoConfig(
-      base::trace_event::TraceConfig(categories, ""),
-      /*privacy_filtering_enabled=*/false,
-      /*convert_to_legacy_json=*/true);
-
-  perfetto_config.set_write_into_file(true);
-  _tracingSession =
-      perfetto::Tracing::NewTrace(perfetto::BackendType::kCustomBackend);
-
-  _tracingSession->Setup(perfetto_config, [_traceFileHandle fileDescriptor]);
-
-  __weak TracingHandler* weakSelf = self;
-  auto runner = base::SequencedTaskRunner::GetCurrentDefault();
-
-  _tracingSession->SetOnStartCallback([runner, startHandler]() {
-    runner->PostTask(FROM_HERE, base::BindOnce(^{
-                       startHandler();
-                     }));
-  });
-
-  _tracingSession->SetOnStopCallback([runner, weakSelf, stopHandler]() {
-    runner->PostTask(FROM_HERE, base::BindOnce(^{
-                       [weakSelf onStopped];
-                       stopHandler();
-                     }));
-  });
-
-  _tracingSession->Start();
-}
-
-- (void)stop {
-  _tracingSession->Stop();
-}
-
-- (void)onStopped {
-  [_traceFileHandle closeFile];
-  _traceFileHandle = nil;
-  _tracingSession.reset();
-}
-
-- (id)init {
-  _traceFileHandle = nil;
-  return self;
-}
-
-- (BOOL)isTracing {
-  return !!_tracingSession.get();
-}
-
-@end
-
 namespace content {
 
 namespace {
@@ -1242,52 +822,6 @@ void ShellPlatformDelegate::ResizeWebContent(Shell* shell,
   DCHECK(base::Contains(shell_data_map_, shell));
 }
 
-void ShellPlatformDelegate::EnableUIControl(Shell* shell,
-                                            UIControl control,
-                                            bool is_enabled) {
-  if (content::Shell::ShouldHideToolbar()) {
-    return;
-  }
-
-  DCHECK(base::Contains(shell_data_map_, shell));
-  ShellData& shell_data = shell_data_map_[shell];
-  UIButton* button = nil;
-  switch (control) {
-    case BACK_BUTTON:
-      button = [((ContentShellWindowDelegate*)
-                     shell_data.window.rootViewController) backButton];
-      break;
-    case FORWARD_BUTTON:
-      button = [((ContentShellWindowDelegate*)
-                     shell_data.window.rootViewController) forwardButton];
-      break;
-    case STOP_BUTTON: {
-      NSString* imageName = is_enabled ? @"ic_stop" : @"ic_reload";
-      [[((ContentShellWindowDelegate*)shell_data.window.rootViewController)
-          reloadOrStopButton] setImage:[UIImage imageNamed:imageName]
-                              forState:UIControlStateNormal];
-      break;
-    }
-    default:
-      NOTREACHED() << "Unknown UI control";
-  }
-  [button setEnabled:is_enabled];
-}
-
-void ShellPlatformDelegate::SetAddressBarURL(Shell* shell, const GURL& url) {
-  if (Shell::ShouldHideToolbar()) {
-    return;
-  }
-  DCHECK(base::Contains(shell_data_map_, shell));
-  ShellData& shell_data = shell_data_map_[shell];
-
-  NSString* url_string = base::SysUTF8ToNSString(url.spec());
-  [((ContentShellWindowDelegate*)shell_data.window.rootViewController)
-      setURL:url_string];
-}
-
-void ShellPlatformDelegate::SetIsLoading(Shell* shell, bool loading) {}
-
 void ShellPlatformDelegate::SetTitle(Shell* shell,
                                      const std::u16string& title) {
   DCHECK(base::Contains(shell_data_map_, shell));
@@ -1321,9 +855,6 @@ void ShellPlatformDelegate::ToggleFullscreenModeForTab(
     return;
   }
   shell_data.fullscreen = enter_fullscreen;
-  [((ContentShellWindowDelegate*)shell_data.window.rootViewController)
-      toolbarContentView]
-      .hidden = enter_fullscreen;
 }
 
 bool ShellPlatformDelegate::IsFullscreenForTabOrPending(

--- a/cobalt/shell/browser/shell_platform_delegate_views.cc
+++ b/cobalt/shell/browser/shell_platform_delegate_views.cc
@@ -49,14 +49,9 @@
 #include "ui/display/screen.h"
 #include "ui/events/event.h"
 #include "ui/views/background.h"
-#include "ui/views/controls/button/md_text_button.h"
-#include "ui/views/controls/textfield/textfield.h"
-#include "ui/views/controls/textfield/textfield_controller.h"
 #include "ui/views/controls/webview/web_contents_set_background_color.h"
 #include "ui/views/controls/webview/webview.h"
 #include "ui/views/layout/box_layout_view.h"
-#include "ui/views/layout/flex_layout_types.h"
-#include "ui/views/layout/flex_layout_view.h"
 #include "ui/views/view.h"
 #include "ui/views/view_class_properties.h"
 #include "ui/views/widget/desktop_aura/desktop_screen.h"
@@ -120,25 +115,17 @@ struct ShellPlatformDelegate::PlatformData {
 
 namespace {
 
-// Maintain the UI controls and web view for content shell
-class ShellView : public views::BoxLayoutView,
-                  public views::TextfieldController {
+// Maintain the web view for content shell
+class ShellView : public views::BoxLayoutView {
   METADATA_HEADER(ShellView, views::BoxLayoutView)
 
  public:
-  enum UIControl { BACK_BUTTON, FORWARD_BUTTON, STOP_BUTTON };
-
   explicit ShellView(Shell* shell) : shell_(shell) { InitShellWindow(); }
   ShellView(const ShellView&) = delete;
   ShellView& operator=(const ShellView&) = delete;
   ~ShellView() override = default;
 
   Shell* ReleaseShell() { return shell_.release(); }
-
-  // Update the state of UI controls
-  void SetAddressBarURL(const GURL& url) {
-    url_entry_->SetText(base::ASCIIToUTF16(url.spec()));
-  }
 
   void SetWebContents(WebContents* web_contents, const gfx::Size& size) {
     // If there was a previous WebView in this Shell it should be removed and
@@ -174,116 +161,23 @@ class ShellView : public views::BoxLayoutView,
     GetWidget()->SetBounds(bounds);
   }
 
-  void EnableUIControl(UIControl control, bool is_enabled) {
-    if (control == BACK_BUTTON) {
-      back_button_->SetState(is_enabled ? views::Button::STATE_NORMAL
-                                        : views::Button::STATE_DISABLED);
-    } else if (control == FORWARD_BUTTON) {
-      forward_button_->SetState(is_enabled ? views::Button::STATE_NORMAL
-                                           : views::Button::STATE_DISABLED);
-    } else if (control == STOP_BUTTON) {
-      stop_button_->SetState(is_enabled ? views::Button::STATE_NORMAL
-                                        : views::Button::STATE_DISABLED);
-    }
-  }
-
  private:
-  // Initialize the UI control contained in shell window
+  // Initialize the contents view contained in shell window
   void InitShellWindow() {
-    auto toolbar_button_rule = [](const views::View* view,
-                                  const views::SizeBounds& size_bounds) {
-      gfx::Size preferred_size = view->GetPreferredSize({});
-      if (size_bounds != views::SizeBounds() &&
-          size_bounds.width().is_bounded()) {
-        preferred_size.set_width(std::max(
-            std::min(size_bounds.width().value(), preferred_size.width()),
-            preferred_size.width() / 2));
-      }
-      return preferred_size;
-    };
-
     auto builder =
         views::Builder<views::BoxLayoutView>(this)
             .SetBackground(
                 views::CreateSolidBackground(ui::kColorWindowBackground))
             .SetOrientation(views::BoxLayout::Orientation::kVertical);
 
-    if (!Shell::ShouldHideToolbar()) {
-      builder.AddChild(
-          views::Builder<views::FlexLayoutView>()
-              .CopyAddressTo(&toolbar_view_)
-              .SetOrientation(views::LayoutOrientation::kHorizontal)
-              // Top padding = 2, Bottom padding = 5
-              .SetProperty(views::kMarginsKey, gfx::Insets::TLBR(2, 0, 5, 0))
-              .AddChildren(
-                  views::Builder<views::MdTextButton>()
-                      .CopyAddressTo(&back_button_)
-                      .SetText(u"Back")
-                      .SetCallback(base::BindRepeating(
-                          &Shell::GoBackOrForward,
-                          base::Unretained(shell_.get()), -1))
-                      .SetProperty(views::kFlexBehaviorKey,
-                                   views::FlexSpecification(base::BindRepeating(
-                                       toolbar_button_rule))),
-                  views::Builder<views::MdTextButton>()
-                      .CopyAddressTo(&forward_button_)
-                      .SetText(u"Forward")
-                      .SetCallback(base::BindRepeating(
-                          &Shell::GoBackOrForward,
-                          base::Unretained(shell_.get()), 1))
-                      .SetProperty(views::kFlexBehaviorKey,
-                                   views::FlexSpecification(base::BindRepeating(
-                                       toolbar_button_rule))),
-                  views::Builder<views::MdTextButton>()
-                      .CopyAddressTo(&refresh_button_)
-                      .SetText(u"Refresh")
-                      .SetCallback(base::BindRepeating(
-                          &Shell::Reload, base::Unretained(shell_.get())))
-                      .SetProperty(views::kFlexBehaviorKey,
-                                   views::FlexSpecification(base::BindRepeating(
-                                       toolbar_button_rule))),
-                  views::Builder<views::MdTextButton>()
-                      .CopyAddressTo(&stop_button_)
-                      .SetText(u"Stop")
-                      .SetCallback(base::BindRepeating(
-                          &Shell::Stop, base::Unretained(shell_.get())))
-                      .SetProperty(views::kFlexBehaviorKey,
-                                   views::FlexSpecification(base::BindRepeating(
-                                       toolbar_button_rule))),
-                  views::Builder<views::Textfield>()
-                      .CopyAddressTo(&url_entry_)
-                      .SetAccessibleName(u"Enter URL")
-                      .SetController(this)
-                      .SetTextInputType(ui::TextInputType::TEXT_INPUT_TYPE_URL)
-                      .SetProperty(
-                          views::kFlexBehaviorKey,
-                          views::FlexSpecification(
-                              views::LayoutOrientation::kHorizontal,
-                              views::MinimumFlexSizeRule::kScaleToMinimum,
-                              views::MaximumFlexSizeRule::kUnbounded))
-                      // Left padding  = 2, Right padding = 2
-                      .SetProperty(views::kMarginsKey,
-                                   gfx::Insets::TLBR(0, 2, 0, 2))));
-    }
-
     builder.AddChild(views::Builder<views::View>()
                          .CopyAddressTo(&contents_view_)
-                         .SetUseDefaultFillLayout(true)
-                         .CustomConfigure(base::BindOnce([](views::View* view) {
-                           if (!Shell::ShouldHideToolbar()) {
-                             view->SetProperty(views::kMarginsKey,
-                                               gfx::Insets::TLBR(0, 2, 0, 2));
-                           }
-                         })));
-
-    if (!Shell::ShouldHideToolbar()) {
-      builder.AddChild(views::Builder<views::View>().SetProperty(
-          views::kMarginsKey, gfx::Insets::TLBR(0, 0, 5, 0)));
-    }
+                         .SetUseDefaultFillLayout(true));
 
     std::move(builder).BuildChildren();
     SetFlexForView(contents_view_, 1);
   }
+
   void InitAccelerators() {
     // This function must be called when part of the widget hierarchy.
     DCHECK(GetWidget());
@@ -297,24 +191,6 @@ class ShellView : public views::BoxLayoutView,
           ui::Accelerator(keys[i], ui::EF_NONE),
           ui::AcceleratorManager::kNormalPriority, this);
     }
-  }
-  // Overridden from TextfieldController
-  void ContentsChanged(views::Textfield* sender,
-                       const std::u16string& new_contents) override {}
-  bool HandleKeyEvent(views::Textfield* sender,
-                      const ui::KeyEvent& key_event) override {
-    if (key_event.type() == ui::EventType::kKeyPressed &&
-        sender == url_entry_ && key_event.key_code() == ui::VKEY_RETURN) {
-      std::string text = base::UTF16ToUTF8(url_entry_->GetText());
-      GURL url(text);
-      if (!url.has_scheme()) {
-        url = GURL(std::string("http://") + std::string(text));
-        url_entry_->SetText(base::ASCIIToUTF16(url.spec()));
-      }
-      shell_->LoadURL(url);
-      return true;
-    }
-    return false;
   }
 
   // Overridden from View
@@ -347,14 +223,6 @@ class ShellView : public views::BoxLayoutView,
 
   // Window title
   std::u16string title_;
-
-  // Toolbar view contains forward/backward/reload button and URL entry
-  raw_ptr<views::View> toolbar_view_ = nullptr;
-  raw_ptr<views::Button> back_button_ = nullptr;
-  raw_ptr<views::Button> forward_button_ = nullptr;
-  raw_ptr<views::Button> refresh_button_ = nullptr;
-  raw_ptr<views::Button> stop_button_ = nullptr;
-  raw_ptr<views::Textfield> url_entry_ = nullptr;
 
   // Contents view contains the web contents view
   raw_ptr<views::View> contents_view_ = nullptr;
@@ -572,43 +440,6 @@ void ShellPlatformDelegate::ResizeWebContent(Shell* shell,
                                              const gfx::Size& content_size) {
   shell->web_contents()->Resize(gfx::Rect(content_size));
 }
-
-void ShellPlatformDelegate::EnableUIControl(Shell* shell,
-                                            UIControl control,
-                                            bool is_enabled) {
-  if (Shell::ShouldHideToolbar()) {
-    return;
-  }
-
-  DCHECK(base::Contains(shell_data_map_, shell));
-  ShellData& shell_data = shell_data_map_[shell];
-
-  if (shell_data.window_widget) {
-    auto* view = ShellViewForWidget(shell_data.window_widget);
-    if (control == BACK_BUTTON) {
-      view->EnableUIControl(ShellView::BACK_BUTTON, is_enabled);
-    } else if (control == FORWARD_BUTTON) {
-      view->EnableUIControl(ShellView::FORWARD_BUTTON, is_enabled);
-    } else if (control == STOP_BUTTON) {
-      view->EnableUIControl(ShellView::STOP_BUTTON, is_enabled);
-    }
-  }
-}
-
-void ShellPlatformDelegate::SetAddressBarURL(Shell* shell, const GURL& url) {
-  if (Shell::ShouldHideToolbar()) {
-    return;
-  }
-
-  DCHECK(base::Contains(shell_data_map_, shell));
-  ShellData& shell_data = shell_data_map_[shell];
-
-  if (shell_data.window_widget) {
-    ShellViewForWidget(shell_data.window_widget)->SetAddressBarURL(url);
-  }
-}
-
-void ShellPlatformDelegate::SetIsLoading(Shell* shell, bool loading) {}
 
 void ShellPlatformDelegate::SetTitle(Shell* shell,
                                      const std::u16string& title) {

--- a/cobalt/shell/browser/shell_test_support.h
+++ b/cobalt/shell/browser/shell_test_support.h
@@ -72,14 +72,6 @@ class MockShellPlatformDelegate : public ShellPlatformDelegate {
   MOCK_METHOD(bool, DestroyShell, (Shell * shell), (override));
   MOCK_METHOD(void, CleanUp, (Shell * shell), (override));
   MOCK_METHOD(void,
-              EnableUIControl,
-              (Shell * shell, UIControl control, bool is_enabled),
-              (override));
-  MOCK_METHOD(void,
-              SetAddressBarURL,
-              (Shell * shell, const GURL& url),
-              (override));
-  MOCK_METHOD(void,
               SetTitle,
               (Shell * shell, const std::u16string& title),
               (override));

--- a/cobalt/shell/common/shell_switches.cc
+++ b/cobalt/shell/common/shell_switches.cc
@@ -36,9 +36,6 @@ const char kDisableSystemFontCheck[] = "disable-system-font-check";
 // Size for the content_shell's host window (i.e. "800x600").
 const char kContentShellHostWindowSize[] = "content-shell-host-window-size";
 
-// Hides toolbar from content_shell's host window.
-const char kContentShellHideToolbar[] = "content-shell-hide-toolbar";
-
 // Enables APIs guarded with the [IsolatedContext] IDL attribute for the given
 // comma-separated list of origins.
 const char kIsolatedContextOrigins[] = "isolated-context-origins";

--- a/cobalt/shell/common/shell_switches.h
+++ b/cobalt/shell/common/shell_switches.h
@@ -33,7 +33,6 @@ extern const char kContentShellUserDataDir[];
 extern const char kCrashDumpsDir[];
 extern const char kDisableSystemFontCheck[];
 extern const char kContentShellHostWindowSize[];
-extern const char kContentShellHideToolbar[];
 extern const char kIsolatedContextOrigins[];
 extern const char kOmitDeviceAuthenticationQueryParameters[];
 extern const char kRemoteDebuggingAddress[];

--- a/cobalt/testing/browser_tests/content_browser_test.cc
+++ b/cobalt/testing/browser_tests/content_browser_test.cc
@@ -94,10 +94,7 @@ ContentBrowserTest::ContentBrowserTest() {
 
 ContentBrowserTest::~ContentBrowserTest() {}
 
-void ContentBrowserTest::SetUpCommandLine(base::CommandLine* command_line) {
-  // Cobalt UI does not need nor support Toolbar.
-  command_line->AppendSwitch(switches::kContentShellHideToolbar);
-}
+void ContentBrowserTest::SetUpCommandLine(base::CommandLine*) {}
 
 void ContentBrowserTest::SetUp() {
   metrics::CleanExitBeacon::SkipCleanShutdownStepsForTesting();


### PR DESCRIPTION
Cobalt does not use nor support the content_shell navigation toolbar
(such as the address bar, back, forward, and reload/stop buttons).
  
Remove unused toolbar UI views, textfield controller logic, dead JNI
stubs, and the obsolete content-shell-hide-toolbar switch.

Issue: 546214042