### PR TITLE
media: Re-introduce Image Cache Capacity Multiplier to DiscardableMemoryManager

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -129,6 +129,13 @@ public class JavaSwitches {
   public static final String DISABLE_LESS_AGGRESSIVE_PARKABLE_STRING =
       "DisableLessAggressiveParkableString";
 
+  /**
+   * Flag to enable aggressively shrinking the Image Cache during video playback to prevent Android
+   * OOMs.
+   */
+  public static final String ENABLE_COBALT_IMAGE_CACHE_CAPACITY_MULTIPLIER =
+      "EnableCobaltImageCacheCapacityMultiplier";
+
   public static List<String> getExtraCommandLineArgs(Map<String, String> javaSwitches) {
     List<String> extraCommandLineArgs = new ArrayList<>();
     StringJoiner jsFlags = new StringJoiner(";");
@@ -306,11 +313,17 @@ public class JavaSwitches {
     }
 
     if (javaSwitches.containsKey(JavaSwitches.EVICT_MEMORY_CACHE_ON_CRITICAL_MEMORY_PRESSURE)) {
-      extraCommandLineArgs.add("--enable-features=" + JavaSwitches.EVICT_MEMORY_CACHE_ON_CRITICAL_MEMORY_PRESSURE);
+      extraCommandLineArgs.add(
+          "--enable-features=" + JavaSwitches.EVICT_MEMORY_CACHE_ON_CRITICAL_MEMORY_PRESSURE);
     }
 
     if (javaSwitches.containsKey(JavaSwitches.DISABLE_LESS_AGGRESSIVE_PARKABLE_STRING)) {
       extraCommandLineArgs.add("--disable-features=LessAggressiveParkableString");
+    }
+
+    if (javaSwitches.containsKey(JavaSwitches.ENABLE_COBALT_IMAGE_CACHE_CAPACITY_MULTIPLIER)) {
+      extraCommandLineArgs.add(
+          "--enable-features=CobaltImageCacheCapacityMultiplier:multiplier/0.33/default_limit_mb/30");
     }
 
     return extraCommandLineArgs;

--- a/cobalt/app/cobalt_switch_defaults_starboard.cc
+++ b/cobalt/app/cobalt_switch_defaults_starboard.cc
@@ -99,6 +99,12 @@ CommandLinePreprocessor::GetCobaltParamSwitchDefaults() {
        "SmallerInterestArea, "
        "ReclaimPrepaintTilesWhenIdle, "
        "ReclaimOldPrepaintTiles"},
+
+      // Memory Optimization Limits: V8, Skia, Media
+      {"js-flags", "--max-old-space-size=48"},
+      {"media-cache-size", "2097152"},
+      {"max-discardable-memory-mb", "30"},
+      {"skia-ganesh-resource-cache-limit-mb", "16"},
   // Force some ozone settings.
 #if BUILDFLAG(IS_OZONE)
       {::switches::kUseGL, "angle"},

--- a/third_party/blink/renderer/platform/media/web_media_player_impl.cc
+++ b/third_party/blink/renderer/platform/media/web_media_player_impl.cc
@@ -151,7 +151,7 @@ struct CrossThreadCopier<media::VideoTransformation>
 
 BASE_FEATURE(kCobaltImageCacheCapacityMultiplier,
              "CobaltImageCacheCapacityMultiplier",
-             base::FEATURE_ENABLED_BY_DEFAULT);
+             base::FEATURE_DISABLED_BY_DEFAULT);
 
 const base::FeatureParam<double> kCobaltImageCacheCapacityMultiplierValue{
     &kCobaltImageCacheCapacityMultiplier, "multiplier", 0.33};

--- a/third_party/blink/renderer/platform/media/web_media_player_impl.cc
+++ b/third_party/blink/renderer/platform/media/web_media_player_impl.cc
@@ -142,9 +142,7 @@ struct CrossThreadCopier<media::VideoTransformation>
 }  // namespace WTF
 
 #if BUILDFLAG(IS_COBALT)
-#include <set>
 #include <algorithm>
-#include "base/no_destructor.h"
 #include "base/feature_list.h"
 #include "base/metrics/field_trial_params.h"
 #include "components/discardable_memory/service/discardable_shared_memory_manager.h"
@@ -158,16 +156,13 @@ const base::FeatureParam<double> kCobaltImageCacheCapacityMultiplierValue{
 const base::FeatureParam<int> kCobaltImageCacheDefaultLimitMb{
     &kCobaltImageCacheCapacityMultiplier, "default_limit_mb", 30};
 
-std::set<void*>& GetActiveCobaltPlayers() {
-  static base::NoDestructor<std::set<void*>> active_players;
-  return *active_players;
-}
+static int s_active_cobalt_players = 0;
 
 void UpdateImageCacheLimit() {
   if (base::FeatureList::IsEnabled(kCobaltImageCacheCapacityMultiplier)) {
     if (auto* mgr = discardable_memory::DiscardableSharedMemoryManager::Get()) {
       int default_mb = std::max(0, kCobaltImageCacheDefaultLimitMb.Get());
-      if (!GetActiveCobaltPlayers().empty()) {
+      if (s_active_cobalt_players > 0) {
         double multiplier = std::max(0.0, kCobaltImageCacheCapacityMultiplierValue.Get());
         mgr->SetMemoryLimit(static_cast<size_t>(default_mb * multiplier * 1024 * 1024));
       } else {
@@ -663,8 +658,11 @@ WebMediaPlayerImpl::WebMediaPlayerImpl(
 
 WebMediaPlayerImpl::~WebMediaPlayerImpl() {
 #if BUILDFLAG(IS_COBALT)
-  GetActiveCobaltPlayers().erase(this);
-  UpdateImageCacheLimit();
+  if (is_image_cache_squeezed_) {
+    is_image_cache_squeezed_ = false;
+    s_active_cobalt_players--;
+    UpdateImageCacheLimit();
+  }
 #endif
   DVLOG(1) << __func__;
   DCHECK(main_task_runner_->BelongsToCurrentThread());
@@ -1053,8 +1051,11 @@ void WebMediaPlayerImpl::DoLoad(LoadType load_type,
 
 void WebMediaPlayerImpl::Play() {
 #if BUILDFLAG(IS_COBALT)
-  GetActiveCobaltPlayers().insert(this);
-  UpdateImageCacheLimit();
+  if (!is_image_cache_squeezed_) {
+    is_image_cache_squeezed_ = true;
+    s_active_cobalt_players++;
+    UpdateImageCacheLimit();
+  }
 #endif
   DVLOG(1) << __func__;
   DCHECK(main_task_runner_->BelongsToCurrentThread());
@@ -1104,8 +1105,11 @@ void WebMediaPlayerImpl::Play() {
 
 void WebMediaPlayerImpl::Pause(PauseReason pause_reason) {
 #if BUILDFLAG(IS_COBALT)
-  GetActiveCobaltPlayers().erase(this);
-  UpdateImageCacheLimit();
+  if (is_image_cache_squeezed_) {
+    is_image_cache_squeezed_ = false;
+    s_active_cobalt_players--;
+    UpdateImageCacheLimit();
+  }
 #endif
   DVLOG(1) << __func__;
   DCHECK(main_task_runner_->BelongsToCurrentThread());

--- a/third_party/blink/renderer/platform/media/web_media_player_impl.cc
+++ b/third_party/blink/renderer/platform/media/web_media_player_impl.cc
@@ -47,6 +47,10 @@
 #include "media/base/media_player_logging_id.h"
 #include "media/base/media_switches.h"
 #include "media/base/memory_dump_provider_proxy.h"
+#if BUILDFLAG(IS_COBALT)
+#include "components/discardable_memory/service/discardable_shared_memory_manager.h"
+#endif
+
 #include "media/base/output_device_info.h"
 #include "media/base/remoting_constants.h"
 #include "media/base/renderer.h"
@@ -119,6 +123,8 @@
 #include "media/base/android/media_codec_util.h"
 #endif
 
+
+
 namespace WTF {
 
 template <>
@@ -134,6 +140,44 @@ struct CrossThreadCopier<media::VideoTransformation>
 };
 
 }  // namespace WTF
+
+#if BUILDFLAG(IS_COBALT)
+#include <set>
+#include <algorithm>
+#include "base/no_destructor.h"
+#include "base/feature_list.h"
+#include "base/metrics/field_trial_params.h"
+#include "components/discardable_memory/service/discardable_shared_memory_manager.h"
+
+BASE_FEATURE(kCobaltImageCacheCapacityMultiplier,
+             "CobaltImageCacheCapacityMultiplier",
+             base::FEATURE_ENABLED_BY_DEFAULT);
+
+const base::FeatureParam<double> kCobaltImageCacheCapacityMultiplierValue{
+    &kCobaltImageCacheCapacityMultiplier, "multiplier", 0.33};
+const base::FeatureParam<int> kCobaltImageCacheDefaultLimitMb{
+    &kCobaltImageCacheCapacityMultiplier, "default_limit_mb", 30};
+
+std::set<void*>& GetActiveCobaltPlayers() {
+  static base::NoDestructor<std::set<void*>> active_players;
+  return *active_players;
+}
+
+void UpdateImageCacheLimit() {
+  if (base::FeatureList::IsEnabled(kCobaltImageCacheCapacityMultiplier)) {
+    if (auto* mgr = discardable_memory::DiscardableSharedMemoryManager::Get()) {
+      int default_mb = std::max(0, kCobaltImageCacheDefaultLimitMb.Get());
+      if (!GetActiveCobaltPlayers().empty()) {
+        double multiplier = std::max(0.0, kCobaltImageCacheCapacityMultiplierValue.Get());
+        mgr->SetMemoryLimit(static_cast<size_t>(default_mb * multiplier * 1024 * 1024));
+      } else {
+        mgr->SetMemoryLimit(static_cast<size_t>(default_mb * 1024 * 1024));
+      }
+    }
+  }
+}
+#endif
+
 
 namespace blink {
 
@@ -618,6 +662,10 @@ WebMediaPlayerImpl::WebMediaPlayerImpl(
 }
 
 WebMediaPlayerImpl::~WebMediaPlayerImpl() {
+#if BUILDFLAG(IS_COBALT)
+  GetActiveCobaltPlayers().erase(this);
+  UpdateImageCacheLimit();
+#endif
   DVLOG(1) << __func__;
   DCHECK(main_task_runner_->BelongsToCurrentThread());
 
@@ -1004,6 +1052,10 @@ void WebMediaPlayerImpl::DoLoad(LoadType load_type,
 }
 
 void WebMediaPlayerImpl::Play() {
+#if BUILDFLAG(IS_COBALT)
+  GetActiveCobaltPlayers().insert(this);
+  UpdateImageCacheLimit();
+#endif
   DVLOG(1) << __func__;
   DCHECK(main_task_runner_->BelongsToCurrentThread());
 
@@ -1051,6 +1103,10 @@ void WebMediaPlayerImpl::Play() {
 }
 
 void WebMediaPlayerImpl::Pause(PauseReason pause_reason) {
+#if BUILDFLAG(IS_COBALT)
+  GetActiveCobaltPlayers().erase(this);
+  UpdateImageCacheLimit();
+#endif
   DVLOG(1) << __func__;
   DCHECK(main_task_runner_->BelongsToCurrentThread());
 
@@ -4236,3 +4292,4 @@ void WebMediaPlayerImpl::DidMediaMetadataChange() {
 }
 
 }  // namespace blink
+

--- a/third_party/blink/renderer/platform/media/web_media_player_impl.h
+++ b/third_party/blink/renderer/platform/media/web_media_player_impl.h
@@ -1153,6 +1153,9 @@ class PLATFORM_EXPORT WebMediaPlayerImpl
   unsigned video_frame_readback_count_ = 0;
 
   base::WeakPtr<WebMediaPlayerImpl> weak_this_;
+  #if BUILDFLAG(IS_COBALT)
+  bool is_image_cache_squeezed_ = false;
+#endif
   base::WeakPtrFactory<WebMediaPlayerImpl> weak_factory_{this};
 };
 


### PR DESCRIPTION
This PR creates a `base::Feature` to natively recreate the legacy Cobalt 25 Image Cache capacity multiplier. It dynamically squeezes the Blink `DiscardableSharedMemoryManager` down by a given multiplier (e.g. 0.33x) during active video playback, clawing back roughly 20-30MB of RAM from offscreen thumbnails while retaining sufficient runway to smoothly render the video playback UI controls. 

TAG=agy 
CONV=ad9993af-182a-4fb5-b46f-4d407ca8ca60