### PR TITLE
[android] Remove hardwareAccelerated setting

### DIFF
--- a/cobalt/shell/android/shell_apk/AndroidManifest.xml.jinja2
+++ b/cobalt/shell/android/shell_apk/AndroidManifest.xml.jinja2
@@ -66,7 +66,6 @@
                   android:theme="@style/CobaltTheme"
                   android:configChanges="keyboard|keyboardHidden|navigation|orientation|screenSize|uiMode"
                   android:windowSoftInputMode="adjustResize"
-                  android:hardwareAccelerated="false"
                   android:exported="true">
             <meta-data android:name="cobalt.APP_URL" android:value="https://www.youtube.com/tv"/>
             <meta-data android:name="cobalt.ENABLE_SPLASH_SCREEN" android:value="true"/>

--- a/cobalt/shell/android/shell_apk/AndroidManifest.xml.jinja2
+++ b/cobalt/shell/android/shell_apk/AndroidManifest.xml.jinja2
@@ -66,7 +66,7 @@
                   android:theme="@style/CobaltTheme"
                   android:configChanges="keyboard|keyboardHidden|navigation|orientation|screenSize|uiMode"
                   android:windowSoftInputMode="adjustResize"
-                  android:hardwareAccelerated="true"
+                  android:hardwareAccelerated="false"
                   android:exported="true">
             <meta-data android:name="cobalt.APP_URL" android:value="https://www.youtube.com/tv"/>
             <meta-data android:name="cobalt.ENABLE_SPLASH_SCREEN" android:value="true"/>


### PR DESCRIPTION
Because Chrobalt manages its own rendering pipeline without utilizing
Android native Views for UI rendering, system UI hardware acceleration
is unnecessary. Remove hardwareAccelerated setting to make it use
default value and aligned to Kimono.


Bug: 546272332