### PR TITLE
ci(26.eap): Remove setup-gcloud and replace gsutil with gcloud storage

### DIFF
--- a/.github/actions/docker/action.yaml
+++ b/.github/actions/docker/action.yaml
@@ -20,10 +20,6 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up Cloud SDK
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
-      if: ${{ inputs.is_pr == 'true' }}
-
     - name: Set Docker Build Vars
       env:
         DOCKER_SERVICE: ${{ inputs.docker_service }}

--- a/.github/actions/e2e_tests/action.yaml
+++ b/.github/actions/e2e_tests/action.yaml
@@ -28,8 +28,6 @@ runs:
             --grpc_python_out=${GITHUB_WORKSPACE}/cobalt/tools/ \
             ${GITHUB_WORKSPACE}/cobalt/tools/on_device_tests_gateway.proto
       shell: bash
-    - name: Set Up Cloud SDK
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
     - name: Set GCS Project Name
       run: |
         echo "PROJECT_NAME=$(gcloud config get-value project)" >> $GITHUB_ENV

--- a/.github/actions/on_device_tests/action.yaml
+++ b/.github/actions/on_device_tests/action.yaml
@@ -34,8 +34,6 @@ runs:
             --grpc_python_out=${GITHUB_WORKSPACE}/cobalt/tools/ \
             ${GITHUB_WORKSPACE}/cobalt/tools/on_device_tests_gateway.proto
       shell: bash
-    - name: Set Up Cloud SDK
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
     - name: Set GCS Project Name
       run: |
         echo "PROJECT_NAME=$(gcloud config get-value project)" >> $GITHUB_ENV
@@ -115,7 +113,7 @@ runs:
         # Test results (xml and logs) must be in a subfolder in results_dir.
         # to be picked up by the test result processor.
         mkdir -p "${test_output}/${{ matrix.platform }}"
-        gsutil -q cp -r "${{ inputs.gcs_results_path }}/" "${test_output}/${{ matrix.platform }}"
+        gcloud storage cp -r "${{ inputs.gcs_results_path }}/*" "${test_output}/${{ matrix.platform }}"
 
         # Check for missing result xml files.
         readarray -t test_targets < <(echo "$TEST_TARGETS_JSON" | jq -r '.[]')

--- a/.github/actions/print_logs/action.yaml
+++ b/.github/actions/print_logs/action.yaml
@@ -15,9 +15,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set Up Cloud SDK
-      if: inputs.symbolize == 'true'
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
     - name: Set GCS Project Name
       if: inputs.symbolize == 'true'
       id: gcs-project
@@ -29,8 +26,8 @@ runs:
       env:
         WORKFLOW: ${{ github.workflow }}
       run: |
-        gsutil -m cp "gs://${{ steps.gcs-project.outputs.name }}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}/symbols/*" \
-          "${GITHUB_WORKSPACE}/out/${{ matrix.platform }}_${{ matrix.config }}/lib.unstripped/
+        gcloud storage cp "gs://${{ steps.gcs-project.outputs.name }}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}/symbols/*" \
+          "${GITHUB_WORKSPACE}/out/${{ matrix.platform }}_${{ matrix.config }}/lib.unstripped/"
       shell: bash
     - name: Print Logs and Test Summary
       run: |

--- a/.github/actions/upload_test_artifacts/action.yaml
+++ b/.github/actions/upload_test_artifacts/action.yaml
@@ -67,9 +67,6 @@ runs:
         name: ${{ inputs.test_artifacts_key }}
         path: artifacts/*
         retention-days: 3
-    - name: Set up Cloud SDK
-      if: inputs.upload_on_device_test_artifacts == 'true' || inputs.upload_e2e_test_artifacts == 'true'
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
     - name: Upload On-Device Test Artifacts to GCS
       if: inputs.upload_on_device_test_artifacts == 'true' || inputs.upload_e2e_test_artifacts == 'true'
       env:
@@ -90,6 +87,6 @@ runs:
              "${GITHUB_WORKSPACE}/artifacts/"
         fi
 
-        gsutil -m cp -r "${GITHUB_WORKSPACE}/artifacts/*" \
+        gcloud storage cp -r "${GITHUB_WORKSPACE}/artifacts/*" \
           "gs://${project_name}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}/"
       shell: bash


### PR DESCRIPTION
ci(26.eap): Remove setup-gcloud and replace gsutil with gcloud storage

Remove setup-gcloud action from composite actions to resolve network errors and
rate-limiting when retrieving versions.json. Replace gsutil invocations with
gcloud storage.

Tag: agy
Conv: e8eb9390-5eca-47d7-b307-2a4f9e3cd0d1