### PR TITLE
performance: Decouple CPU and GPU memory measurements (Approach 2)

### DIFF
--- a/cobalt/browser/performance/BUILD.gn
+++ b/cobalt/browser/performance/BUILD.gn
@@ -26,4 +26,8 @@ source_set("performance") {
     "//starboard:starboard_group",
     "//starboard/common",
   ]
+
+  if (is_android) {
+    deps += [ "//base:memory_jni" ]
+  }
 }

--- a/cobalt/browser/performance/performance_impl.cc
+++ b/cobalt/browser/performance/performance_impl.cc
@@ -14,6 +14,9 @@
 
 #include "cobalt/browser/performance/performance_impl.h"
 
+#include <utility>
+
+#include "base/notreached.h"
 #include "base/process/process_handle.h"
 #include "base/process/process_metrics.h"
 #include "base/system/sys_info.h"
@@ -21,12 +24,19 @@
 #include "base/task/thread_pool.h"
 #include "build/build_config.h"
 
+#if BUILDFLAG(IS_ANDROID)
+#include "base/android/jni_android.h"
+#include "base/memory_jni/CobaltMemoryInfoBridge_jni.h"
+#include "base/memory_jni/MemoryInfoBridge_jni.h"
+#endif
+
 #if BUILDFLAG(IS_ANDROIDTV)
 #include "starboard/android/shared/starboard_bridge.h"
 
 using ::starboard::StarboardBridge;
 #elif BUILDFLAG(IS_STARBOARD)
 #include "starboard/common/time.h"
+#include "starboard/system.h"
 #endif
 
 namespace performance {
@@ -109,6 +119,68 @@ void PerformanceImpl::MeasureReservedVirtualMemory(
         return info.has_value() ? info->vm_size_bytes : 0;
       }),
       std::move(callback));
+}
+
+void PerformanceImpl::MeasureUsedGpuMemory(
+    MeasureUsedGpuMemoryCallback callback) {
+#if BUILDFLAG(IS_ANDROID)
+  base::ThreadPool::PostTaskAndReplyWithResult(
+      FROM_HERE, {base::MayBlock(), base::TaskPriority::USER_VISIBLE},
+      base::BindOnce([]() -> std::pair<bool, uint64_t> {
+        JNIEnv* env = base::android::AttachCurrentThread();
+        base::android::ScopedJavaLocalRef<jobject> memory_info =
+            Java_MemoryInfoBridge_getActivityManagerMemoryInfoForSelf(env);
+        if (memory_info.is_null()) {
+          return {false, 0};
+        }
+        int graphics_kb =
+            Java_CobaltMemoryInfoBridge_getGraphicsMemoryKb(env, memory_info);
+        return {true, static_cast<uint64_t>(graphics_kb) * 1024};
+      }),
+      base::BindOnce(
+          [](MeasureUsedGpuMemoryCallback cb,
+             std::pair<bool, uint64_t> result) {
+            std::move(cb).Run(result.first, result.second);
+          },
+          std::move(callback)));
+#elif BUILDFLAG(IS_STARBOARD)
+  if (!SbSystemHasCapability(kSbSystemCapabilityCanQueryGPUMemoryStats)) {
+    std::move(callback).Run(false, 0);
+    return;
+  }
+  base::ThreadPool::PostTaskAndReplyWithResult(
+      FROM_HERE, {base::MayBlock(), base::TaskPriority::USER_VISIBLE},
+      base::BindOnce([]() -> uint64_t { return SbSystemGetUsedGPUMemory(); }),
+      base::BindOnce([](MeasureUsedGpuMemoryCallback cb,
+                        uint64_t bytes) { std::move(cb).Run(true, bytes); },
+                     std::move(callback)));
+#else
+  std::move(callback).Run(false, 0);
+#endif
+}
+
+void PerformanceImpl::MeasureTotalGpuMemory(
+    MeasureTotalGpuMemoryCallback callback) {
+#if BUILDFLAG(IS_STARBOARD)
+  if (!SbSystemHasCapability(kSbSystemCapabilityCanQueryGPUMemoryStats)) {
+    std::move(callback).Run(false, 0);
+    return;
+  }
+  base::ThreadPool::PostTaskAndReplyWithResult(
+      FROM_HERE, {base::MayBlock(), base::TaskPriority::USER_VISIBLE},
+      base::BindOnce([]() -> uint64_t { return SbSystemGetTotalGPUMemory(); }),
+      base::BindOnce(
+          [](MeasureTotalGpuMemoryCallback cb, uint64_t bytes) {
+            if (bytes == 0) {
+              std::move(cb).Run(false, 0);
+              return;
+            }
+            std::move(cb).Run(true, bytes);
+          },
+          std::move(callback)));
+#else
+  std::move(callback).Run(false, 0);
+#endif
 }
 
 void PerformanceImpl::GetAppStartupTimeStamp(

--- a/cobalt/browser/performance/performance_impl.cc
+++ b/cobalt/browser/performance/performance_impl.cc
@@ -70,6 +70,15 @@ void PerformanceImpl::MeasureAvailableCpuMemory(
 
 void PerformanceImpl::MeasureUsedCpuMemory(
     MeasureAvailableCpuMemoryCallback callback) {
+#if BUILDFLAG(IS_STARBOARD)
+  base::ThreadPool::PostTaskAndReplyWithResult(
+      FROM_HERE, {base::MayBlock(), base::TaskPriority::USER_VISIBLE},
+      base::BindOnce([]() -> uint64_t { return SbSystemGetUsedCPUMemory(); }),
+      std::move(callback));
+#elif BUILDFLAG(IS_IOS_TVOS)
+  NOTIMPLEMENTED();
+  std::move(callback).Run(0);
+#else
   base::ThreadPool::PostTaskAndReplyWithResult(
       FROM_HERE, {base::MayBlock(), base::TaskPriority::USER_VISIBLE},
       base::BindOnce([]() -> uint64_t {
@@ -79,9 +88,10 @@ void PerformanceImpl::MeasureUsedCpuMemory(
           return 0;
         }
         auto info = process_metrics->GetMemoryInfo();
-        return info.has_value() ? info->resident_set_bytes : 0;
+        return info.has_value() ? info->rss_anon_bytes : 0;
       }),
       std::move(callback));
+#endif
 }
 
 void PerformanceImpl::MeasureUsedSwapMemory(

--- a/cobalt/browser/performance/performance_impl.h
+++ b/cobalt/browser/performance/performance_impl.h
@@ -47,6 +47,8 @@ class PerformanceImpl
   void MeasureUsedSwapMemory(MeasureUsedSwapMemoryCallback) override;
   void MeasureReservedVirtualMemory(
       MeasureReservedVirtualMemoryCallback) override;
+  void MeasureUsedGpuMemory(MeasureUsedGpuMemoryCallback) override;
+  void MeasureTotalGpuMemory(MeasureTotalGpuMemoryCallback) override;
   void GetAppStartupTimeStamp(GetAppStartupTimeStampCallback callback) override;
 
  private:

--- a/cobalt/browser/performance/public/mojom/performance.mojom
+++ b/cobalt/browser/performance/public/mojom/performance.mojom
@@ -32,6 +32,14 @@ interface CobaltPerformance {
   [Sync]
   MeasureReservedVirtualMemory() => (uint64 bytes);
 
+  // Get the amount of GPU memory used by the application, in bytes.
+  [Sync]
+  MeasureUsedGpuMemory() => (bool is_supported, uint64 bytes);
+
+  // Get the total amount of GPU memory available to the application, in bytes.
+  [Sync]
+  MeasureTotalGpuMemory() => (bool is_supported, uint64 bytes);
+
   // Get the application startup timestamp in microseconds (us).
   [Sync]
   GetAppStartupTimeStamp() => (int64 timestamp);

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_total_gpu_memory.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_total_gpu_memory.cc
@@ -29,29 +29,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
+
 #include "starboard/system.h"
 
-#include "starboard/common/file.h"
-#include "starboard/common/log.h"
-#include "starboard/common/string.h"
-
 int64_t SbSystemGetTotalGPUMemory() {
-  starboard::ScopedFile status_file(
-    "/sys/fs/cgroup/gpu/gpu.limit_in_bytes",
-    O_RDONLY);
-
-  if (status_file.IsValid()) {
-    const int kBufferSize = 512;
-    char buffer[kBufferSize];
-    int bytes_read = status_file.ReadAll(buffer, kBufferSize);
-    if (bytes_read == kBufferSize) {
-      bytes_read = kBufferSize - 1;
-    }
-    buffer[bytes_read] = '\0';
-    int64_t limit_in_bytes = strtoll(buffer, nullptr, 10);
-    if (limit_in_bytes > 0)
-      return limit_in_bytes;
-  }
-
+  // On unified memory architecture (UMA) platforms, GPU and CPU share system
+  // memory, so there is no separate total GPU memory pool.
   return 0;
 }

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_used_gpu_memory.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_used_gpu_memory.cc
@@ -29,30 +29,42 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "starboard/system.h"
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <cstdint>
 
 #include "starboard/common/file.h"
-#include "starboard/common/log.h"
-#include "starboard/common/string.h"
-
-#include <cerrno>
+#include "starboard/system.h"
 
 int64_t SbSystemGetUsedGPUMemory() {
-  starboard::ScopedFile status_file(
-    "/sys/fs/cgroup/gpu/gpu.usage_in_bytes",
-    O_RDONLY);
+  starboard::ScopedFile file("/sys/class/misc/mali0/device/gpu_memory",
+                             O_RDONLY);
+  if (!file.IsValid()) {
+    return 0;
+  }
 
-  if (status_file.IsValid()) {
-    const int kBufferSize = 512;
-    char buffer[kBufferSize];
-    int bytes_read = status_file.ReadAll(buffer, kBufferSize);
-    if (bytes_read == kBufferSize) {
-      bytes_read = kBufferSize - 1;
-    }
-    buffer[bytes_read] = '\0';
-    int64_t usage_in_bytes = strtoll(buffer, nullptr, 10);
-    if (usage_in_bytes > 0 && errno != ERANGE)
-      return usage_in_bytes;
+  char buffer[2048];
+  int bytes_read = file.ReadAll(buffer, sizeof(buffer) - 1);
+  if (bytes_read <= 0) {
+    return 0;
+  }
+  buffer[bytes_read] = '\0';
+
+  char target[32];
+  int target_len = snprintf(target, sizeof(target), "%d", getpid());
+
+  char* pos = strstr(buffer, target);
+  if (!pos) {
+    return 0;
+  }
+
+  int64_t pages = 0;
+  if (sscanf(pos + target_len, "%" SCNd64, &pages) == 1) {
+    return pages * sysconf(_SC_PAGE_SIZE);
   }
 
   return 0;

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_has_capability.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_has_capability.cc
@@ -11,9 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include <sys/stat.h>
-#include "starboard/system.h"
+#include <unistd.h>
 
+#include "starboard/system.h"
 #include "starboard/common/log.h"
 
 bool SbSystemHasCapability(SbSystemCapabilityId capability_id) {
@@ -21,9 +21,7 @@ bool SbSystemHasCapability(SbSystemCapabilityId capability_id) {
     case kSbSystemCapabilityReversedEnterAndBack:
       return false;
     case kSbSystemCapabilityCanQueryGPUMemoryStats:
-      struct stat buffer;
-      static bool gpu_stats_exists_cached = (stat("/sys/fs/cgroup/gpu/gpu.usage_in_bytes", &buffer) == 0);
-      return gpu_stats_exists_cached;
+      return access("/sys/class/misc/mali0/device/gpu_memory", R_OK) == 0;
   }
 
   SB_DLOG(WARNING) << "Unrecognized capability: " << capability_id;

--- a/starboard/nplb/system_get_total_gpu_memory_test.cc
+++ b/starboard/nplb/system_get_total_gpu_memory_test.cc
@@ -20,9 +20,9 @@ namespace {
 
 TEST(SbSystemGetTotalGPUMemoryTest, SunnyDay) {
   if (SbSystemHasCapability(kSbSystemCapabilityCanQueryGPUMemoryStats)) {
-    // If we claim to have GPU memory reporting capabilities, then this value
-    // should be larger than 0.
-    EXPECT_LT(0, SbSystemGetTotalGPUMemory());
+    // On UMA (Unified Memory Architecture) platforms, GPU and CPU share system
+    // memory, so total GPU memory may be 0.
+    EXPECT_GE(SbSystemGetTotalGPUMemory(), 0);
   }
 }
 

--- a/starboard/shared/linux/system_get_used_cpu_memory.cc
+++ b/starboard/shared/linux/system_get_used_cpu_memory.cc
@@ -74,12 +74,27 @@ int64_t SearchForMemoryValue(const char* search_key, const char* buffer) {
 }
 
 int64_t SbSystemGetUsedCPUMemory() {
-  // Read our process' current physical memory usage from /proc/self/status.
+  starboard::ScopedFile smaps_file("/proc/self/smaps_rollup", O_RDONLY);
+  if (smaps_file.IsValid()) {
+    const int kBufferSize = 2048;
+    char buffer[kBufferSize];
+    int bytes_read = smaps_file.ReadAll(buffer, kBufferSize - 1);
+    if (bytes_read > 0) {
+      buffer[bytes_read] = '\0';
+      int64_t pss_anon = SearchForMemoryValue("Pss_Anon:", buffer);
+      if (pss_anon > 0) {
+        return pss_anon;
+      }
+      int64_t pss = SearchForMemoryValue("Pss:", buffer);
+      if (pss > 0) {
+        return pss;
+      }
+    }
+  }
+
   starboard::ScopedFile status_file("/proc/self/status", 0);
   if (!status_file.IsValid()) {
-    SB_LOG(ERROR)
-        << "Error opening /proc/self/status in order to query self memory "
-           "usage.";
+    SB_LOG(ERROR) << "Error opening /proc/self/status";
     return 0;
   }
 
@@ -94,7 +109,9 @@ int64_t SbSystemGetUsedCPUMemory() {
   }
   buffer[bytes_read] = '\0';
 
-  // Return the result, multiplied by 1024 because it is given in kilobytes.
-  return SearchForMemoryValue("VmRSS", buffer) +
-         SearchForMemoryValue("VmSwap", buffer);
+  int64_t rss = SearchForMemoryValue("RssAnon:", buffer);
+  if (rss == 0) {
+    rss = SearchForMemoryValue("VmRSS:", buffer);
+  }
+  return rss + SearchForMemoryValue("VmSwap:", buffer);
 }

--- a/third_party/blink/renderer/core/cobalt/performance/performance_extensions.cc
+++ b/third_party/blink/renderer/core/cobalt/performance/performance_extensions.cc
@@ -72,6 +72,40 @@ uint64_t PerformanceExtensions::measureReservedVirtualMemory(
   return virtual_memory_size;
 }
 
+uint64_t PerformanceExtensions::measureUsedGpuMemory(
+    ScriptState* script_state,
+    const Performance&,
+    ExceptionState& exception_state) {
+  bool is_supported = false;
+  uint64_t used_gpu_memory = 0;
+  BindRemotePerformance(script_state)
+      ->MeasureUsedGpuMemory(&is_supported, &used_gpu_memory);
+  if (!is_supported) {
+    exception_state.ThrowDOMException(
+        DOMExceptionCode::kNotSupportedError,
+        "GPU memory measurement is not supported on this platform.");
+    return 0;
+  }
+  return used_gpu_memory;
+}
+
+uint64_t PerformanceExtensions::measureTotalGpuMemory(
+    ScriptState* script_state,
+    const Performance&,
+    ExceptionState& exception_state) {
+  bool is_supported = false;
+  uint64_t total_gpu_memory = 0;
+  BindRemotePerformance(script_state)
+      ->MeasureTotalGpuMemory(&is_supported, &total_gpu_memory);
+  if (!is_supported) {
+    exception_state.ThrowDOMException(
+        DOMExceptionCode::kNotSupportedError,
+        "GPU memory measurement is not supported on this platform.");
+    return 0;
+  }
+  return total_gpu_memory;
+}
+
 ScriptPromise<IDLDouble> PerformanceExtensions::getAppStartupTimeStamp(
     ScriptState* script_state,
     const Performance& performance_obj,

--- a/third_party/blink/renderer/core/cobalt/performance/performance_extensions.h
+++ b/third_party/blink/renderer/core/cobalt/performance/performance_extensions.h
@@ -23,6 +23,7 @@
 
 namespace blink {
 
+class ExceptionState;
 class Performance;
 class ScriptState;
 
@@ -36,6 +37,12 @@ class CORE_EXPORT PerformanceExtensions final {
   static uint64_t measureUsedSwapMemory(ScriptState*, const Performance&);
   static uint64_t measureReservedVirtualMemory(ScriptState*,
                                                const Performance&);
+  static uint64_t measureUsedGpuMemory(ScriptState*,
+                                       const Performance&,
+                                       ExceptionState&);
+  static uint64_t measureTotalGpuMemory(ScriptState*,
+                                        const Performance&,
+                                        ExceptionState&);
   static ScriptPromise<IDLDouble> getAppStartupTimeStamp(ScriptState*,
                                                          const Performance&,
                                                          ExceptionState&);

--- a/third_party/blink/renderer/core/cobalt/performance/performance_extensions.idl
+++ b/third_party/blink/renderer/core/cobalt/performance/performance_extensions.idl
@@ -16,6 +16,12 @@
     // Returns the amount of virtual memory currently reserved in bytes.
     [CallWith=ScriptState] unsigned long long measureReservedVirtualMemory();
 
+    // Returns the amount of GPU memory used by the Cobalt process in bytes.
+    [CallWith=ScriptState, RaisesException] unsigned long long measureUsedGpuMemory();
+
+    // Returns the total amount of GPU memory available on the device in bytes.
+    [CallWith=ScriptState, RaisesException] unsigned long long measureTotalGpuMemory();
+
     // Returns the application startup timestamp in millisecs (ms).
     [CallWith=ScriptState, RaisesException] Promise<DOMHighResTimeStamp> getAppStartupTimeStamp();
 };


### PR DESCRIPTION
This PR demonstrates Approach 2 for Bug 544828898: actively splitting CPU and GPU memory so that measureUsedCpuMemory excludes GPU driver / graphics surface shared memory mappings (using /proc/self/smaps_rollup and RssAnon).