### PR TITLE
Add Peak Memory Guardrails and Proportional Distribution Bar to Cobalt memory extension

### DIFF
--- a/cobalt/tools/devtools_extension/README.md
+++ b/cobalt/tools/devtools_extension/README.md
@@ -61,15 +61,16 @@ A lightweight Manifest V3 Chrome Extension providing real-time memory inspection
 
 ---
 
-## Metric Breakdown Reference
+## Metric Breakdown & Reference
 
-The primary **Session Median Telemetry (P50 Breakdown)** table renders the 12 continuous native and managed allocators matching production Kimono / PLX field telemetry (`go/kimono-memory-metrics`):
+### 1. Session P50 Memory Breakdown
+Aggregated median memory footprint across continuous allocators matching production Kimono / PLX field telemetry (`go/kimono-memory-metrics`). Includes an embedded proportional distribution bar visualizing relative allocator weights across the total Physical Resident Set (RSS).
 
-### Process Totals (OS / Kernel)
-* **Physical Resident Set (RSS)** (`Memory.Browser.ResidentSet`): Total physical RAM pages in RAM mapped by the OS kernel.
+#### Process Totals (OS / Kernel)
+* **Physical Resident Set (RSS)** (`Memory.Browser.ResidentSet`): Total physical RAM pages mapped by the OS kernel.
 * **Private Memory Footprint** (`Memory.Browser.PrivateMemoryFootprint`): Unshared memory dedicated strictly to Cobalt (Anonymous RSS + Swap), directly contributing to device OOM threshold.
 
-### Subsystem & Allocator Breakdown
+#### Subsystem & Allocator Breakdown
 * **PartitionAlloc C++ Heap** (`Memory.Experimental.Browser2.PartitionAlloc`): General C++ allocations across browser/engine modules and JavaScript `ArrayBuffer` backing stores.
 * **System Malloc Heap** (`Memory.Experimental.Browser2.Malloc`): System C runtime `malloc` (allocations outside PartitionAlloc-Everywhere, e.g. third-party dynamic libraries).
 * **V8 JavaScript Engine Heap** (`Memory.Experimental.Browser2.V8`): V8 JavaScript engine managed heap (JS objects, compiled bytecode, closures, IC caches).
@@ -80,3 +81,14 @@ The primary **Session Median Telemetry (P50 Breakdown)** table renders the 12 co
 * **Font Caches & Glyph Buffers** (`Memory.Experimental.Browser2.Fonts`): Font tables, FreeType glyph slot caches, and HarfBuzz text shaping buffers.
 * **Thread Stacks** (`Memory.Experimental.Browser2.Stacks`): Active stack frames for Cobalt threads (Browser, Compositor, IO, Media workers).
 * **Android ART Java Heap** (`Memory.Experimental.Browser2.JavaHeap`): Android Java runtime heap for Coat activity lifecycle and JNI media bridges.
+
+---
+
+### 2. Lifecycle Peak Memory
+Tracks maximum memory peaks recorded across elapsed lifecycle time windows and initial graphics rendering:
+
+* **0 to 2 min Window** (`Memory.Experimental.Renderer.HighestPrivateMemoryFootprint.0to2min`): Peak private memory footprint reached during app boot and initial browse.
+* **2 to 4 min Window** (`Memory.Experimental.Renderer.HighestPrivateMemoryFootprint.2to4min`): Peak PMF reached during early navigation & initial video playback.
+* **4 to 8 min Window** (`Memory.Experimental.Renderer.HighestPrivateMemoryFootprint.4to8min`): Peak PMF reached during continuous browsing.
+* **8 to 16 min Window** (`Memory.Experimental.Renderer.HighestPrivateMemoryFootprint.8to16min`): Peak PMF reached during extended session stability.
+* **Peak GPU (Page Load)** (`Memory.GPU.PeakMemoryUsage2.PageLoad`): Maximum GPU VRAM allocated during initial page navigation and rendering.

--- a/cobalt/tools/devtools_extension/panel.css
+++ b/cobalt/tools/devtools_extension/panel.css
@@ -29,6 +29,19 @@
   --status-pending: #fbbf24;
   --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+
+  /* 10 Canonical Allocator Palette (go/kimono-memory-metrics) */
+  --color-binary: #8b5cf6;
+  --color-codeother: #a855f7;
+  --color-pa: #3b82f6;
+  --color-malloc: #0ea5e9;
+  --color-v8: #f59e0b;
+  --color-blinkgc: #ec4899;
+  --color-skia: #10b981;
+  --color-fonts: #14b8a6;
+  --color-stacks: #f97316;
+  --color-java: #e11d48;
+  --color-other: #64748b;
 }
 
 * {
@@ -171,7 +184,7 @@ body {
   gap: 10px;
 }
 
-/* Table Section */
+/* Primary Table Section */
 .table-section {
   background-color: var(--bg-card);
   border: 1px solid var(--border-color);
@@ -179,7 +192,7 @@ body {
   padding: 16px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 14px;
 }
 
 .section-header {
@@ -248,6 +261,56 @@ body {
   font-family: var(--font-mono);
 }
 
+/* Integrated Distribution Bar */
+.distribution-bar-container {
+  width: 100%;
+  background-color: rgba(0, 0, 0, 0.3);
+  border-radius: 6px;
+  border: 1px solid var(--border-color);
+  overflow: hidden;
+  height: 20px;
+}
+
+.distribution-bar {
+  display: flex;
+  width: 100%;
+  height: 100%;
+}
+
+.distribution-bar-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  font-size: 11px;
+  color: var(--text-dim);
+  font-style: italic;
+}
+
+.distribution-segment {
+  height: 100%;
+  transition: width 0.4s ease;
+  position: relative;
+}
+
+.distribution-segment:hover {
+  filter: brightness(1.15);
+}
+
+.segment-binary { background-color: var(--color-binary); }
+.segment-codeother { background-color: var(--color-codeother); }
+.segment-pa { background-color: var(--color-pa); }
+.segment-malloc { background-color: var(--color-malloc); }
+.segment-v8 { background-color: var(--color-v8); }
+.segment-blinkgc { background-color: var(--color-blinkgc); }
+.segment-skia { background-color: var(--color-skia); }
+.segment-fonts { background-color: var(--color-fonts); }
+.segment-stacks { background-color: var(--color-stacks); }
+.segment-java { background-color: var(--color-java); }
+.segment-other { background-color: var(--color-other); }
+
+/* Metrics Table */
 .metrics-table {
   width: 100%;
   border-collapse: collapse;
@@ -297,6 +360,20 @@ body {
   gap: 2px;
 }
 
+.metric-label-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.metric-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+  flex-shrink: 0;
+}
+
 .metric-label {
   font-weight: 600;
   color: var(--text-bright);
@@ -309,26 +386,6 @@ body {
   color: var(--text-dim);
   font-family: var(--font-mono);
   word-break: break-all;
-}
-
-.badge-p50 {
-  display: inline-block;
-  font-size: 11px;
-  font-weight: 600;
-  color: #fbbf24;
-  background-color: rgba(251, 191, 36, 0.12);
-  padding: 2px 6px;
-  border-radius: 4px;
-}
-
-.badge-pending {
-  display: inline-block;
-  font-size: 11px;
-  font-weight: 500;
-  color: #a1a1aa;
-  background-color: rgba(161, 161, 170, 0.12);
-  padding: 2px 6px;
-  border-radius: 4px;
 }
 
 .pending-text {
@@ -346,6 +403,115 @@ body {
   font-family: var(--font-family) !important;
 }
 
+/* Lifecycle Peak Memory Section */
+.guardrails-section {
+  background-color: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.guardrails-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 12px;
+}
+
+.guardrail-card {
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 8px;
+  transition: transform 0.15s ease, border-color 0.15s ease;
+}
+
+.guardrail-card:hover {
+  border-color: #52525b;
+}
+
+.guardrail-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.guardrail-title {
+  font-weight: 700;
+  font-size: 12px;
+  color: var(--text-bright);
+}
+
+.guardrail-key {
+  font-size: 10px;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  word-break: break-all;
+  margin-top: 1px;
+}
+
+.guardrail-value-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  margin: 4px 0;
+}
+
+.guardrail-value {
+  font-size: 18px;
+  font-weight: 800;
+  font-family: var(--font-mono);
+  color: var(--text-bright);
+}
+
+.guardrail-value.pending {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-dim);
+  font-style: italic;
+  font-family: var(--font-family);
+}
+
+.guardrail-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 11px;
+  padding-top: 6px;
+  border-top: 1px solid rgba(63, 63, 70, 0.4);
+}
+
+.guardrail-desc {
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
+.badge-guardrail-recorded {
+  background-color: rgba(34, 197, 94, 0.15);
+  color: var(--status-connected);
+  font-weight: 600;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 10px;
+}
+
+.badge-guardrail-pending {
+  background-color: rgba(161, 161, 170, 0.15);
+  color: var(--text-dim);
+  font-weight: 500;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 10px;
+}
+
 @media (max-width: 768px) {
   .toolbar {
     flex-direction: column;
@@ -356,5 +522,8 @@ body {
   }
   .connection-bar input[type="text"] {
     flex: 1;
+  }
+  .guardrails-grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/cobalt/tools/devtools_extension/panel.html
+++ b/cobalt/tools/devtools_extension/panel.html
@@ -30,7 +30,7 @@
     <section class="table-section">
       <div class="section-header">
         <div class="title-row">
-          <div class="section-title">📊 Session Median Telemetry (P50 Breakdown)</div>
+          <div class="section-title">📊 Session P50 Memory Breakdown</div>
           <div id="sampling-progress" class="sampling-badge">0 / 12 Reported</div>
         </div>
         <div class="section-instruction">
@@ -43,6 +43,14 @@
         </div>
       </div>
 
+      <!-- Integrated Proportional Distribution Visualizer -->
+      <div class="distribution-bar-container">
+        <div id="distribution-bar" class="distribution-bar">
+          <div class="distribution-bar-empty">Waiting for memory telemetry...</div>
+        </div>
+      </div>
+
+      <!-- Breakdown Table with Color-Coded Allocator Mapping -->
       <table class="metrics-table" id="metrics-table">
         <thead>
           <tr>
@@ -57,6 +65,20 @@
           </tr>
         </tbody>
       </table>
+    </section>
+
+    <!-- Lifecycle Peak Memory Section -->
+    <section class="guardrails-section">
+      <div class="section-header">
+        <div class="section-title">⏱ Lifecycle Peak Memory</div>
+        <div class="section-instruction">
+          Highest private memory footprint (PMF) peaks recorded across elapsed session duration windows and initial GPU page load.
+        </div>
+      </div>
+
+      <div class="guardrails-grid" id="guardrails-grid">
+        <!-- 4 Time-Windowed PMF Cards + 1 Peak GPU Card dynamically rendered by panel.js -->
+      </div>
     </section>
   </div>
 

--- a/cobalt/tools/devtools_extension/panel.js
+++ b/cobalt/tools/devtools_extension/panel.js
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 /**
- * Cobalt Memory Breakdown DevTools Extension Panel Controller (PR 3.1).
- * Connects to Cobalt's active CDP port via WebSocket and renders the
- * primary Session Median Telemetry table (P50 breakdown).
+ * Cobalt Memory Breakdown DevTools Extension Panel Controller.
+ * Connects to Cobalt's active CDP port via WebSocket and renders:
+ * 1. Proportional Memory Footprint Distribution Bar (10 Canonical Allocators).
+ * 2. Primary Session P50 Memory Breakdown table (12 continuous P50 allocators).
+ * 3. Lifecycle Peak Memory scorecard (time-windowed PMF & Peak GPU).
  */
 
 // 12 Continuous UMA memory breakdown metrics grouped by Process Totals and Allocator Breakdown
@@ -30,22 +32,56 @@ const METRIC_GROUPS = [
   {
     groupTitle: "Subsystem & Allocator Breakdown",
     metrics: [
-      { umaName: "Memory.Experimental.Browser2.PartitionAlloc", cdpKey: "Memory.Experimental.Browser2.PartitionAlloc.P50", label: "PartitionAlloc C++ Heap" },
-      { umaName: "Memory.Experimental.Browser2.Malloc", cdpKey: "Memory.Experimental.Browser2.Malloc.P50", label: "System Malloc Heap" },
-      { umaName: "Memory.Experimental.Browser2.V8", cdpKey: "Memory.Experimental.Browser2.V8.P50", label: "V8 JavaScript Engine Heap" },
-      { umaName: "Memory.Experimental.Browser2.BlinkGC", cdpKey: "Memory.Experimental.Browser2.BlinkGC.P50", label: "Blink C++ GC (cppgc)" },
-      { umaName: "Memory.Experimental.Browser2.Skia", cdpKey: "Memory.Experimental.Browser2.Skia.P50", label: "Skia 2D Graphics & Images" },
-      { umaName: "Memory.Browser.LibChrobaltRss", cdpKey: "Memory.Browser.LibChrobaltRss.P50", label: "Binary Executable Pages (libchrobalt.so)" },
-      { umaName: "Memory.Experimental.Browser2.CodeOther", cdpKey: "Memory.Experimental.Browser2.CodeOther.P50", label: "Other Dynamic Shared Libraries" },
-      { umaName: "Memory.Experimental.Browser2.Fonts", cdpKey: "Memory.Experimental.Browser2.Fonts.P50", label: "Font Caches & Glyph Buffers" },
-      { umaName: "Memory.Experimental.Browser2.Stacks", cdpKey: "Memory.Experimental.Browser2.Stacks.P50", label: "Thread Stacks" },
-      { umaName: "Memory.Experimental.Browser2.JavaHeap", cdpKey: "Memory.Experimental.Browser2.JavaHeap.P50", label: "Android ART Java Heap" },
+      { umaName: "Memory.Experimental.Browser2.PartitionAlloc", cdpKey: "Memory.Experimental.Browser2.PartitionAlloc.P50", label: "PartitionAlloc C++ Heap", cssClass: "segment-pa", color: "var(--color-pa)" },
+      { umaName: "Memory.Experimental.Browser2.Malloc", cdpKey: "Memory.Experimental.Browser2.Malloc.P50", label: "System Malloc Heap", cssClass: "segment-malloc", color: "var(--color-malloc)" },
+      { umaName: "Memory.Experimental.Browser2.V8", cdpKey: "Memory.Experimental.Browser2.V8.P50", label: "V8 JavaScript Engine Heap", cssClass: "segment-v8", color: "var(--color-v8)" },
+      { umaName: "Memory.Experimental.Browser2.BlinkGC", cdpKey: "Memory.Experimental.Browser2.BlinkGC.P50", label: "Blink C++ GC (cppgc)", cssClass: "segment-blinkgc", color: "var(--color-blinkgc)" },
+      { umaName: "Memory.Experimental.Browser2.Skia", cdpKey: "Memory.Experimental.Browser2.Skia.P50", label: "Skia 2D Graphics & Images", cssClass: "segment-skia", color: "var(--color-skia)" },
+      { umaName: "Memory.Browser.LibChrobaltRss", cdpKey: "Memory.Browser.LibChrobaltRss.P50", label: "Binary Executable Pages (libchrobalt.so)", cssClass: "segment-binary", color: "var(--color-binary)" },
+      { umaName: "Memory.Experimental.Browser2.CodeOther", cdpKey: "Memory.Experimental.Browser2.CodeOther.P50", label: "Other Dynamic Shared Libraries", cssClass: "segment-codeother", color: "var(--color-codeother)" },
+      { umaName: "Memory.Experimental.Browser2.Fonts", cdpKey: "Memory.Experimental.Browser2.Fonts.P50", label: "Font Caches & Glyph Buffers", cssClass: "segment-fonts", color: "var(--color-fonts)" },
+      { umaName: "Memory.Experimental.Browser2.Stacks", cdpKey: "Memory.Experimental.Browser2.Stacks.P50", label: "Thread Stacks", cssClass: "segment-stacks", color: "var(--color-stacks)" },
+      { umaName: "Memory.Experimental.Browser2.JavaHeap", cdpKey: "Memory.Experimental.Browser2.JavaHeap.P50", label: "Android ART Java Heap", cssClass: "segment-java", color: "var(--color-java)" },
     ]
   }
 ];
 
 // Flat list for counter computation
 const ALL_CANONICAL_METRICS = METRIC_GROUPS.flatMap(g => g.metrics);
+
+// 10 Canonical Allocators for Distribution Bar (dynamically retrieved from subsystem group)
+const ALLOCATOR_SEGMENTS = METRIC_GROUPS.find(g => g.groupTitle.includes("Subsystem"))?.metrics || [];
+
+// Peak Guardrail Scorecard Metrics
+const GUARDRAIL_METRICS = [
+  {
+    title: "0 to 2 min Window",
+    umaName: "Memory.Experimental.Renderer.HighestPrivateMemoryFootprint.0to2min",
+    description: "Boot & initial browse phase"
+  },
+  {
+    title: "2 to 4 min Window",
+    umaName: "Memory.Experimental.Renderer.HighestPrivateMemoryFootprint.2to4min",
+    description: "Early navigation & initial playback"
+  },
+  {
+    title: "4 to 8 min Window",
+    umaName: "Memory.Experimental.Renderer.HighestPrivateMemoryFootprint.4to8min",
+    description: "Continuous browsing"
+  },
+  {
+    title: "8 to 16 min Window",
+    umaName: "Memory.Experimental.Renderer.HighestPrivateMemoryFootprint.8to16min",
+    description: "Extended session stability"
+  },
+  {
+    title: "Peak GPU (Page Load)",
+    umaName: "Memory.GPU.PeakMemoryUsage2.PageLoad",
+    cdpKey: "Memory.GPU.PeakMemoryUsage2.PageLoad.P50",
+    fallbackKey: "Memory.GPU.PeakMemoryUsage2.PageLoad",
+    description: "Initial page navigation & render"
+  }
+];
 
 let ws = null;
 let pollInterval = null;
@@ -60,6 +96,8 @@ const statusBadge = document.getElementById("connection-status");
 const tableBody = document.getElementById("metrics-table-body");
 const samplingProgress = document.getElementById("sampling-progress");
 const samplingHint = document.getElementById("sampling-hint");
+const distributionBar = document.getElementById("distribution-bar");
+const guardrailsGrid = document.getElementById("guardrails-grid");
 
 function formatBytesToMB(bytes) {
   if (bytes === undefined || bytes === null || isNaN(bytes)) return "-- MB";
@@ -78,6 +116,8 @@ function clearPolling() {
 
 // Auto-Connect on Panel Load and Restore Persisted URL
 document.addEventListener("DOMContentLoaded", () => {
+  renderGuardrails();
+
   if (typeof chrome !== "undefined" && chrome.storage && chrome.storage.local) {
     chrome.storage.local.get(["cdpUrl"], (result) => {
       if (result && result.cdpUrl) {
@@ -234,12 +274,12 @@ function handlePerformanceMetrics(metrics) {
 }
 
 function updateUi() {
-  const rssP50 = latestMetrics["Memory.Browser.ResidentSet.P50"] || null;
+  const rssP50 = latestMetrics?.["Memory.Browser.ResidentSet.P50"] || null;
 
   // 1. Count Reported vs Pending Canonical Subsystems
   let reportedCount = 0;
   ALL_CANONICAL_METRICS.forEach(item => {
-    if (latestMetrics[item.cdpKey] !== undefined && latestMetrics[item.cdpKey] !== null) {
+    if (latestMetrics?.[item.cdpKey] !== undefined && latestMetrics?.[item.cdpKey] !== null) {
       reportedCount++;
     }
   });
@@ -254,8 +294,50 @@ function updateUi() {
     samplingHint.style.display = "block";
   }
 
-  // 2. Render Grouped Breakdown Rows
+  // 2. Render Integrated Visual Distribution Bar (10 Canonical Allocators)
+  renderDistributionBar(rssP50);
+
+  // 3. Render Grouped Breakdown Table Rows
   renderTable(rssP50);
+
+  // 4. Render Peak Memory & Lifecycle Guardrail Scorecard
+  renderGuardrails();
+}
+
+function renderDistributionBar(totalRss) {
+  if (!totalRss || totalRss <= 0) {
+    distributionBar.innerHTML = `<div class="distribution-bar-empty">Waiting for memory telemetry...</div>`;
+    return;
+  }
+
+  let totalAccountedBytes = 0;
+  let barHtml = "";
+
+  ALLOCATOR_SEGMENTS.forEach(item => {
+    const rawVal = latestMetrics?.[item.cdpKey];
+    if (typeof rawVal === "number" && rawVal > 0) {
+      totalAccountedBytes += rawVal;
+      const pct = ((rawVal / totalRss) * 100).toFixed(1);
+      const mbStr = formatBytesToMB(rawVal);
+
+      barHtml += `
+        <div class="distribution-segment ${item.cssClass}" style="width: ${pct}%" title="${item.label}: ${mbStr} (${pct}%)"></div>
+      `;
+    }
+  });
+
+  // Calculate remaining unallocated / other native resident footprint
+  const otherBytes = Math.max(0, totalRss - totalAccountedBytes);
+  if (otherBytes > 0) {
+    const pctOther = ((otherBytes / totalRss) * 100).toFixed(1);
+    const mbOtherStr = formatBytesToMB(otherBytes);
+
+    barHtml += `
+      <div class="distribution-segment segment-other" style="width: ${pctOther}%" title="Other Resident Pages: ${mbOtherStr} (${pctOther}%)"></div>
+    `;
+  }
+
+  distributionBar.innerHTML = barHtml || `<div class="distribution-bar-empty">Waiting for memory telemetry...</div>`;
 }
 
 function renderTable(totalRss) {
@@ -269,7 +351,7 @@ function renderTable(totalRss) {
     `;
 
     group.metrics.forEach(item => {
-      const rawVal = latestMetrics[item.cdpKey];
+      const rawVal = latestMetrics?.[item.cdpKey];
       const isRecorded = rawVal !== undefined && rawVal !== null;
 
       let valDisplay = `<span class="pending-text">⏳ Pending sample...</span>`;
@@ -282,11 +364,22 @@ function renderTable(totalRss) {
         }
       }
 
+      // If the metric has an assigned color dot (subsystems), render it in the label
+      let labelHtml = `<span class="metric-label">${item.label}</span>`;
+      if (item.color) {
+        labelHtml = `
+          <div class="metric-label-row">
+            <span class="metric-dot" style="background-color: ${item.color}"></span>
+            <span class="metric-label">${item.label}</span>
+          </div>
+        `;
+      }
+
       html += `
         <tr>
           <td>
             <div class="metric-name-cell">
-              <span class="metric-label">${item.label}</span>
+              ${labelHtml}
               <span class="metric-key">${item.umaName}</span>
             </div>
           </td>
@@ -298,6 +391,47 @@ function renderTable(totalRss) {
   });
 
   tableBody.innerHTML = html;
+}
+
+function renderGuardrails() {
+  let html = "";
+
+  GUARDRAIL_METRICS.forEach(g => {
+    const lookupKey = g.cdpKey || g.umaName;
+    let rawVal = latestMetrics?.[lookupKey];
+    if (rawVal === undefined && g.fallbackKey) {
+      rawVal = latestMetrics?.[g.fallbackKey];
+    }
+
+    const isRecorded = rawVal !== undefined && rawVal !== null;
+    let valHtml = `<span class="guardrail-value pending">⏳ Waiting for window...</span>`;
+    let statusBadgeHtml = `<span class="badge-guardrail-pending">Pending</span>`;
+
+    if (isRecorded && typeof rawVal === "number") {
+      valHtml = `<span class="guardrail-value">${formatBytesToMB(rawVal)}</span>`;
+      statusBadgeHtml = `<span class="badge-guardrail-recorded">Recorded</span>`;
+    }
+
+    html += `
+      <div class="guardrail-card">
+        <div class="guardrail-header">
+          <div>
+            <div class="guardrail-title">${g.title}</div>
+            <div class="guardrail-key">${g.umaName}</div>
+          </div>
+          ${statusBadgeHtml}
+        </div>
+        <div class="guardrail-value-row">
+          ${valHtml}
+        </div>
+        <div class="guardrail-footer">
+          <span class="guardrail-desc">${g.description}</span>
+        </div>
+      </div>
+    `;
+  });
+
+  guardrailsGrid.innerHTML = html;
 }
 
 // Event Listeners


### PR DESCRIPTION
This pull request enhances the Cobalt DevTools extension by introducing a proportional memory footprint distribution bar for the 10 canonical allocators, adding a 'Lifecycle Peak Memory' scorecard to track time-windowed private memory footprint peaks and peak GPU usage, and updating the README documentation. 

Demo: https://screenshot-v2.corp.google.com/2s7l4ba42rg68, https://screenshot-v2.corp.google.com/2l89hikihf650

Bug: 530302534

