### PR TITLE
V8 Cache: Increase size to 5MB by Default

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -30,7 +30,6 @@ public class JavaSwitches {
       "EnableAutoRetryOnNetworkRecovery";
 
   public static final String ENABLE_OPTIMIZED_FONT_LOADING = "EnableOptimizedFontLoading";
-  public static final String ENABLE_OPTIMIZED_V8_CODE_CACHE = "EnableOptimizedV8CodeCache";
 
   /** flag to enable deferred V8 bytecode serialization in background/idle */
   public static final String DEFER_V8_CODE_CACHE_WRITE = "DeferV8CodeCacheWrite";
@@ -229,10 +228,6 @@ public class JavaSwitches {
       extraCommandLineArgs.add("--enable-optimized-font-loading");
     }
 
-    if (javaSwitches.containsKey(JavaSwitches.ENABLE_OPTIMIZED_V8_CODE_CACHE)) {
-      extraCommandLineArgs.add("--enable-optimized-v8-code-cache");
-    }
-
     if (javaSwitches.containsKey(JavaSwitches.DEFER_V8_CODE_CACHE_WRITE)) {
       extraCommandLineArgs.add("--defer-v8-code-cache-write");
     }
@@ -306,7 +301,8 @@ public class JavaSwitches {
     }
 
     if (javaSwitches.containsKey(JavaSwitches.EVICT_MEMORY_CACHE_ON_CRITICAL_MEMORY_PRESSURE)) {
-      extraCommandLineArgs.add("--enable-features=" + JavaSwitches.EVICT_MEMORY_CACHE_ON_CRITICAL_MEMORY_PRESSURE);
+      extraCommandLineArgs.add(
+          "--enable-features=" + JavaSwitches.EVICT_MEMORY_CACHE_ON_CRITICAL_MEMORY_PRESSURE);
     }
 
     if (javaSwitches.containsKey(JavaSwitches.DISABLE_LESS_AGGRESSIVE_PARKABLE_STRING)) {

--- a/cobalt/browser/cobalt_content_browser_client.cc
+++ b/cobalt/browser/cobalt_content_browser_client.cc
@@ -326,15 +326,10 @@ void CobaltContentBrowserClient::CreateThrottlesForNavigation(
 content::GeneratedCodeCacheSettings
 CobaltContentBrowserClient::GetGeneratedCodeCacheSettings(
     content::BrowserContext* context) {
-  // Default compiled javascript quota in Cobalt 25 is 3 MB:
+  // Default compiled javascript quota in Cobalt 25 was 3 MB:
   // https://github.com/youtube/cobalt/blob/3ccdb04a5e36c2597fe7066039037eabf4906ba5/cobalt/network/disk_cache/resource_type.cc#L72
-  // When enable-optimized-v8-code-cache switch is set, increase to 5 MB for
-  // YouTube TV.
-  size_t size = 3 * 1024 * 1024;
-  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
-          "enable-optimized-v8-code-cache")) {
-    size = 5 * 1024 * 1024;
-  }
+  // Increased to 5 MB for Cobalt 27+.
+  size_t size = 5 * 1024 * 1024;
   base::FilePath cache_path;
   CHECK(base::PathService::Get(base::DIR_CACHE, &cache_path));
   return content::GeneratedCodeCacheSettings(/*enabled=*/true, size,

--- a/content/browser/code_cache/generated_code_cache.cc
+++ b/content/browser/code_cache/generated_code_cache.cc
@@ -481,7 +481,7 @@ void GeneratedCodeCache::WriteEntry(const GURL& url,
 
 #if BUILDFLAG(IS_COBALT)
   if (cache_type_ == CodeCacheType::kJavaScript) {
-    // We skip caching below experimental thresholds (1KB, 16KB) to preserve
+    // We skip caching below experimental thresholds (16KB) to preserve
     // cache slots for heavy core bundles. Cache switch evaluations statically
     // once per runtime process to avoid redundant map lookups.
     static const size_t kMinBytecodeSize = [] {
@@ -489,10 +489,7 @@ void GeneratedCodeCache::WriteEntry(const GURL& url,
       if (command_line->HasSwitch("enable-http-and-v8-cache-tuning")) {
         return 16384;
       }
-      if (command_line->HasSwitch("enable-optimized-v8-code-cache")) {
-        return 1024;
-      }
-      return 0;
+      return 1024;
     }();
     if (data.size() < kMinBytecodeSize) {
       return;


### PR DESCRIPTION
This PR will by default set the V8 cache size to 5MB and not cache bytecode less than 1KB in size. Experiment results showed no significant regressions in RSS but showed improvements in app start latency and Memory CPU Free bytes amongst other metrics in a launch study [Rasta](http://exp/analysis/_:31-535JjRf33wa4rlijNvjurjXI).


See original PR: #11248 

Bug: 532266766