### PR TITLE
ci: Fix duplicate YAML merge keys in docker-compose.yml (rc_11)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Checkout files
         uses: actions/checkout@v3
         with:
-          fetch-depth: 2
+          fetch-depth: 0
       - name: Login to Docker Registry ${{env.REGISTRY}}
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
         with:
@@ -101,7 +101,7 @@ jobs:
       - name: Checkout files
         uses: actions/checkout@v3
         with:
-          fetch-depth: 2
+          fetch-depth: 0
       - name: Login to Docker Registry ${{env.REGISTRY}}
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
         with:
@@ -179,6 +179,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: 1
+          fetch-depth: 0
       - name: Run Tests
         uses: ./.github/actions/on_host_test

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -39,7 +39,7 @@ jobs:
       - id: checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: 1
+          fetch-depth: 0
       - id: set-platforms
         run: echo "platforms=$(cat ${GITHUB_WORKSPACE}/.github/config/${{ inputs.platform }}.json | jq -c '.platforms')" >> $GITHUB_ENV
       - id: set-includes

--- a/build/download_gold_plugin.py
+++ b/build/download_gold_plugin.py
@@ -35,7 +35,7 @@ def main():
 
   os.chdir(LLVM_BUILD_PATH)
 
-  subprocess.check_call(['python', GSUTIL_PATH,
+  subprocess.check_call(['python3', GSUTIL_PATH,
                          'cp', remote_path, targz_name])
   subprocess.check_call(['tar', 'xzf', targz_name])
   os.remove(targz_name)

--- a/build/download_gold_plugin.py
+++ b/build/download_gold_plugin.py
@@ -35,7 +35,7 @@ def main():
 
   os.chdir(LLVM_BUILD_PATH)
 
-  subprocess.check_call([sys.executable, GSUTIL_PATH,
+  subprocess.check_call(['python3', GSUTIL_PATH,
                          'cp', remote_path, targz_name])
   subprocess.check_call(['tar', 'xzf', targz_name])
   os.remove(targz_name)

--- a/build/download_gold_plugin.py
+++ b/build/download_gold_plugin.py
@@ -35,7 +35,7 @@ def main():
 
   os.chdir(LLVM_BUILD_PATH)
 
-  subprocess.check_call(['python3', GSUTIL_PATH,
+  subprocess.check_call([sys.executable, GSUTIL_PATH,
                          'cp', remote_path, targz_name])
   subprocess.check_call(['tar', 'xzf', targz_name])
   os.remove(targz_name)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,9 @@ x-build-volumes: &build-volumes
     - ${STARBOARD_TOOLCHAINS_DIR:-container-starboard-toolchains}:/root/starboard-toolchains
 
 x-build-common-definitions: &build-common-definitions
-  <<: *common-definitions
-  <<: *build-volumes
+  <<:
+    - *common-definitions
+    - *build-volumes
   depends_on:
     - build-base
 
@@ -89,8 +90,9 @@ services:
       - CONFIG=${CONFIG:-debug}
 
   linux-x64x11-xenial:
-    <<: *common-definitions
-    <<: *build-volumes
+    <<:
+      - *common-definitions
+      - *build-volumes
     build:
       context: ./docker/linux
       dockerfile: linux-x64x11/Dockerfile
@@ -101,8 +103,9 @@ services:
       - build-base-xenial
 
   linux-x64x11-clang-3-6:
-    <<: *common-definitions
-    <<: *build-volumes
+    <<:
+      - *common-definitions
+      - *build-volumes
     build:
       context: ./docker/linux/
       dockerfile: clang-3-6/Dockerfile

--- a/docker/linux/base/Dockerfile
+++ b/docker/linux/base/Dockerfile
@@ -7,9 +7,9 @@ ENV PYTHONUNBUFFERED 1
 ARG GIT_SHA265SUM="93993babac690a06906d832a1715c3315b4787a2845aeb500f7dcc82e1599df2 git-2.18.0.tar.gz"
 
 # === Install common dependencies
-RUN sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list \
-    && sed -i 's/security.debian.org/archive.debian.org/g' /etc/apt/sources.list \
-    && sed -i '/buster-updates/d' /etc/apt/sources.list \
+RUN sed -i -e 's/deb\.debian\.org/archive.debian.org/g' \
+           -e 's/security\.debian\.org/archive.debian.org/g' \
+           -e '/buster-updates/d' /etc/apt/sources.list \
     && echo "Acquire::Check-Valid-Until \"false\";" > /etc/apt/apt.conf.d/99no-check-valid-until
 
 RUN apt update -qqy \

--- a/docker/linux/base/Dockerfile
+++ b/docker/linux/base/Dockerfile
@@ -7,6 +7,11 @@ ENV PYTHONUNBUFFERED 1
 ARG GIT_SHA265SUM="93993babac690a06906d832a1715c3315b4787a2845aeb500f7dcc82e1599df2 git-2.18.0.tar.gz"
 
 # === Install common dependencies
+RUN sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list \
+    && sed -i 's/security.debian.org/archive.debian.org/g' /etc/apt/sources.list \
+    && sed -i '/buster-updates/d' /etc/apt/sources.list \
+    && echo "Acquire::Check-Valid-Until \"false\";" > /etc/apt/apt.conf.d/99no-check-valid-until
+
 RUN apt update -qqy \
     && apt install -qqy --no-install-recommends \
         python-pip \

--- a/docker/linux/base/build/Dockerfile
+++ b/docker/linux/base/build/Dockerfile
@@ -21,7 +21,7 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
 # === Install depot_tools
-RUN git clone https://cobalt.googlesource.com/depot_tools /depot_tools
+RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git /depot_tools
 
 # === Configure common env vars
 ENV PATH="${PATH}:/depot_tools" \

--- a/docker/linux/base/build/Dockerfile
+++ b/docker/linux/base/build/Dockerfile
@@ -21,7 +21,8 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
 # === Install depot_tools
-RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git /depot_tools
+RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git /depot_tools \
+    && git -C /depot_tools checkout 38c697d3eccc54a5e46abc8c267cd0593b7b29b6
 
 # === Configure common env vars
 ENV PATH="${PATH}:/depot_tools" \

--- a/docker/linux/base/build/Dockerfile
+++ b/docker/linux/base/build/Dockerfile
@@ -21,13 +21,13 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
 # === Install depot_tools
+ENV DEPOT_TOOLS_UPDATE=0
 RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git /depot_tools \
     && git -C /depot_tools checkout 38c697d3eccc54a5e46abc8c267cd0593b7b29b6
 
 # === Configure common env vars
 ENV PATH="${PATH}:/depot_tools" \
     OUTDIR=out \
-    DEPOT_TOOLS_UPDATE=0 \
     NINJA_STATUS="[%e sec | %f/%t %u remaining | %c/sec | j%r] " \
     CCACHE_DIR=/root/ccache \
     CCACHE_MAXSIZE=30G

--- a/docker/linux/raspi/Dockerfile
+++ b/docker/linux/raspi/Dockerfile
@@ -29,7 +29,7 @@ RUN mkdir -p ${raspi_home}/tools \
 
 RUN cd ${raspi_home} \
     && wget -q \
-    "https://storage.googleapis.com/cobalt-static-storage/${raspi_sysroot}"
+    "https://storage.googleapis.com/cobalt-static-storage-public/${raspi_sysroot}"
 
 RUN cd ${raspi_home} && tar Jxpvf ${raspi_sysroot} --no-same-owner
 


### PR DESCRIPTION
Convert duplicate <<: merge keys in docker-compose.yml into sequence mappings.
Redirect Debian Buster archive repositories to archive.debian.org.
Update sysroot download URL to cobalt-static-storage-public and depot_tools clone URL to upstream repository.

Tag: agy
Conv: c3a2a510-69c4-4ff1-9634-f3c00bdcba86
Bug: 546190339