### PR TITLE
#11944: Enables update_client unit tests on CI

### DIFF
--- a/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
+++ b/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
@@ -118,5 +118,12 @@
   {
     "target": "third_party/opus:test_opus_padding_loader",
     "executable": "out/evergreen-arm-hardfp-rdk_devel/test_opus_padding_loader.py"
+  },
+  {
+    "target": "components/update_client:update_client_unittests_loader",
+    "executable": "out/evergreen-arm-hardfp-rdk_devel/update_client_unittests_loader.py",
+    "runs_on": "device",
+    "test_type": "gtest",
+    "required": false
   }
 ]

--- a/cobalt/build/testing/targets/evergreen-x64/test_targets.json
+++ b/cobalt/build/testing/targets/evergreen-x64/test_targets.json
@@ -201,5 +201,12 @@
     "executable": "out/evergreen-x64_devel/url_unittests_loader.py",
     "runs_on": "host",
     "test_type": "gtest"
+  },
+  {
+    "target": "components/update_client:update_client_unittests_loader",
+    "executable": "out/evergreen-x64_devel/update_client_unittests_loader.py",
+    "runs_on": "host",
+    "test_type": "gtest",
+    "required": false
   }
 ]

--- a/components/update_client/BUILD.gn
+++ b/components/update_client/BUILD.gn
@@ -468,5 +468,13 @@ if (is_cobalt && use_evergreen) {
       "//components/test:run_all_unittests",
       "//components/test:test_support",
     ]
+
+    # ui_test.pak is required at runtime by ComponentsTestSuite::Initialize().
+    # Because //ui/resources:ui_test_pak does not set mark_as_data = true,
+    # specifying data = [ "$root_out_dir/ui_test.pak" ] is required for GN
+    # to include the .pak file in update_client_unittests_loader.runtime_deps
+    # so archive_test_artifacts.py packages it for device testing.
+    data = [ "$root_out_dir/ui_test.pak" ]
+    data_deps = [ "//ui/resources:ui_test_pak" ]
   }
 }


### PR DESCRIPTION
Fixes update_client_unittests crashing on device due to missing ui_test.pak in the test archive. Adds ui_test.pak to data and data_deps so it gets included in runtime_deps for packaging. Enables update_client_unittests_loader in test_targets.json for evergreen-x64 (host) and evergreen-arm-hardfp-rdk (device).

Bug: 446745795