### PR TITLE
ci: Fix duplicate YAML merge keys in docker-compose.yml (rc_11)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,9 @@ x-build-volumes: &build-volumes
     - ${STARBOARD_TOOLCHAINS_DIR:-container-starboard-toolchains}:/root/starboard-toolchains
 
 x-build-common-definitions: &build-common-definitions
-  <<: *common-definitions
-  <<: *build-volumes
+  <<:
+    - *common-definitions
+    - *build-volumes
   depends_on:
     - build-base
 
@@ -89,8 +90,9 @@ services:
       - CONFIG=${CONFIG:-debug}
 
   linux-x64x11-xenial:
-    <<: *common-definitions
-    <<: *build-volumes
+    <<:
+      - *common-definitions
+      - *build-volumes
     build:
       context: ./docker/linux
       dockerfile: linux-x64x11/Dockerfile
@@ -101,8 +103,9 @@ services:
       - build-base-xenial
 
   linux-x64x11-clang-3-6:
-    <<: *common-definitions
-    <<: *build-volumes
+    <<:
+      - *common-definitions
+      - *build-volumes
     build:
       context: ./docker/linux/
       dockerfile: clang-3-6/Dockerfile

--- a/docker/linux/base/Dockerfile
+++ b/docker/linux/base/Dockerfile
@@ -7,6 +7,11 @@ ENV PYTHONUNBUFFERED 1
 ARG GIT_SHA265SUM="93993babac690a06906d832a1715c3315b4787a2845aeb500f7dcc82e1599df2 git-2.18.0.tar.gz"
 
 # === Install common dependencies
+RUN sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list \
+    && sed -i 's/security.debian.org/archive.debian.org/g' /etc/apt/sources.list \
+    && sed -i '/buster-updates/d' /etc/apt/sources.list \
+    && echo "Acquire::Check-Valid-Until \"false\";" > /etc/apt/apt.conf.d/99no-check-valid-until
+
 RUN apt update -qqy \
     && apt install -qqy --no-install-recommends \
         python-pip \

--- a/docker/linux/base/build/Dockerfile
+++ b/docker/linux/base/build/Dockerfile
@@ -21,7 +21,7 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
 # === Install depot_tools
-RUN git clone https://cobalt.googlesource.com/depot_tools /depot_tools
+RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git /depot_tools
 
 # === Configure common env vars
 ENV PATH="${PATH}:/depot_tools" \

--- a/docker/linux/raspi/Dockerfile
+++ b/docker/linux/raspi/Dockerfile
@@ -29,7 +29,7 @@ RUN mkdir -p ${raspi_home}/tools \
 
 RUN cd ${raspi_home} \
     && wget -q \
-    "https://storage.googleapis.com/cobalt-static-storage/${raspi_sysroot}"
+    "https://storage.googleapis.com/cobalt-static-storage-public/${raspi_sysroot}"
 
 RUN cd ${raspi_home} && tar Jxpvf ${raspi_sysroot} --no-same-owner
 


### PR DESCRIPTION
Replace duplicate '<<:' mapping keys with a list of mapping anchors in docker-compose.yml to comply with standard YAML syntax and ensure compatibility with Docker Compose v2.

Tag: agy
Conv: c3a2a510-69c4-4ff1-9634-f3c00bdcba86
Bug: 546190339