### PR TITLE
Remove deprecated siso remove step.

### DIFF
--- a/.github/actions/depot_tools/action.yaml
+++ b/.github/actions/depot_tools/action.yaml
@@ -119,15 +119,6 @@ runs:
       if: inputs.run_sync == 'true'
       working-directory: cobalt/src
       run: |
-        # Remove after all workers have migrated to new siso directory
-        if [ -d "../.cipd" ]; then
-          if grep -r "infra/build/siso" "../.cipd" > /dev/null 2>&1; then
-            echo "Deleting conflicting siso package."
-            rm -rf "third_party/siso/cipd"
-            rm -rf "../.cipd"
-          fi
-        fi
-
         # Identify and delete dirty sub-repositories
         git -c core.quotepath=false status --porcelain -unormal | while IFS= read -r line; do
           path="${line:3}"


### PR DESCRIPTION
The siso remove step was used to help migration to a newer siso version without running into stale cache issues as siso is brought in via an unique cipd mechanism.

Bug: 507872651