### PR TITLE
ci: Fix docker-compose syntax and Debian Buster EOL (COBALT_9)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,9 @@ x-build-volumes: &build-volumes
     - ${STARBOARD_TOOLCHAINS_DIR:-container-starboard-toolchains}:/root/starboard-toolchains
 
 x-build-common-definitions: &build-common-definitions
-  <<: *common-definitions
-  <<: *build-volumes
+  <<:
+    - *common-definitions
+    - *build-volumes
   depends_on:
     - build-base
 
@@ -89,8 +90,9 @@ services:
       - CONFIG=${CONFIG:-debug}
 
   linux-x64x11-xenial:
-    <<: *common-definitions
-    <<: *build-volumes
+    <<:
+      - *common-definitions
+      - *build-volumes
     build:
       context: ./docker/linux
       dockerfile: linux-x64x11/Dockerfile
@@ -101,8 +103,9 @@ services:
       - build-base-xenial
 
   linux-x64x11-clang-3-6:
-    <<: *common-definitions
-    <<: *build-volumes
+    <<:
+      - *common-definitions
+      - *build-volumes
     build:
       context: ./docker/linux/
       dockerfile: clang-3-6/Dockerfile

--- a/docker/linux/base/Dockerfile
+++ b/docker/linux/base/Dockerfile
@@ -7,6 +7,11 @@ ENV PYTHONUNBUFFERED 1
 ARG GIT_SHA265SUM="93993babac690a06906d832a1715c3315b4787a2845aeb500f7dcc82e1599df2 git-2.18.0.tar.gz"
 
 # === Install common dependencies
+RUN sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list \
+    && sed -i 's/security.debian.org/archive.debian.org/g' /etc/apt/sources.list \
+    && sed -i '/buster-updates/d' /etc/apt/sources.list \
+    && echo "Acquire::Check-Valid-Until \"false\";" > /etc/apt/apt.conf.d/99no-check-valid-until
+
 RUN apt update -qqy \
     && apt install -qqy --no-install-recommends \
         python-pip \


### PR DESCRIPTION
Fix YAML duplicate merge key syntax in docker-compose.yml for Docker Compose v2 compatibility, and update Debian Buster apt repositories to archive.debian.org due to Debian Buster EOL.

Tag: agy
Conv: c3a2a510-69c4-4ff1-9634-f3c00bdcba86
Bug: 546190339