### PR TITLE
Enable Cobalt local memory breakdown tool to the QA build

### DIFF
--- a/third_party/blink/renderer/core/BUILD.gn
+++ b/third_party/blink/renderer/core/BUILD.gn
@@ -467,7 +467,7 @@ component("core") {
     deps += [ "//starboard:starboard_group" ]
   }
 
-  if (is_cobalt && !is_official_build) {
+  if (is_cobalt && !cobalt_is_release_build) {
     sources += [
       "inspector/cobalt_memory_metrics_helper.cc",
       "inspector/cobalt_memory_metrics_helper.h",
@@ -1577,7 +1577,7 @@ source_set("unit_tests") {
 
   data_deps = [ ":unit_tests_data" ]
 
-  if (is_cobalt && !is_official_build) {
+  if (is_cobalt && !cobalt_is_release_build) {
     sources += [ "inspector/cobalt_memory_metrics_helper_test.cc" ]
   }
 

--- a/third_party/blink/renderer/core/inspector/inspector_performance_agent.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_performance_agent.cc
@@ -22,9 +22,9 @@
 #include "third_party/blink/renderer/platform/instrumentation/instance_counters.h"
 #include "third_party/blink/renderer/platform/scheduler/public/thread.h"
 
-#if BUILDFLAG(IS_COBALT) && !defined(OFFICIAL_BUILD)
+#if BUILDFLAG(IS_COBALT) && !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
 #include "third_party/blink/renderer/core/inspector/cobalt_memory_metrics_helper.h"
-#endif
+#endif  // BUILDFLAG(IS_COBALT) && !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
 
 namespace blink {
 
@@ -274,7 +274,7 @@ protocol::Response InspectorPerformanceAgent::getMetrics(
                      .InSecondsF());
   }
 
-#if BUILDFLAG(IS_COBALT) && !defined(OFFICIAL_BUILD)
+#if BUILDFLAG(IS_COBALT) && !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
   auto append_metrics =
       [&result](const std::optional<std::vector<MemoryBreakdownMetric>>&
                     metrics) {
@@ -291,7 +291,7 @@ protocol::Response InspectorPerformanceAgent::getMetrics(
   append_metrics(GetLiveMemoryBreakdown());
   append_metrics(GetP50MemoryBreakdown());
   append_metrics(GetPeakMemoryGuardrails());
-#endif
+#endif  // BUILDFLAG(IS_COBALT) && !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
 
   *out_result = std::move(result);
   return protocol::Response::Success();


### PR DESCRIPTION
This pull request replaces the use of is_official_build and OFFICIAL_BUILD with cobalt_is_release_build and BUILDFLAG(COBALT_IS_RELEASE_BUILD) in BUILD.gn and inspector_performance_agent.cc, so that qa cobalt builds have access to the memory breakdown feature.

Bug: 530302534