### PR TITLE
test(black_box_tests): Disable signal_handler_doesnt_crash on 22.lts.1+

### DIFF
--- a/cobalt/black_box_tests/black_box_tests.py
+++ b/cobalt/black_box_tests/black_box_tests.py
@@ -52,7 +52,8 @@ _TESTS_NEEDING_SYSTEM_SIGNAL = [
     'preload_font',
     'preload_visibility',
     'preload_launch_parameter',
-    'signal_handler_doesnt_crash',
+    # TODO(b/254502632): Re-enable once deflaked.
+    # 'signal_handler_doesnt_crash',
     'suspend_visibility',
     'timer_hit_after_preload',
     'timer_hit_in_preload',


### PR DESCRIPTION
Disable flaky signal_handler_doesnt_crash test in cobalt/black_box_tests/black_box_tests.py that fails in container runners when receiving rapid SIGCONT signals (b/254502632).

Tag: agy
Conv: c3a2a510-69c4-4ff1-9634-f3c00bdcba86
Bug: 546190339