### PR TITLE
docker: Install gcloud SDK in unittest and webtest docker images

### DIFF
--- a/cobalt/docker/unittest/Dockerfile
+++ b/cobalt/docker/unittest/Dockerfile
@@ -22,6 +22,8 @@ RUN apt-get update && apt-get install -y \
     libnss3 \
     libxcomposite-dev \
     openbox \
+    python3 \
+    python3-dev \
     x11-xserver-utils \
     xcompmgr \
     xcvt \
@@ -31,6 +33,13 @@ RUN apt-get update && apt-get install -y \
     xz-utils \
     zstd \
     && rm -rf /var/lib/apt/lists/*
+
+ARG GCLOUD=google-cloud-cli-linux-x86_64.tar.gz
+RUN cd /tmp \
+    && curl -L -O "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${GCLOUD}" \
+    && tar xf "${GCLOUD}" -C /usr/local --strip-components=1 google-cloud-sdk/bin google-cloud-sdk/lib \
+    && rm "${GCLOUD}" \
+    && gcloud --version
 
 # This locale satisfies SbSystemGetLocaleIdTest.
 ENV LANG=en_US.UTF-8

--- a/cobalt/docker/webtest/Dockerfile
+++ b/cobalt/docker/webtest/Dockerfile
@@ -24,5 +24,12 @@ RUN apt-get update && apt-get install -y \
     fuse-overlayfs \
     && rm -rf /var/lib/apt/lists/*
 
+ARG GCLOUD=google-cloud-cli-linux-x86_64.tar.gz
+RUN cd /tmp \
+    && curl -L -O "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${GCLOUD}" \
+    && tar xf "${GCLOUD}" -C /usr/local --strip-components=1 google-cloud-sdk/bin google-cloud-sdk/lib \
+    && rm "${GCLOUD}" \
+    && gcloud --version
+
 # This locale satisfies SbSystemGetLocaleIdTest.
 ENV LANG en_US.UTF-8


### PR DESCRIPTION
## Description

Install Google Cloud SDK (`gcloud`) in `cobalt/docker/unittest/Dockerfile` and `cobalt/docker/webtest/Dockerfile`.

After PR #11889 removed `google-github-actions/setup-gcloud` from `linux_browser_tests` in favor of using `gcloud` from docker images, `browser-test-on-host` failed with `gcloud: command not found` because the `unittest` docker image did not contain `gcloud`.

Tag: agy
Conv: 83e8e5ac-e27d-4a3c-89b4-b648f46c1c49
Bug: 543494079