### PR TITLE
ci(21.lts): Install gcloud in base Docker image, remove setup-gcloud, use gcloud storage

### DIFF
--- a/.github/actions/docker/action.yaml
+++ b/.github/actions/docker/action.yaml
@@ -48,7 +48,6 @@ runs:
       shell: bash
     - name: Set up Cloud SDK
       if: ${{ (steps.changed-files.outputs.any_changed == 'true') && (github.event_name == 'pull_request') && (github.event.pull_request.head.repo.fork) }}
-      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
     - name: Set Docker Tag
       id: set-docker-tag-presubmit-fork
       env:

--- a/.github/actions/on_host_test/action.yaml
+++ b/.github/actions/on_host_test/action.yaml
@@ -3,8 +3,6 @@ description: Runs on-host tests.
 runs:
   using: "composite"
   steps:
-    - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
     - name: Configure Environment
       id: configure-environment
       shell: bash
@@ -18,7 +16,7 @@ runs:
       run: |
         set -x
         PROJECT_NAME=$(gcloud config get-value project)
-        gsutil cp gs://${PROJECT_NAME}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}_${{matrix.config}}/${{matrix.platform}}_${{matrix.config}}.${ARCHIVE_EXTENSION} ${GITHUB_WORKSPACE}/out/tmp/${{matrix.platform}}_${{matrix.config}}.${ARCHIVE_EXTENSION}
+        gcloud storage cp gs://${PROJECT_NAME}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}_${{matrix.config}}/${{matrix.platform}}_${{matrix.config}}.${ARCHIVE_EXTENSION} ${GITHUB_WORKSPACE}/out/tmp/${{matrix.platform}}_${{matrix.config}}.${ARCHIVE_EXTENSION}
     - name: Extract Archive
       shell: bash
       run: |
@@ -33,7 +31,7 @@ runs:
       run: |
         set -x
         PROJECT_NAME=$(gcloud config get-value project)
-        gsutil cp gs://${PROJECT_NAME}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}_${{matrix.config}}/${COBALT_BOOTLOADER}_${{matrix.config}}.${ARCHIVE_EXTENSION} ${GITHUB_WORKSPACE}/out/tmp/${COBALT_BOOTLOADER}_${{matrix.config}}.${ARCHIVE_EXTENSION}
+        gcloud storage cp gs://${PROJECT_NAME}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}_${{matrix.config}}/${COBALT_BOOTLOADER}_${{matrix.config}}.${ARCHIVE_EXTENSION} ${GITHUB_WORKSPACE}/out/tmp/${COBALT_BOOTLOADER}_${{matrix.config}}.${ARCHIVE_EXTENSION}
     - name: Extract Bootloader Archive
       if: ${{ env.COBALT_BOOTLOADER != null && env.COBALT_BOOTLOADER != 'null' }}
       shell: bash

--- a/.github/actions/upload_nightly_artifacts/action.yaml
+++ b/.github/actions/upload_nightly_artifacts/action.yaml
@@ -3,8 +3,6 @@ description: Archives and uploads nightly artifacts to GCS bucket.
 runs:
   using: "composite"
   steps:
-    - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
     - name: Set env vars
       env:
         WORKFLOW: ${{github.workflow}}
@@ -35,4 +33,4 @@ runs:
       shell: bash
       run: |
         set -uex
-        gsutil -d cp "${ARCHIVE_PATH}" "gs://${PROJECT_NAME}-build-artifacts/${WORKFLOW}/${TODAY}/${GITHUB_RUN_NUMBER}/"
+        gcloud storage cp "${ARCHIVE_PATH}" "gs://${PROJECT_NAME}-build-artifacts/${WORKFLOW}/${TODAY}/${GITHUB_RUN_NUMBER}/"

--- a/.github/actions/upload_test_artifacts/action.yaml
+++ b/.github/actions/upload_test_artifacts/action.yaml
@@ -7,8 +7,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
     - name: Configure Environment
       env:
         WORKFLOW: ${{ github.workflow }}
@@ -60,4 +58,4 @@ runs:
       shell: bash
       run: |
         set -eux
-        gsutil -d cp "${ARCHIVE_PATH}" "gs://${DESTINATION}"
+        gcloud storage cp "${ARCHIVE_PATH}" "gs://${DESTINATION}"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -192,8 +192,6 @@ jobs:
         run: |
           python -m grpc_tools.protoc -Itools/ --python_out=tools/ --grpc_python_out=tools/ tools/on_device_tests_gateway.proto
         shell: bash
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
       - name: Set env vars
         run: |
           echo "PROJECT_NAME=$(gcloud config get-value project)" >> $GITHUB_ENV

--- a/docker/linux/base/Dockerfile
+++ b/docker/linux/base/Dockerfile
@@ -21,3 +21,6 @@ RUN apt update -qqy \
     && echo "Done"
 
 CMD ["/usr/bin/python","--version"]
+
+ARG GCLOUD=google-cloud-cli-linux-x86_64.tar.gz
+RUN cd /tmp     && curl -L -O "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/"     && tar xf "" -C /usr/local --strip-components=1 google-cloud-sdk/bin google-cloud-sdk/lib     && rm ""     && gcloud --version


### PR DESCRIPTION
ci(21.lts): Install gcloud in base Docker image, remove setup-gcloud, use gcloud storage

Install Google Cloud SDK directly into docker/linux/base/Dockerfile for
containerized CI builds. Remove setup-gcloud action from composite actions and
replace legacy gsutil invocations with gcloud storage.

Tag: agy
Conv: e8eb9390-5eca-47d7-b307-2a4f9e3cd0d1