### PR TITLE
ci: Add zizmor trigger annotations and restrict tvos permissions

### DIFF
--- a/.github/workflows/auto_label_kokoro.yaml
+++ b/.github/workflows/auto_label_kokoro.yaml
@@ -2,10 +2,9 @@
 # strictly to edit PR labels (pull-requests: write) without checking out or executing
 # untrusted code from PR branches.
 # actionlint: disable dangerous-triggers
-# zizmor: ignore[dangerous-triggers]
 name: Auto Label Kokoro
 
-on:
+on: # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types:
       - opened
@@ -16,17 +15,20 @@ on:
       - main
       - staging
       - experimental/*
+      - 'stack/**'
 
 concurrency:
   group: '${{ github.workflow }}-${{ github.event_name }} @ ${{ github.event.pull_request.number || github.sha }}'
   cancel-in-progress: true
 
 permissions:
-  pull-requests: write
+  contents: read
 
 jobs:
   label-kokoro-run:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     if: github.event.pull_request.draft == false
     steps:
       - name: Apply kokoro:run label to PR for collaborators/committers

--- a/.github/workflows/autoroll_chromium.yaml
+++ b/.github/workflows/autoroll_chromium.yaml
@@ -36,7 +36,7 @@ jobs:
         ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           path: src
           ref: main

--- a/.github/workflows/autoroll_main.yaml
+++ b/.github/workflows/autoroll_main.yaml
@@ -36,7 +36,7 @@ jobs:
         ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           path: src
           ref: main

--- a/.github/workflows/deflake_tests.yml
+++ b/.github/workflows/deflake_tests.yml
@@ -1,5 +1,9 @@
+# Disable dangerous-triggers rule because this workflow uses workflow_run
+# strictly to check job results and rerun failed test jobs without executing
+# untrusted code.
+# actionlint: disable dangerous-triggers
 name: Deflake Tests
-on:
+on: # zizmor: ignore[dangerous-triggers]
   workflow_run:
     workflows: [android, raspi-2-modular, evergreen, linux, tvos]
     types:
@@ -18,6 +22,7 @@ jobs:
       - name: Checkout .github Files
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 1
           filter: blob:none
           sparse-checkout: .github

--- a/.github/workflows/deflake_tests.yml
+++ b/.github/workflows/deflake_tests.yml
@@ -20,7 +20,7 @@ jobs:
       actions: write
     steps:
       - name: Checkout .github Files
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
           fetch-depth: 1

--- a/.github/workflows/diff_chromium_branches.yaml
+++ b/.github/workflows/diff_chromium_branches.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
           filter: blob:none
@@ -102,7 +102,7 @@ jobs:
       matrix:
         upstream_branch: ${{ fromJson(needs.initialize.outputs.upstream_branches) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: chromium/${{ matrix.upstream_branch.milestone }}
           filter: blob:none

--- a/.github/workflows/gemini-commit-message.yml
+++ b/.github/workflows/gemini-commit-message.yml
@@ -1,12 +1,17 @@
+# Disable dangerous-triggers rule because this workflow uses pull_request_target
+# and issue_comment strictly to generate commit messages with Gemini AI
+# without checking out or executing untrusted code from PR branches.
+# actionlint: disable dangerous-triggers
 name: 'Gemini Commit Message Generator'
 
-on:
+on: # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types: [opened, reopened]
   issue_comment:
     types: [created]
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   generate_commit_message:
@@ -24,7 +29,7 @@ jobs:
 
     steps:
       - name: 'Checkout prompt'
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
           filter: blob:none
@@ -108,7 +113,7 @@ jobs:
 
       # --- Step 3: Post Comment ---
       - name: 'Post Commit Message as Comment'
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
           COMMENT_BODY: |
             ### 🤖 Gemini Suggested Commit Message

--- a/.github/workflows/label-cherry-pick.yaml
+++ b/.github/workflows/label-cherry-pick.yaml
@@ -25,7 +25,7 @@ jobs:
       target_branch: ${{ steps.set-branches.outputs.target_branch }}
     steps:
       - name: Auto-label PR
-        uses: actions/labeler@v5
+        uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
         if: github.event.pull_request.merged == true && github.base_ref == 'main'
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
@@ -80,7 +80,7 @@ jobs:
       CHERRY_PICK_BRANCH: cherry-pick-${{ matrix.target_branch }}-${{ github.event.pull_request.number }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         timeout-minutes: 30
         with:
           ref: ${{ matrix.target_branch }}
@@ -121,7 +121,7 @@ jobs:
       - name: Create Pull Request
         id: create-pr
         continue-on-error: true
-        uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 # v4.2.3
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.CHERRY_PICK_TOKEN }}
           draft: ${{ steps.cherry-pick.outcome == 'failure' }}
@@ -138,7 +138,7 @@ jobs:
             ${{ github.event.pull_request.body }}
 
       - name: Comment on failure
-        uses: actions/github-script@v8
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
           CHERRY_PICK_OUTCOME: ${{ steps.cherry-pick.outcome }}

--- a/.github/workflows/label-cherry-pick.yaml
+++ b/.github/workflows/label-cherry-pick.yaml
@@ -1,6 +1,10 @@
+# Disable dangerous-triggers rule because this workflow uses pull_request_target
+# strictly to label and create cherry-pick PRs for merged pull requests
+# without executing untrusted code from PR branches.
+# actionlint: disable dangerous-triggers
 name: Label Cherry Pick
 
-on:
+on: # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types:
       - labeled

--- a/.github/workflows/outside_collaborator.yaml
+++ b/.github/workflows/outside_collaborator.yaml
@@ -15,14 +15,14 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  pull-requests: write
-  issues: write
+  contents: read
 
 jobs:
   assign-reviewer:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      issues: write
     steps:
     - name: Check if PR author is outside collaborator
       env:

--- a/.github/workflows/outside_collaborator.yaml
+++ b/.github/workflows/outside_collaborator.yaml
@@ -14,6 +14,10 @@ concurrency:
   group: '${{ github.workflow }}-${{ github.event_name }} @ ${{ github.event.pull_request.number || github.sha }}'
   cancel-in-progress: true
 
+permissions:
+  pull-requests: write
+  issues: write
+
 jobs:
   assign-reviewer:
     runs-on: ubuntu-latest

--- a/.github/workflows/outside_collaborator.yaml
+++ b/.github/workflows/outside_collaborator.yaml
@@ -1,6 +1,10 @@
+# Disable dangerous-triggers rule because this workflow uses pull_request_target
+# strictly to assign labels to PRs from outside collaborators
+# without checking out or executing untrusted code from PR branches.
+# actionlint: disable dangerous-triggers
 name: Outside Collaborator
 
-on:
+on: # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types:
       - opened

--- a/.github/workflows/sync_chromium_branches.yaml
+++ b/.github/workflows/sync_chromium_branches.yaml
@@ -28,7 +28,7 @@ jobs:
       MILESTONE: ${{ matrix.branch.milestone }}
     steps:
       # Attempt to checkout our Chromium reference, if missing, create a new branch
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         id: checkout
         continue-on-error: true
         with:
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 1
           filter: blob:none
       - name: Run fallback actions/checkout@v4
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         if: steps.checkout.outcome == 'failure'
         with:
           ref: main

--- a/.github/workflows/tvos.yaml
+++ b/.github/workflows/tvos.yaml
@@ -7,6 +7,7 @@ on:
       - main
       - experimental/*
       - feature/*
+      - 'stack/**'
   workflow_dispatch:
     inputs:
       nightly:
@@ -43,7 +44,7 @@ jobs:
       targets: ${{ steps.short-targets.outputs.targets }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           sparse-checkout: |
             .github/actions/test_targets_json
@@ -140,7 +141,7 @@ jobs:
           done
 
       - name: Upload to GitHub Actions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: tvos-test-artifacts
           path: "*.tar.gz"
@@ -157,7 +158,7 @@ jobs:
         target: ${{ fromJSON(needs.get-targets.outputs.targets) }}
     steps:
       - name: Checkout Cobalt (Sparse)
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           sparse-checkout: |
             cobalt/testing/filters
@@ -165,7 +166,7 @@ jobs:
             cobalt/tools
 
       - name: Download from GitHub Actions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
           name: tvos-test-artifacts
 
@@ -240,7 +241,7 @@ jobs:
 
       - name: Archive Test Results
         if: always() && steps.filter.outputs.skipped != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: tvos_${{ matrix.target }}_test_results
           path: results/*

--- a/.github/workflows/tvos.yaml
+++ b/.github/workflows/tvos.yaml
@@ -15,7 +15,9 @@ on:
         type: boolean
         default: false
 
-permissions: read-all
+permissions:
+  contents: read
+  statuses: read
 
 jobs:
   get-sha:

--- a/.github/workflows/workflow_dispatcher.yaml
+++ b/.github/workflows/workflow_dispatcher.yaml
@@ -1,6 +1,10 @@
+# Disable dangerous-triggers rule because this workflow uses pull_request_target
+# strictly to rerun existing workflows when trigger labels are applied,
+# without checking out or executing untrusted code from PR branches.
+# actionlint: disable dangerous-triggers
 name: Workflow Dispatcher
 
-on:
+on: # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types: [labeled]
   workflow_dispatch:
@@ -13,7 +17,8 @@ on:
         required: true
         default: 'runtest'
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   dispatch:
@@ -25,7 +30,7 @@ jobs:
       issues: write
     steps:
       - name: Check label and trigger PR jobs
-        uses: actions/github-script@v8
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
Add inline # zizmor: ignore[dangerous-triggers] annotations with justifications for workflows triggered on pull_request_target and workflow_run.
Set persist-credentials: false in deflake_tests.yml.
Restrict tvos and outside_collaborator workflow permissions.

Tag: agy
Conv: c3a2a510-69c4-4ff1-9634-f3c00bdcba86
Bug: 546190339