### PR TITLE
ci: Fix Gemini commit workflow and add zizmor trigger ignores

### DIFF
--- a/.github/workflows/deflake_tests.yml
+++ b/.github/workflows/deflake_tests.yml
@@ -1,5 +1,9 @@
+# Disable dangerous-triggers rule because this workflow uses workflow_run
+# strictly to check job results and rerun failed test jobs without executing
+# untrusted code.
+# actionlint: disable dangerous-triggers
 name: Deflake Tests
-on:
+on: # zizmor: ignore[dangerous-triggers]
   workflow_run:
     workflows: [android, raspi-2-modular, evergreen, linux, tvos]
     types:
@@ -18,6 +22,7 @@ jobs:
       - name: Checkout .github Files
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 1
           filter: blob:none
           sparse-checkout: .github

--- a/.github/workflows/gemini-commit-message.yml
+++ b/.github/workflows/gemini-commit-message.yml
@@ -1,6 +1,10 @@
+# Disable dangerous-triggers rule because this workflow uses pull_request_target
+# strictly to generate commit messages from the PR diff and comment on PRs
+# without checking out or executing untrusted code from PR branches.
+# actionlint: disable dangerous-triggers
 name: 'Gemini Commit Message Generator'
 
-on:
+on: # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types: [opened, reopened]
   issue_comment:
@@ -110,8 +114,12 @@ jobs:
           GEMINI_SECRET: ${{ secrets.GEMINI_ACTIONS_API_KEY }}
         run: |
           set -eux
-          # Keep only what is after the first space in the comment body.
-          COMMENT=${COMMENT_BODY#* }
+          # Keep only what is after the first space in the comment body if a comment was provided.
+          if [[ -n "${COMMENT}" && "${COMMENT}" == *" "* ]]; then
+            COMMENT="${COMMENT#* }"
+          else
+            COMMENT=""
+          fi
 
           # Use jq to safely combine the instructions with the variables.
           json_payload=$(jq -n \
@@ -120,7 +128,7 @@ jobs:
             --arg title "${PR_TITLE}" \
             --arg body "${PR_BODY}" \
             --arg diff "${PR_DIFF}" \
-            --arg comment "$COMMENT}" \
+            --arg comment "${COMMENT}" \
             '{
               contents: [{
                 parts: [{

--- a/.github/workflows/label-cherry-pick.yaml
+++ b/.github/workflows/label-cherry-pick.yaml
@@ -1,6 +1,10 @@
+# Disable dangerous-triggers rule because this workflow uses pull_request_target
+# strictly to label and create cherry-pick PRs for merged pull requests
+# without executing untrusted code from PR branches.
+# actionlint: disable dangerous-triggers
 name: Label Cherry Pick
 
-on:
+on: # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types:
       - labeled

--- a/.github/workflows/outside_collaborator.yaml
+++ b/.github/workflows/outside_collaborator.yaml
@@ -1,6 +1,10 @@
+# Disable dangerous-triggers rule because this workflow uses pull_request_target
+# strictly to assign labels to PRs from outside collaborators
+# without checking out or executing untrusted code from PR branches.
+# actionlint: disable dangerous-triggers
 name: Outside Collaborator
 
-on:
+on: # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types:
       - opened


### PR DESCRIPTION
## Summary

- Add `# zizmor: ignore[dangerous-triggers]` annotations to workflows triggered by `pull_request_target` or `workflow_run` (`gemini-commit-message.yml`, `deflake_tests.yml`, `label-cherry-pick.yaml`, `outside_collaborator.yaml`) to satisfy the Zizmor security audit.
- Fix `gemini-commit-message.yml` to safely parse the comment body when triggered by `pull_request_target`, preventing an unbound variable error under `set -u`, and fix a syntax typo in the jq argument.
- Add `persist-credentials: false` to `deflake_tests.yml`.

Tag: agy
Conv: c3a2a510-69c4-4ff1-9634-f3c00bdcba86

Bug: 546190339