### PR TITLE
ci(24.lts): Install gcloud in base Docker image, remove setup-gcloud, use gcloud storage

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -3,9 +3,6 @@ description: Builds Cobalt targets
 runs:
   using: "composite"
   steps:
-    - name: Set up Cloud SDK
-      if: startsWith(${{matrix.target_platform}}, 'android')
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
     - name: Set Android env vars
       if: startsWith(${{matrix.target_platform}}, 'android')
       run: |

--- a/.github/actions/docker/action.yaml
+++ b/.github/actions/docker/action.yaml
@@ -50,8 +50,6 @@ runs:
       if: ${{ (steps.changed-files.outputs.any_changed == 'false') && (github.event_name == 'pull_request') }}
       run: echo "DOCKER_TAG=ghcr.io/${REPO}/${{inputs.docker_image}}:${GITHUB_BASE_REF%.1+}" >> $GITHUB_ENV
       shell: bash
-    - name: Set up Cloud SDK
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
     - name: Configure Docker auth for GCloud
       shell: bash
       run: |

--- a/.github/actions/gn/action.yaml
+++ b/.github/actions/gn/action.yaml
@@ -7,9 +7,6 @@ runs:
       shell: bash
       run: |
         echo "PYTHONPATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
-    - name: Set up Cloud SDK
-      if: startsWith(${{matrix.target_platform}}, 'android')
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
     - name: Configure Android Environment
       shell: bash
       if: startsWith(${{matrix.target_platform}}, 'android')

--- a/.github/actions/on_device_tests/action.yaml
+++ b/.github/actions/on_device_tests/action.yaml
@@ -17,8 +17,6 @@ runs:
       run: |
         python -m grpc_tools.protoc -Itools/ --python_out=tools/ --grpc_python_out=tools/ tools/on_device_tests_gateway.proto
       shell: bash
-    - name: Set Up Cloud SDK
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
     - name: Set env vars
       run: |
         echo "PROJECT_NAME=$(gcloud config get-value project)" >> $GITHUB_ENV
@@ -124,9 +122,9 @@ runs:
           COBALT_INFO_LOG_FILENAME="webDriverTestLog.INFO"
 
           # This command will fail until the results have been uploaded.
-          gsutil cp "${GCS_RESULTS_PATH}/${COBALT_ERROR_LOG_FILENAME}" .
-          gsutil cp "${GCS_RESULTS_PATH}/${COBALT_INFO_LOG_FILENAME}" .
-          gsutil cp "${GCS_RESULTS_PATH}/${COBALT_XMLS_FILENAME}" .
+          gcloud storage cp "${GCS_RESULTS_PATH}/${COBALT_ERROR_LOG_FILENAME}" .
+          gcloud storage cp "${GCS_RESULTS_PATH}/${COBALT_INFO_LOG_FILENAME}" .
+          gcloud storage cp "${GCS_RESULTS_PATH}/${COBALT_XMLS_FILENAME}" .
 
           # Break if all files were downloaded.
           if [[ -f "${COBALT_XMLS_FILENAME}" && -f "${COBALT_ERROR_LOG_FILENAME}" && -f "${COBALT_INFO_LOG_FILENAME}" ]]; then

--- a/.github/actions/on_host_test/action.yaml
+++ b/.github/actions/on_host_test/action.yaml
@@ -7,8 +7,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up Cloud SDK
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
     - name: Configure Environment
       id: configure-environment
       shell: bash
@@ -28,7 +26,7 @@ runs:
       run: |
         set -x
         PROJECT_NAME=$(gcloud config get-value project)
-        gsutil cp gs://${PROJECT_NAME}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}_${{matrix.config}}/${{matrix.platform}}_${{matrix.config}}.${ARCHIVE_EXTENSION} ${GITHUB_WORKSPACE}/out/tmp/${{matrix.platform}}_${{matrix.config}}.${ARCHIVE_EXTENSION}
+        gcloud storage cp gs://${PROJECT_NAME}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}_${{matrix.config}}/${{matrix.platform}}_${{matrix.config}}.${ARCHIVE_EXTENSION} ${GITHUB_WORKSPACE}/out/tmp/${{matrix.platform}}_${{matrix.config}}.${ARCHIVE_EXTENSION}
     - name: Extract Archive
       shell: bash
       run: |
@@ -47,7 +45,7 @@ runs:
       run: |
         set -x
         PROJECT_NAME=$(gcloud config get-value project)
-        gsutil cp gs://${PROJECT_NAME}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}_${{matrix.config}}/${COBALT_EVERGREEN_LOADER}_${{matrix.config}}.${ARCHIVE_EXTENSION} ${GITHUB_WORKSPACE}/out/tmp/${COBALT_EVERGREEN_LOADER}_${{matrix.config}}.${ARCHIVE_EXTENSION}
+        gcloud storage cp gs://${PROJECT_NAME}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}_${{matrix.config}}/${COBALT_EVERGREEN_LOADER}_${{matrix.config}}.${ARCHIVE_EXTENSION} ${GITHUB_WORKSPACE}/out/tmp/${COBALT_EVERGREEN_LOADER}_${{matrix.config}}.${ARCHIVE_EXTENSION}
     - name: Extract Evergreen loader Archive
       if: ${{ env.COBALT_EVERGREEN_LOADER != null && env.COBALT_EVERGREEN_LOADER != 'null' }}
       shell: bash

--- a/.github/actions/upload_nightly_artifacts/action.yaml
+++ b/.github/actions/upload_nightly_artifacts/action.yaml
@@ -3,8 +3,6 @@ description: Archives and uploads nightly artifacts to GCS bucket.
 runs:
   using: "composite"
   steps:
-    - name: Set up Cloud SDK
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
     - name: Set env vars
       env:
         WORKFLOW: ${{github.workflow}}
@@ -36,4 +34,4 @@ runs:
       shell: bash
       run: |
         set -uex
-        gsutil -d cp "${ARCHIVE_PATH}" "gs://${PROJECT_NAME}-build-artifacts/${WORKFLOW}/${TODAY}/${GITHUB_RUN_NUMBER}/"
+        gcloud storage cp "${ARCHIVE_PATH}" "gs://${PROJECT_NAME}-build-artifacts/${WORKFLOW}/${TODAY}/${GITHUB_RUN_NUMBER}/"

--- a/.github/actions/upload_test_artifacts/action.yaml
+++ b/.github/actions/upload_test_artifacts/action.yaml
@@ -10,8 +10,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up Cloud SDK
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
     - name: Configure Environment
       env:
         WORKFLOW: ${{ github.workflow }}
@@ -75,4 +73,4 @@ runs:
       shell: bash
       run: |
         set -eux
-        gsutil -d cp "${ARCHIVE_PATH}" "gs://${DESTINATION}"
+        gcloud storage cp "${ARCHIVE_PATH}" "gs://${DESTINATION}"

--- a/docker/linux/base/Dockerfile
+++ b/docker/linux/base/Dockerfile
@@ -37,4 +37,11 @@ RUN apt update -qqy \
         curl xz-utils \
     && /opt/clean-after-apt.sh
 
+ARG GCLOUD=google-cloud-cli-linux-x86_64.tar.gz
+RUN cd /tmp \
+    && curl -L -O "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${GCLOUD}" \
+    && tar xf "${GCLOUD}" -C /usr/local --strip-components=1 google-cloud-sdk/bin google-cloud-sdk/lib \
+    && rm "${GCLOUD}" \
+    && gcloud --version
+
 CMD ["/usr/bin/python","--version"]


### PR DESCRIPTION
ci(24.lts): Install gcloud in base Docker image, remove setup-gcloud, use gcloud storage

Install Google Cloud SDK directly into docker/linux/base/Dockerfile for
containerized CI builds. Remove setup-gcloud action from composite actions and
replace legacy gsutil invocations with gcloud storage.

Tag: agy
Conv: e8eb9390-5eca-47d7-b307-2a4f9e3cd0d1