### PR TITLE
ci: Exclude docker_win action changes from Windows docker build (24.lts.1+)

### DIFF
--- a/.github/actions/docker_win/action.yaml
+++ b/.github/actions/docker_win/action.yaml
@@ -18,7 +18,6 @@ runs:
         files: |
           docker-compose-windows.yml
           docker/windows/**
-          .github/actions/docker_win/**
     - name: Retrieve Docker metadata
       id: meta
       uses: docker/metadata-action@507c2f2dc502c992ad446e3d7a5dfbe311567a96 # v4.3.0


### PR DESCRIPTION
Do not trigger Windows Docker image rebuilds when changes are made
only to .github/actions/docker_win/** workflows.

Tag: agy
Conv: c3a2a510-69c4-4ff1-9634-f3c00bdcba86
Bug: 546190339