### PR TITLE
cobalt: Update image cache limit flag to MBs

### DIFF
--- a/cc/base/switches.cc
+++ b/cc/base/switches.cc
@@ -115,7 +115,7 @@ const char kCCScrollAnimationDurationForTesting[] =
 
 #if BUILDFLAG(IS_COBALT)
 const char kCCImageCacheLimitItems[] = "cc-image-cache-limit-items";
-const char kCCImageCacheLimitBytes[] = "cc-image-cache-limit-bytes";
+const char kCCImageCacheLimitMbs[] = "cc-image-cache-limit-mbs";
 const char kDecodedImageWorkingSetBudgetBytes[] =
     "decoded-image-working-set-budget-bytes";
 // Avoid reuse resource.

--- a/cc/base/switches.h
+++ b/cc/base/switches.h
@@ -69,7 +69,7 @@ CC_BASE_EXPORT extern const char kCCScrollAnimationDurationForTesting[];
 
 #if BUILDFLAG(IS_COBALT)
 CC_BASE_EXPORT extern const char kCCImageCacheLimitItems[];
-CC_BASE_EXPORT extern const char kCCImageCacheLimitBytes[];
+CC_BASE_EXPORT extern const char kCCImageCacheLimitMbs[];
 CC_BASE_EXPORT extern const char kDecodedImageWorkingSetBudgetBytes[];
 // Avoid reuse resource.
 CC_BASE_EXPORT extern const char kAvoidCCReuseResource[];

--- a/cc/tiles/image_decode_cache_utils.cc
+++ b/cc/tiles/image_decode_cache_utils.cc
@@ -102,12 +102,12 @@ size_t ImageDecodeCacheUtils::GetPersistentCacheBudgetBytes() {
   static const size_t cobalt_decoded_image_persistent_cache_budget_bytes = []() {
     size_t budget = std::numeric_limits<size_t>::max();
     auto* command_line = base::CommandLine::ForCurrentProcess();
-    if (command_line->HasSwitch(switches::kCCImageCacheLimitBytes)) {
+    if (command_line->HasSwitch(switches::kCCImageCacheLimitMbs)) {
       std::string value = command_line->GetSwitchValueASCII(
-          switches::kCCImageCacheLimitBytes);
-      int64_t parsed_value;
-      if (base::StringToInt64(value, &parsed_value) && parsed_value >= 0) {
-        budget = static_cast<size_t>(parsed_value);
+          switches::kCCImageCacheLimitMbs);
+      int parsed_value;
+      if (base::StringToInt(value, &parsed_value) && parsed_value >= 0) {
+        budget = static_cast<size_t>(parsed_value) * 1024 * 1024;
       }
     }
     return budget;

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -62,6 +62,9 @@ public class JavaSwitches {
   /** flag to limit GPU image cache items */
   public static final String GPU_IMAGE_CACHE_LIMIT_ITEMS = "GpuImageCacheLimitItems";
 
+  /** flag to limit GPU image cache bytes, resuing LimitImageDecodeCacheSizeMb */
+  public static final String LIMIT_IMAGE_DECODE_CACHE_SIZE_MB = "LimitImageDecodeCacheSizeMb";
+
   /** flag to globally configure max HTTP cache size ceiling in bytes. */
   public static final String MAX_HTTP_CACHE_SIZE = "MaxHttpCacheSize";
 
@@ -167,6 +170,11 @@ public class JavaSwitches {
       String limit =
           javaSwitches.get(JavaSwitches.GPU_IMAGE_CACHE_LIMIT_ITEMS).replaceAll("[^0-9]", "");
       extraCommandLineArgs.add("--cc-image-cache-limit-items=" + limit);
+    }
+    if (javaSwitches.containsKey(JavaSwitches.LIMIT_IMAGE_DECODE_CACHE_SIZE_MB)) {
+      String limit =
+          javaSwitches.get(JavaSwitches.LIMIT_IMAGE_DECODE_CACHE_SIZE_MB).replaceAll("[^0-9]", "");
+      extraCommandLineArgs.add("--cc-image-cache-limit-mbs=" + limit);
     }
     if (javaSwitches.containsKey(JavaSwitches.DECODED_IMAGE_WORKING_SET_BUDGET_BYTES)) {
       String budget =
@@ -306,7 +314,8 @@ public class JavaSwitches {
     }
 
     if (javaSwitches.containsKey(JavaSwitches.EVICT_MEMORY_CACHE_ON_CRITICAL_MEMORY_PRESSURE)) {
-      extraCommandLineArgs.add("--enable-features=" + JavaSwitches.EVICT_MEMORY_CACHE_ON_CRITICAL_MEMORY_PRESSURE);
+      extraCommandLineArgs.add(
+          "--enable-features=" + JavaSwitches.EVICT_MEMORY_CACHE_ON_CRITICAL_MEMORY_PRESSURE);
     }
 
     if (javaSwitches.containsKey(JavaSwitches.DISABLE_LESS_AGGRESSIVE_PARKABLE_STRING)) {


### PR DESCRIPTION
Update the image cache limit command-line switch to use megabytes
instead of bytes. This change renames the flag to
cc-image-cache-limit-mbs and updates the internal budget calculation
to perform the appropriate unit conversion.

This alignment improves compatibility with the C26
LimitImageDecodeCacheSize flag and simplifies experiment
configurations. The Android Java switch mapping is also updated
to reflect these changes.

Bug: 545216717