### PR TITLE
ci: Allow Gradle wrapper checksums (25.lts.1+)

### DIFF
--- a/.github/workflows/gradle_25.lts.1+.yaml
+++ b/.github/workflows/gradle_25.lts.1+.yaml
@@ -26,6 +26,8 @@ jobs:
           java-version: 11
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@ccb4328a959376b642e027874838f60f8e596de3 #v1.0.6
+        with:
+          allow-checksums: c5a643cf80162e665cc228f7b16f343fef868e47d3a4836f62e18b7e17ac018a,3dc39ad650d40f6c029bd8ff605c6d95865d657dbfdeacdb079db0ddfffedf9f,96f793a18e056c23ffeec67c1f3bb8eccff5a4a407fc9ceac183527e7eedf4b6
       - name: Build with Gradle
         uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629 #v2.4.2
         with:

--- a/.github/workflows/gradle_25.lts.1+.yaml
+++ b/.github/workflows/gradle_25.lts.1+.yaml
@@ -26,6 +26,11 @@ jobs:
           java-version: 11
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@ccb4328a959376b642e027874838f60f8e596de3 #v1.0.6
+        with:
+          allow-list: |
+            c5a643cf80162e665cc228f7b16f343fef868e47d3a4836f62e18b7e17ac018a
+            3dc39ad650d40f6c029bd8ff605c6d95865d657dbfdeacdb079db0ddfffedf9f
+            96f793a18e056c23ffeec67c1f3bb8eccff5a4a407fc9ceac183527e7eedf4b6
       - name: Build with Gradle
         uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629 #v2.4.2
         with:


### PR DESCRIPTION
Update the Gradle wrapper validation action to include the SHA-256 checksums of existing gradle-wrapper.jar files.

Fixes: 548635638