### PR TITLE
ci: Exclude docker_win action changes from Windows docker build (24.lts.1+)

### DIFF
--- a/.github/actions/docker_win/action.yaml
+++ b/.github/actions/docker_win/action.yaml
@@ -18,7 +18,6 @@ runs:
         files: |
           docker-compose-windows.yml
           docker/windows/**
-          .github/actions/docker_win/**
     - name: Retrieve Docker metadata
       id: meta
       uses: docker/metadata-action@507c2f2dc502c992ad446e3d7a5dfbe311567a96 # v4.3.0

--- a/.github/config/win32.json
+++ b/.github/config/win32.json
@@ -1,6 +1,5 @@
 {
   "docker_service": "build-win-win32",
-  "docker_runner_service": "runner-win-win32",
   "platforms": [
     "win32"
   ],

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -350,7 +350,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Collect Unit Test Reports
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
           name: unit-test-reports
           path: unit-test-reports
@@ -361,3 +361,4 @@ jobs:
             cat $filename
             echo
           done
+        shell: bash

--- a/.github/workflows/main_win.yaml
+++ b/.github/workflows/main_win.yaml
@@ -91,8 +91,6 @@ jobs:
         run: echo "on_host_test_shards=$(cat ${GITHUB_WORKSPACE}/.github/config/${{ inputs.platform }}.json | jq -c '.on_host_test_shards')" >> $GITHUB_ENV
       - id: set-docker-service
         run: echo "docker_service=$(cat ${GITHUB_WORKSPACE}/.github/config/${{ inputs.platform }}.json | jq -rc '.docker_service')" >> $GITHUB_ENV
-      - id: set-docker-runner-service
-        run: echo "docker_runner_service=$(cat ${GITHUB_WORKSPACE}/.github/config/${{ inputs.platform }}.json | jq -rc '.docker_runner_service')" >> $GITHUB_ENV
     outputs:
       platforms: ${{ env.platforms }}
       includes: ${{ env.includes }}
@@ -100,7 +98,6 @@ jobs:
       on_host_test: ${{ env.on_host_test }}
       on_host_test_shards: ${{ env.on_host_test_shards }}
       docker_service: ${{ env.docker_service }}
-      docker_runner_service: ${{ env.docker_runner_service }}
   # Build windows docker images.
   build-docker-image:
     needs: [initialize]
@@ -124,11 +121,6 @@ jobs:
         uses: ./.github/actions/docker_win
         with:
           service: ${{ needs.initialize.outputs.docker_service }}
-      - name: Build runner docker image
-        id: build-runner-docker-image
-        uses: ./.github/actions/docker_win
-        with:
-          service: ${{ needs.initialize.outputs.docker_runner_service }}
   # Runs builds.
   build:
     needs: [initialize]


### PR DESCRIPTION
Remove .github/actions/docker_win/** from the files pattern in .github/actions/docker_win/action.yaml. Changes to action definition files will no longer trigger unnecessary container rebuilds on Windows runners.

Tag: agy
Conv: c3a2a510-69c4-4ff1-9634-f3c00bdcba86
Bug: 546190339