### PR TITLE
Add live memory metrics table to UI

### DIFF
--- a/cobalt/tools/devtools_extension/README.md
+++ b/cobalt/tools/devtools_extension/README.md
@@ -84,7 +84,15 @@ Aggregated median memory footprint across continuous allocators matching product
 
 ---
 
-### 2. Lifecycle Peak Memory
+### 2. Real-Time Live Memory (1 Hz Streaming)
+A high-frequency rolling 60-second time-series chart plotting instantaneous memory metrics ($t = \text{now}$) sampled at 1 Hz directly from process metrics and the V8 isolate runtime:
+* 🟣 **Physical Resident Set (RSS)** (`Memory.Browser.ResidentSet.Live`): Instantaneous physical RAM pages mapped by the OS.
+* 🔵 **Private Memory Footprint (PMF)** (`Memory.Browser.PrivateMemoryFootprint.Live`): Instantaneous anonymous resident pages contributing to the OOM threshold.
+* 🟡 **V8 JavaScript Engine Heap** (`Memory.Experimental.Browser2.V8.Live`): Live used JavaScript heap memory, displaying active GC sawtooth sweeps and allocation bursts.
+
+---
+
+### 3. Lifecycle Peak Memory
 Tracks maximum memory peaks recorded across elapsed lifecycle time windows and initial graphics rendering:
 
 * **0 to 2 min Window** (`Memory.Experimental.Renderer.HighestPrivateMemoryFootprint.0to2min`): Peak private memory footprint reached during app boot and initial browse.

--- a/cobalt/tools/devtools_extension/panel.css
+++ b/cobalt/tools/devtools_extension/panel.css
@@ -30,6 +30,11 @@
   --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 
+  /* Live Line Chart Colors */
+  --color-live-rss: #a855f7;
+  --color-live-pmf: #38bdf8;
+  --color-live-v8: #fbbf24;
+
   /* 10 Canonical Allocator Palette (go/kimono-memory-metrics) */
   --color-binary: #8b5cf6;
   --color-codeother: #a855f7;
@@ -183,6 +188,112 @@ body {
   align-items: center;
   gap: 10px;
 }
+
+/* Real-Time Live Memory Chart Section */
+.chart-section {
+  background-color: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.streaming-badge {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 3px 8px;
+  border-radius: 12px;
+  background-color: rgba(34, 197, 94, 0.15);
+  color: var(--status-connected);
+  font-family: var(--font-mono);
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.streaming-badge.inactive {
+  background-color: rgba(161, 161, 170, 0.15);
+  color: var(--text-dim);
+}
+
+.chart-canvas-container {
+  position: relative;
+  width: 100%;
+  height: 150px;
+  background-color: rgba(0, 0, 0, 0.35);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+#live-memory-chart {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.chart-tooltip {
+  position: absolute;
+  top: 8px;
+  right: 12px;
+  background: rgba(24, 24, 27, 0.9);
+  border: 1px solid var(--border-color);
+  padding: 6px 10px;
+  border-radius: 6px;
+  font-size: 11px;
+  font-family: var(--font-mono);
+  color: var(--text-normal);
+  pointer-events: none;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  line-height: 1.5;
+}
+
+.live-legend-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.live-legend-chip {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  padding: 4px 10px;
+  border-radius: 6px;
+  font-size: 11px;
+}
+
+.live-legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+.dot-rss { background-color: var(--color-live-rss); }
+.dot-pmf { background-color: var(--color-live-pmf); }
+.dot-v8 { background-color: var(--color-live-v8); }
+
+.live-legend-label {
+  font-weight: 600;
+  color: var(--text-bright);
+}
+
+.live-legend-val {
+  font-family: var(--font-mono);
+  font-weight: 700;
+  color: var(--text-bright);
+}
+
+.chip-rss .live-legend-val { color: #d8b4fe; }
+.chip-pmf .live-legend-val { color: #7dd3fc; }
+.chip-v8 .live-legend-val { color: #fde047; }
 
 /* Primary Table Section */
 .table-section {

--- a/cobalt/tools/devtools_extension/panel.html
+++ b/cobalt/tools/devtools_extension/panel.html
@@ -26,7 +26,7 @@
       </div>
     </header>
 
-    <!-- Primary Section: Session Median Telemetry (12 Continuous P50 Allocators) -->
+    <!-- Primary Section: Session P50 Memory Breakdown (12 Continuous P50 Allocators) -->
     <section class="table-section">
       <div class="section-header">
         <div class="title-row">
@@ -65,6 +65,44 @@
           </tr>
         </tbody>
       </table>
+    </section>
+
+    <!-- Real-Time Live Memory Time Series Section (1 Hz Streaming) -->
+    <section class="chart-section">
+      <div class="section-header">
+        <div class="title-row">
+          <div class="section-title">📈 Real-Time Live Memory</div>
+          <div id="streaming-badge" class="streaming-badge inactive">● 1 Hz Inactive</div>
+        </div>
+        <div class="section-instruction">
+          Instantaneous physical memory footprint sampled at 1 Hz over a rolling 60-second window, displaying GC sawtooth patterns and live allocation spikes.
+        </div>
+      </div>
+
+      <!-- Time Series Canvas Visualizer -->
+      <div class="chart-canvas-container">
+        <canvas id="live-memory-chart" height="150"></canvas>
+        <div id="chart-tooltip" class="chart-tooltip" style="display: none;"></div>
+      </div>
+
+      <!-- Real-Time Live Meter Badges -->
+      <div class="live-legend-bar">
+        <div class="live-legend-chip chip-rss">
+          <span class="live-legend-dot dot-rss"></span>
+          <span class="live-legend-label">RSS (Live):</span>
+          <span id="live-val-rss" class="live-legend-val">-- MB</span>
+        </div>
+        <div class="live-legend-chip chip-pmf">
+          <span class="live-legend-dot dot-pmf"></span>
+          <span class="live-legend-label">PMF (Live):</span>
+          <span id="live-val-pmf" class="live-legend-val">-- MB</span>
+        </div>
+        <div class="live-legend-chip chip-v8">
+          <span class="live-legend-dot dot-v8"></span>
+          <span class="live-legend-label">V8 Heap (Live):</span>
+          <span id="live-val-v8" class="live-legend-val">-- MB</span>
+        </div>
+      </div>
     </section>
 
     <!-- Lifecycle Peak Memory Section -->

--- a/cobalt/tools/devtools_extension/panel.js
+++ b/cobalt/tools/devtools_extension/panel.js
@@ -15,9 +15,9 @@
 /**
  * Cobalt Memory Breakdown DevTools Extension Panel Controller.
  * Connects to Cobalt's active CDP port via WebSocket and renders:
- * 1. Real-Time Live Memory Time Series Chart (1 Hz polling over 60s window).
+ * 1. Primary Session P50 Memory Breakdown table (12 continuous P50 allocators).
  * 2. Integrated Proportional Memory Distribution Bar (10 Canonical Allocators).
- * 3. Primary Session P50 Memory Breakdown table (12 continuous P50 allocators).
+ * 3. Real-Time Live Memory Time Series Chart (1 Hz polling over 60s window).
  * 4. Lifecycle Peak Memory scorecard (time-windowed PMF & Peak GPU).
  */
 
@@ -155,10 +155,12 @@ window.addEventListener("beforeunload", () => {
 });
 
 async function resolveWebSocketUrl(baseHostUrl) {
+  // If already a direct ws:// or wss:// URL with target ID, return directly.
   if ((baseHostUrl.startsWith("ws://") || baseHostUrl.startsWith("wss://")) && baseHostUrl.includes("/devtools/page/")) {
     return baseHostUrl;
   }
 
+  // Convert WebSocket scheme to HTTP scheme for target discovery
   let httpBase = baseHostUrl.replace(/^ws:\/\//, "http://").replace(/^wss:\/\//, "https://");
   if (!httpBase.startsWith("http://") && !httpBase.startsWith("https://")) {
     httpBase = "http://" + httpBase;
@@ -296,12 +298,9 @@ function handlePerformanceMetrics(metrics) {
 }
 
 function recordLiveSample() {
-  const rssBytes = latestMetrics["Memory.Browser.ResidentSet.Live"] ??
-                   latestMetrics["Memory.Browser.ResidentSet.P50"] ?? 0;
-  const pmfBytes = latestMetrics["Memory.Browser.PrivateMemoryFootprint.Live"] ??
-                   latestMetrics["Memory.Browser.PrivateMemoryFootprint.P50"] ?? 0;
-  const v8Bytes = latestMetrics["Memory.Experimental.Browser2.V8.Live"] ??
-                  latestMetrics["Memory.Experimental.Browser2.V8.P50"] ?? 0;
+  const rssBytes = latestMetrics?.["Memory.Browser.ResidentSet.Live"] ?? null;
+  const pmfBytes = latestMetrics?.["Memory.Browser.PrivateMemoryFootprint.Live"] ?? null;
+  const v8Bytes = latestMetrics?.["Memory.Experimental.Browser2.V8.Live"] ?? null;
 
   liveHistory.push({
     timestamp: Date.now(),
@@ -375,6 +374,7 @@ function renderDistributionBar(totalRss) {
     }
   });
 
+  // Calculate remaining unallocated / other native resident footprint
   const otherBytes = Math.max(0, totalRss - totalAccountedBytes);
   if (otherBytes > 0) {
     const pctOther = ((otherBytes / totalRss) * 100).toFixed(1);
@@ -412,6 +412,7 @@ function renderTable(totalRss) {
         }
       }
 
+      // If the metric has an assigned color dot (subsystems), render it in the label
       let labelHtml = `<span class="metric-label">${item.label}</span>`;
       if (item.color) {
         labelHtml = `
@@ -490,8 +491,8 @@ function drawTimeSeriesChart() {
 
   const dpr = window.devicePixelRatio || 1;
   const rect = chartCanvas.getBoundingClientRect();
-  const width = rect.width;
-  const height = rect.height;
+  const width = rect.width || 300;
+  const height = rect.height || 150;
 
   chartCanvas.width = width * dpr;
   chartCanvas.height = height * dpr;
@@ -501,13 +502,17 @@ function drawTimeSeriesChart() {
   ctx.clearRect(0, 0, width, height);
 
   const padding = { top: 12, right: 16, bottom: 24, left: 48 };
-  const chartW = width - padding.left - padding.right;
-  const chartH = height - padding.top - padding.bottom;
+  const chartW = Math.max(1, width - padding.left - padding.right);
+  const chartH = Math.max(1, height - padding.top - padding.bottom);
 
   // Compute Max Y value in MB across all series (min ceiling: 50 MB)
   let maxBytes = 50 * 1024 * 1024;
   liveHistory.forEach(s => {
-    if (s.rss > maxBytes) maxBytes = s.rss;
+    const vals = [s.rss, s.pmf, s.v8].filter(v => typeof v === "number" && v > 0);
+    if (vals.length > 0) {
+      const m = Math.max(...vals);
+      if (m > maxBytes) maxBytes = m;
+    }
   });
   const maxYMB = Math.ceil((maxBytes / (1024 * 1024)) * 1.15); // 15% headroom
 
@@ -541,7 +546,13 @@ function drawTimeSeriesChart() {
     ctx.fillText(lbl, xVal, height - padding.bottom + 6);
   });
 
-  if (liveHistory.length < 2) {
+  const validSamplesCount = liveHistory.filter(s =>
+    (typeof s.rss === "number" && s.rss > 0) ||
+    (typeof s.pmf === "number" && s.pmf > 0) ||
+    (typeof s.v8 === "number" && s.v8 > 0)
+  ).length;
+
+  if (validSamplesCount < 2) {
     ctx.fillStyle = "#71717a";
     ctx.font = "italic 12px sans-serif";
     ctx.textAlign = "center";
@@ -552,21 +563,27 @@ function drawTimeSeriesChart() {
   // Helper coordinate mapper
   function getPointCoords(index, valBytes) {
     const x = padding.left + (index / (MAX_HISTORY_SAMPLES - 1)) * chartW;
-    const mb = valBytes / (1024 * 1024);
-    const y = padding.top + chartH - (mb / maxYMB) * chartH;
+    const mb = (typeof valBytes === "number" && valBytes > 0) ? valBytes / (1024 * 1024) : 0;
+    const y = Math.max(padding.top, Math.min(padding.top + chartH, padding.top + chartH - (mb / maxYMB) * chartH));
     return { x, y };
   }
 
   // Draw Line Series with Fill
   function drawSeries(key, strokeColor, fillColor) {
+    const hasData = liveHistory.some(s => typeof s[key] === "number" && s[key] > 0);
+    if (!hasData) return;
+
     const startIdx = MAX_HISTORY_SAMPLES - liveHistory.length;
 
     // Line Path
     ctx.beginPath();
+    let isFirst = true;
     liveHistory.forEach((sample, i) => {
-      const { x, y } = getPointCoords(startIdx + i, sample[key]);
-      if (i === 0) {
+      const val = typeof sample[key] === "number" ? sample[key] : 0;
+      const { x, y } = getPointCoords(startIdx + i, val);
+      if (isFirst) {
         ctx.moveTo(x, y);
+        isFirst = false;
       } else {
         ctx.lineTo(x, y);
       }
@@ -578,8 +595,12 @@ function drawTimeSeriesChart() {
 
     // Area Fill
     if (fillColor) {
-      const lastPoint = getPointCoords(startIdx + liveHistory.length - 1, liveHistory[liveHistory.length - 1][key]);
-      const firstPoint = getPointCoords(startIdx, liveHistory[0][key]);
+      const lastVal = typeof liveHistory[liveHistory.length - 1][key] === "number"
+        ? liveHistory[liveHistory.length - 1][key] : 0;
+      const firstVal = typeof liveHistory[0][key] === "number"
+        ? liveHistory[0][key] : 0;
+      const lastPoint = getPointCoords(startIdx + liveHistory.length - 1, lastVal);
+      const firstPoint = getPointCoords(startIdx, firstVal);
 
       ctx.lineTo(lastPoint.x, padding.top + chartH);
       ctx.lineTo(firstPoint.x, padding.top + chartH);
@@ -588,19 +609,24 @@ function drawTimeSeriesChart() {
       ctx.fill();
     }
 
-    // Draw endpoint circle at current "Now" sample
+    // Draw endpoint circle at current "Now" sample if latest value is present
     const latest = liveHistory[liveHistory.length - 1];
-    const endCoord = getPointCoords(MAX_HISTORY_SAMPLES - 1, latest[key]);
-    ctx.beginPath();
-    ctx.arc(endCoord.x, endCoord.y, 3.5, 0, Math.PI * 2);
-    ctx.fillStyle = strokeColor;
-    ctx.fill();
+    if (typeof latest[key] === "number" && latest[key] > 0) {
+      const endCoord = getPointCoords(MAX_HISTORY_SAMPLES - 1, latest[key]);
+      ctx.beginPath();
+      ctx.arc(endCoord.x, endCoord.y, 3.5, 0, Math.PI * 2);
+      ctx.fillStyle = strokeColor;
+      ctx.fill();
+    }
   }
 
-  // Draw layers: V8 Heap -> Private Footprint -> Resident Set
-  drawSeries("v8", "#fbbf24", "rgba(251, 191, 36, 0.1)");
-  drawSeries("pmf", "#38bdf8", "rgba(56, 189, 248, 0.08)");
+  // Draw layers in order from largest to smallest to avoid line occlusion:
+  // 1. Resident Set (RSS) - Largest background area fill
+  // 2. Private Memory Footprint (PMF) - Middle area fill
+  // 3. V8 JavaScript Heap - Top layer crisp line
   drawSeries("rss", "#a855f7", "rgba(168, 85, 247, 0.05)");
+  drawSeries("pmf", "#38bdf8", "rgba(56, 189, 248, 0.08)");
+  drawSeries("v8", "#fbbf24", "rgba(251, 191, 36, 0.1)");
 }
 
 function setupChartInteractivity() {

--- a/cobalt/tools/devtools_extension/panel.js
+++ b/cobalt/tools/devtools_extension/panel.js
@@ -15,9 +15,10 @@
 /**
  * Cobalt Memory Breakdown DevTools Extension Panel Controller.
  * Connects to Cobalt's active CDP port via WebSocket and renders:
- * 1. Proportional Memory Footprint Distribution Bar (10 Canonical Allocators).
- * 2. Primary Session P50 Memory Breakdown table (12 continuous P50 allocators).
- * 3. Lifecycle Peak Memory scorecard (time-windowed PMF & Peak GPU).
+ * 1. Real-Time Live Memory Time Series Chart (1 Hz polling over 60s window).
+ * 2. Integrated Proportional Memory Distribution Bar (10 Canonical Allocators).
+ * 3. Primary Session P50 Memory Breakdown table (12 continuous P50 allocators).
+ * 4. Lifecycle Peak Memory scorecard (time-windowed PMF & Peak GPU).
  */
 
 // 12 Continuous UMA memory breakdown metrics grouped by Process Totals and Allocator Breakdown
@@ -83,6 +84,10 @@ const GUARDRAIL_METRICS = [
   }
 ];
 
+// Live Time-Series State (Rolling 60s Window at 1 Hz)
+const MAX_HISTORY_SAMPLES = 60;
+const liveHistory = [];
+
 let ws = null;
 let pollInterval = null;
 let nextRequestId = 1;
@@ -93,11 +98,19 @@ const cdpUrlInput = document.getElementById("cdp-url");
 const btnConnect = document.getElementById("btn-connect");
 const btnRefresh = document.getElementById("btn-refresh");
 const statusBadge = document.getElementById("connection-status");
+const streamingBadge = document.getElementById("streaming-badge");
 const tableBody = document.getElementById("metrics-table-body");
 const samplingProgress = document.getElementById("sampling-progress");
 const samplingHint = document.getElementById("sampling-hint");
 const distributionBar = document.getElementById("distribution-bar");
 const guardrailsGrid = document.getElementById("guardrails-grid");
+
+// Chart DOM Elements
+const chartCanvas = document.getElementById("live-memory-chart");
+const chartTooltip = document.getElementById("chart-tooltip");
+const liveValRss = document.getElementById("live-val-rss");
+const liveValPmf = document.getElementById("live-val-pmf");
+const liveValV8 = document.getElementById("live-val-v8");
 
 function formatBytesToMB(bytes) {
   if (bytes === undefined || bytes === null || isNaN(bytes)) return "-- MB";
@@ -117,6 +130,8 @@ function clearPolling() {
 // Auto-Connect on Panel Load and Restore Persisted URL
 document.addEventListener("DOMContentLoaded", () => {
   renderGuardrails();
+  setupChartInteractivity();
+  drawTimeSeriesChart();
 
   if (typeof chrome !== "undefined" && chrome.storage && chrome.storage.local) {
     chrome.storage.local.get(["cdpUrl"], (result) => {
@@ -140,12 +155,10 @@ window.addEventListener("beforeunload", () => {
 });
 
 async function resolveWebSocketUrl(baseHostUrl) {
-  // If already a direct ws:// or wss:// URL with target ID, return directly.
   if ((baseHostUrl.startsWith("ws://") || baseHostUrl.startsWith("wss://")) && baseHostUrl.includes("/devtools/page/")) {
     return baseHostUrl;
   }
 
-  // Convert WebSocket scheme to HTTP scheme for target discovery
   let httpBase = baseHostUrl.replace(/^ws:\/\//, "http://").replace(/^wss:\/\//, "https://");
   if (!httpBase.startsWith("http://") && !httpBase.startsWith("https://")) {
     httpBase = "http://" + httpBase;
@@ -198,22 +211,22 @@ async function connectCDP() {
     ws.onopen = () => {
       statusBadge.textContent = "Connected ●";
       statusBadge.className = "status-badge connected";
+      streamingBadge.textContent = "● 1 Hz Active";
+      streamingBadge.className = "streaming-badge";
       btnConnect.textContent = "Disconnect";
       btnConnect.className = "btn btn-secondary";
       btnRefresh.disabled = false;
 
-      // Save the successfully connected URL
       if (typeof chrome !== "undefined" && chrome.storage && chrome.storage.local) {
         chrome.storage.local.set({ cdpUrl: targetUrl });
       }
 
-      // Enable Performance Domain & query metrics
       sendCdpCommand("Performance.enable");
       requestMetrics();
 
-      // Start periodic polling every 3 seconds for real-time telemetry updates
+      // Static 1 Hz live telemetry streaming polling
       clearPolling();
-      pollInterval = setInterval(requestMetrics, 3000);
+      pollInterval = setInterval(requestMetrics, 1000);
     };
 
     ws.onmessage = (event) => {
@@ -236,6 +249,8 @@ async function connectCDP() {
       clearPolling();
       statusBadge.textContent = "Disconnected";
       statusBadge.className = "status-badge disconnected";
+      streamingBadge.textContent = "● 1 Hz Inactive";
+      streamingBadge.className = "streaming-badge inactive";
       btnConnect.textContent = "Connect";
       btnConnect.className = "btn btn-primary";
       btnRefresh.disabled = true;
@@ -246,6 +261,8 @@ async function connectCDP() {
       clearPolling();
       statusBadge.textContent = "Error";
       statusBadge.className = "status-badge disconnected";
+      streamingBadge.textContent = "● 1 Hz Inactive";
+      streamingBadge.className = "streaming-badge inactive";
       btnRefresh.disabled = true;
     };
   } catch (error) {
@@ -253,6 +270,8 @@ async function connectCDP() {
     clearPolling();
     statusBadge.textContent = "Failed";
     statusBadge.className = "status-badge disconnected";
+    streamingBadge.textContent = "● 1 Hz Inactive";
+    streamingBadge.className = "streaming-badge inactive";
     btnRefresh.disabled = true;
   }
 }
@@ -270,7 +289,37 @@ function handlePerformanceMetrics(metrics) {
     }
   });
 
+  // Record live time series snapshot
+  recordLiveSample();
+
   updateUi();
+}
+
+function recordLiveSample() {
+  const rssBytes = latestMetrics["Memory.Browser.ResidentSet.Live"] ??
+                   latestMetrics["Memory.Browser.ResidentSet.P50"] ?? 0;
+  const pmfBytes = latestMetrics["Memory.Browser.PrivateMemoryFootprint.Live"] ??
+                   latestMetrics["Memory.Browser.PrivateMemoryFootprint.P50"] ?? 0;
+  const v8Bytes = latestMetrics["Memory.Experimental.Browser2.V8.Live"] ??
+                  latestMetrics["Memory.Experimental.Browser2.V8.P50"] ?? 0;
+
+  liveHistory.push({
+    timestamp: Date.now(),
+    rss: rssBytes,
+    pmf: pmfBytes,
+    v8: v8Bytes,
+  });
+
+  if (liveHistory.length > MAX_HISTORY_SAMPLES) {
+    liveHistory.shift();
+  }
+
+  // Update live legend values
+  liveValRss.textContent = formatBytesToMB(rssBytes);
+  liveValPmf.textContent = formatBytesToMB(pmfBytes);
+  liveValV8.textContent = formatBytesToMB(v8Bytes);
+
+  drawTimeSeriesChart();
 }
 
 function updateUi() {
@@ -326,7 +375,6 @@ function renderDistributionBar(totalRss) {
     }
   });
 
-  // Calculate remaining unallocated / other native resident footprint
   const otherBytes = Math.max(0, totalRss - totalAccountedBytes);
   if (otherBytes > 0) {
     const pctOther = ((otherBytes / totalRss) * 100).toFixed(1);
@@ -364,7 +412,6 @@ function renderTable(totalRss) {
         }
       }
 
-      // If the metric has an assigned color dot (subsystems), render it in the label
       let labelHtml = `<span class="metric-label">${item.label}</span>`;
       if (item.color) {
         labelHtml = `
@@ -432,6 +479,175 @@ function renderGuardrails() {
   });
 
   guardrailsGrid.innerHTML = html;
+}
+
+// ============================================================================
+// HTML5 Canvas Time Series Chart Rendering
+// ============================================================================
+
+function drawTimeSeriesChart() {
+  if (!chartCanvas) return;
+
+  const dpr = window.devicePixelRatio || 1;
+  const rect = chartCanvas.getBoundingClientRect();
+  const width = rect.width;
+  const height = rect.height;
+
+  chartCanvas.width = width * dpr;
+  chartCanvas.height = height * dpr;
+
+  const ctx = chartCanvas.getContext("2d");
+  ctx.scale(dpr, dpr);
+  ctx.clearRect(0, 0, width, height);
+
+  const padding = { top: 12, right: 16, bottom: 24, left: 48 };
+  const chartW = width - padding.left - padding.right;
+  const chartH = height - padding.top - padding.bottom;
+
+  // Compute Max Y value in MB across all series (min ceiling: 50 MB)
+  let maxBytes = 50 * 1024 * 1024;
+  liveHistory.forEach(s => {
+    if (s.rss > maxBytes) maxBytes = s.rss;
+  });
+  const maxYMB = Math.ceil((maxBytes / (1024 * 1024)) * 1.15); // 15% headroom
+
+  // 1. Draw Gridlines & Y-Axis Scale
+  ctx.strokeStyle = "rgba(63, 63, 70, 0.4)";
+  ctx.lineWidth = 1;
+  ctx.fillStyle = "#a1a1aa";
+  ctx.font = "10px ui-monospace, SFMono-Regular, monospace";
+  ctx.textAlign = "right";
+  ctx.textBaseline = "middle";
+
+  const numGridLines = 4;
+  for (let i = 0; i <= numGridLines; i++) {
+    const yVal = padding.top + (chartH / numGridLines) * i;
+    const mbVal = Math.round(maxYMB - (maxYMB / numGridLines) * i);
+
+    ctx.beginPath();
+    ctx.moveTo(padding.left, yVal);
+    ctx.lineTo(width - padding.right, yVal);
+    ctx.stroke();
+
+    ctx.fillText(`${mbVal} MB`, padding.left - 6, yVal);
+  }
+
+  // 2. Draw X-Axis Time Labels
+  ctx.textAlign = "center";
+  ctx.textBaseline = "top";
+  const timeLabels = ["-60s", "-45s", "-30s", "-15s", "Now"];
+  timeLabels.forEach((lbl, idx) => {
+    const xVal = padding.left + (chartW / (timeLabels.length - 1)) * idx;
+    ctx.fillText(lbl, xVal, height - padding.bottom + 6);
+  });
+
+  if (liveHistory.length < 2) {
+    ctx.fillStyle = "#71717a";
+    ctx.font = "italic 12px sans-serif";
+    ctx.textAlign = "center";
+    ctx.fillText("Waiting for real-time memory stream...", padding.left + chartW / 2, padding.top + chartH / 2);
+    return;
+  }
+
+  // Helper coordinate mapper
+  function getPointCoords(index, valBytes) {
+    const x = padding.left + (index / (MAX_HISTORY_SAMPLES - 1)) * chartW;
+    const mb = valBytes / (1024 * 1024);
+    const y = padding.top + chartH - (mb / maxYMB) * chartH;
+    return { x, y };
+  }
+
+  // Draw Line Series with Fill
+  function drawSeries(key, strokeColor, fillColor) {
+    const startIdx = MAX_HISTORY_SAMPLES - liveHistory.length;
+
+    // Line Path
+    ctx.beginPath();
+    liveHistory.forEach((sample, i) => {
+      const { x, y } = getPointCoords(startIdx + i, sample[key]);
+      if (i === 0) {
+        ctx.moveTo(x, y);
+      } else {
+        ctx.lineTo(x, y);
+      }
+    });
+
+    ctx.strokeStyle = strokeColor;
+    ctx.lineWidth = 2;
+    ctx.stroke();
+
+    // Area Fill
+    if (fillColor) {
+      const lastPoint = getPointCoords(startIdx + liveHistory.length - 1, liveHistory[liveHistory.length - 1][key]);
+      const firstPoint = getPointCoords(startIdx, liveHistory[0][key]);
+
+      ctx.lineTo(lastPoint.x, padding.top + chartH);
+      ctx.lineTo(firstPoint.x, padding.top + chartH);
+      ctx.closePath();
+      ctx.fillStyle = fillColor;
+      ctx.fill();
+    }
+
+    // Draw endpoint circle at current "Now" sample
+    const latest = liveHistory[liveHistory.length - 1];
+    const endCoord = getPointCoords(MAX_HISTORY_SAMPLES - 1, latest[key]);
+    ctx.beginPath();
+    ctx.arc(endCoord.x, endCoord.y, 3.5, 0, Math.PI * 2);
+    ctx.fillStyle = strokeColor;
+    ctx.fill();
+  }
+
+  // Draw layers: V8 Heap -> Private Footprint -> Resident Set
+  drawSeries("v8", "#fbbf24", "rgba(251, 191, 36, 0.1)");
+  drawSeries("pmf", "#38bdf8", "rgba(56, 189, 248, 0.08)");
+  drawSeries("rss", "#a855f7", "rgba(168, 85, 247, 0.05)");
+}
+
+function setupChartInteractivity() {
+  if (!chartCanvas || !chartTooltip) return;
+
+  chartCanvas.addEventListener("mousemove", (e) => {
+    if (liveHistory.length === 0) return;
+
+    const rect = chartCanvas.getBoundingClientRect();
+    const mouseX = e.clientX - rect.left;
+    const padding = { left: 48, right: 16 };
+    const chartW = rect.width - padding.left - padding.right;
+
+    if (mouseX < padding.left || mouseX > rect.width - padding.right) {
+      chartTooltip.style.display = "none";
+      return;
+    }
+
+    const relX = (mouseX - padding.left) / chartW;
+    const sampleSlot = Math.round(relX * (MAX_HISTORY_SAMPLES - 1));
+    const startIdx = MAX_HISTORY_SAMPLES - liveHistory.length;
+    const historyIdx = sampleSlot - startIdx;
+
+    if (historyIdx >= 0 && historyIdx < liveHistory.length) {
+      const sample = liveHistory[historyIdx];
+      const secondsAgo = Math.round((Date.now() - sample.timestamp) / 1000);
+      const timeStr = secondsAgo <= 0 ? "Now" : `-${secondsAgo}s ago`;
+
+      chartTooltip.innerHTML = `
+        <div style="font-weight: 700; color: #fff; margin-bottom: 3px;">⏱ ${timeStr}</div>
+        <div style="color: #d8b4fe;">● RSS: ${formatBytesToMB(sample.rss)}</div>
+        <div style="color: #7dd3fc;">● PMF: ${formatBytesToMB(sample.pmf)}</div>
+        <div style="color: #fde047;">● V8: ${formatBytesToMB(sample.v8)}</div>
+      `;
+      chartTooltip.style.display = "block";
+    } else {
+      chartTooltip.style.display = "none";
+    }
+  });
+
+  chartCanvas.addEventListener("mouseleave", () => {
+    chartTooltip.style.display = "none";
+  });
+
+  window.addEventListener("resize", () => {
+    drawTimeSeriesChart();
+  });
 }
 
 // Event Listeners


### PR DESCRIPTION
This pull request introduces a real-time live memory time-series chart (1 Hz streaming) to the Cobalt Memory Breakdown DevTools Extension, including UI elements, CSS styling, and canvas-based rendering logic.

Demo: https://screenshot-v2.corp.google.com/0t4isruosv38o
Bug: 530302534