### PR TITLE
ci(25.lts): Install gcloud in base Docker image, remove setup-gcloud, use gcloud storage

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -7,7 +7,11 @@ runs:
       if: startsWith(${{matrix.target_platform}}, 'android')
       run: |
         echo "ANDROID_HOME=/root/starboard-toolchains/AndroidSdk/" >> $GITHUB_ENV
-        PROJECT_NAME=$(curl -s -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
+        PROJECT_NAME=$(curl --fail --connect-timeout 2 -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/project/project-id 2>/dev/null || gcloud config get-value project 2>/dev/null)
+        if [[ -z "${PROJECT_NAME}" ]]; then
+          echo "Failed to retrieve Google Cloud project ID"
+          exit 1
+        fi
         echo "GCS_NIGHTLY_PATH=gs://${PROJECT_NAME}-build-artifacts" >> $GITHUB_ENV
       shell: bash
     - name: Build

--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -3,14 +3,11 @@ description: Builds Cobalt targets
 runs:
   using: "composite"
   steps:
-    - name: Set up Cloud SDK
-      if: startsWith(${{matrix.target_platform}}, 'android')
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
     - name: Set Android env vars
       if: startsWith(${{matrix.target_platform}}, 'android')
       run: |
         echo "ANDROID_HOME=/root/starboard-toolchains/AndroidSdk/" >> $GITHUB_ENV
-        PROJECT_NAME=$(gcloud config get-value project)
+        PROJECT_NAME=$(curl -s -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
         echo "GCS_NIGHTLY_PATH=gs://${PROJECT_NAME}-build-artifacts" >> $GITHUB_ENV
       shell: bash
     - name: Build

--- a/.github/actions/docker/action.yaml
+++ b/.github/actions/docker/action.yaml
@@ -104,7 +104,7 @@ runs:
       shell: bash
       run: |
         set -xue
-        DOCKER_BUILDKIT=0 docker compose -f docker-compose.yml up --build --no-start "${SERVICE}"
+        docker compose -f docker-compose.yml up --build --no-start "${SERVICE}"
     - name: Tag images
       id: tag-images
       if: env.need_to_build == 'true'

--- a/.github/actions/docker/action.yaml
+++ b/.github/actions/docker/action.yaml
@@ -60,12 +60,6 @@ runs:
         docker_tag="${docker_tag%.1[+,-]}"
         echo "DOCKER_TAG=${docker_tag}" >> $GITHUB_ENV
       shell: bash
-    - name: Set up Cloud SDK
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
-    - name: Configure Docker auth for GCloud
-      shell: bash
-      run: |
-        gcloud auth configure-docker
     - name: Set Docker Tag
       id: set-docker-tag-presubmit-fork
       env:
@@ -73,12 +67,22 @@ runs:
       if: ${{ (steps.changed-files.outputs.any_changed == 'true') && (github.event_name == 'pull_request') && (github.event.pull_request.head.repo.fork) }}
       run: |
         # Need to login to GCR to be able to push images created by fork based PR workflows.
-        PROJECT_NAME=$(gcloud config get-value project)
+        PROJECT_NAME=$(curl -s -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
         METADATA="http://metadata.google.internal./computeMetadata/v1"
         SVC_ACCT="${METADATA}/instance/service-accounts/default"
         ACCESS_TOKEN=$(curl -H 'Metadata-Flavor: Google' ${SVC_ACCT}/token | cut -d'"' -f 4)
         printf ${ACCESS_TOKEN} | docker login -u oauth2accesstoken --password-stdin https://gcr.io
         echo "DOCKER_TAG=gcr.io/${PROJECT_NAME}/${{inputs.docker_image}}:pr-${GITHUB_EVENT_NUMBER}" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Login to Marketplace GCR
+      run: |
+        METADATA="http://metadata.google.internal./computeMetadata/v1"
+        SVC_ACCT="${METADATA}/instance/service-accounts/default"
+        ACCESS_TOKEN=$(curl -s -f -H 'Metadata-Flavor: Google' ${SVC_ACCT}/token 2>/dev/null | cut -d'"' -f 4 || true)
+        if [[ -n "${ACCESS_TOKEN}" ]]; then
+          printf ${ACCESS_TOKEN} | docker login -u oauth2accesstoken --password-stdin https://marketplace.gcr.io || true
+        fi
       shell: bash
     - name: Process Docker metadata
       id: process-docker-metadata

--- a/.github/actions/docker/action.yaml
+++ b/.github/actions/docker/action.yaml
@@ -67,8 +67,12 @@ runs:
       if: ${{ (steps.changed-files.outputs.any_changed == 'true') && (github.event_name == 'pull_request') && (github.event.pull_request.head.repo.fork) }}
       run: |
         # Need to login to GCR to be able to push images created by fork based PR workflows.
-        PROJECT_NAME=$(curl -s -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
-        METADATA="http://metadata.google.internal./computeMetadata/v1"
+        PROJECT_NAME=$(curl --fail --connect-timeout 2 -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/project/project-id 2>/dev/null || gcloud config get-value project 2>/dev/null)
+        if [[ -z "${PROJECT_NAME}" ]]; then
+          echo "Failed to retrieve Google Cloud project ID"
+          exit 1
+        fi
+        METADATA="http://metadata.google.internal/computeMetadata/v1"
         SVC_ACCT="${METADATA}/instance/service-accounts/default"
         ACCESS_TOKEN=$(curl -s -f --connect-timeout 5 -H 'Metadata-Flavor: Google' ${SVC_ACCT}/token | cut -d'"' -f 4)
         printf ${ACCESS_TOKEN} | docker login -u oauth2accesstoken --password-stdin https://gcr.io
@@ -77,7 +81,7 @@ runs:
 
     - name: Login to Marketplace GCR
       run: |
-        METADATA="http://metadata.google.internal./computeMetadata/v1"
+        METADATA="http://metadata.google.internal/computeMetadata/v1"
         SVC_ACCT="${METADATA}/instance/service-accounts/default"
         ACCESS_TOKEN=$(curl -s -f --connect-timeout 5 -H 'Metadata-Flavor: Google' ${SVC_ACCT}/token 2>/dev/null | cut -d'"' -f 4 || true)
         if [[ -n "${ACCESS_TOKEN}" ]]; then

--- a/.github/actions/docker/action.yaml
+++ b/.github/actions/docker/action.yaml
@@ -108,7 +108,7 @@ runs:
       shell: bash
       run: |
         set -xue
-        DOCKER_BUILDKIT=0 docker compose -f docker-compose.yml up --build --no-start "${SERVICE}"
+        docker compose -f docker-compose.yml up --build --no-start "${SERVICE}"
     - name: Tag images
       id: tag-images
       if: env.need_to_build == 'true'

--- a/.github/actions/docker/action.yaml
+++ b/.github/actions/docker/action.yaml
@@ -70,7 +70,7 @@ runs:
         PROJECT_NAME=$(curl -s -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
         METADATA="http://metadata.google.internal./computeMetadata/v1"
         SVC_ACCT="${METADATA}/instance/service-accounts/default"
-        ACCESS_TOKEN=$(curl -H 'Metadata-Flavor: Google' ${SVC_ACCT}/token | cut -d'"' -f 4)
+        ACCESS_TOKEN=$(curl -s -f --connect-timeout 5 -H 'Metadata-Flavor: Google' ${SVC_ACCT}/token | cut -d'"' -f 4)
         printf ${ACCESS_TOKEN} | docker login -u oauth2accesstoken --password-stdin https://gcr.io
         echo "DOCKER_TAG=gcr.io/${PROJECT_NAME}/${{inputs.docker_image}}:pr-${GITHUB_EVENT_NUMBER}" >> $GITHUB_ENV
       shell: bash
@@ -79,7 +79,7 @@ runs:
       run: |
         METADATA="http://metadata.google.internal./computeMetadata/v1"
         SVC_ACCT="${METADATA}/instance/service-accounts/default"
-        ACCESS_TOKEN=$(curl -s -f -H 'Metadata-Flavor: Google' ${SVC_ACCT}/token 2>/dev/null | cut -d'"' -f 4 || true)
+        ACCESS_TOKEN=$(curl -s -f --connect-timeout 5 -H 'Metadata-Flavor: Google' ${SVC_ACCT}/token 2>/dev/null | cut -d'"' -f 4 || true)
         if [[ -n "${ACCESS_TOKEN}" ]]; then
           printf ${ACCESS_TOKEN} | docker login -u oauth2accesstoken --password-stdin https://marketplace.gcr.io || true
         fi

--- a/.github/actions/docker/action.yaml
+++ b/.github/actions/docker/action.yaml
@@ -108,7 +108,7 @@ runs:
       shell: bash
       run: |
         set -xue
-        docker compose -f docker-compose.yml up --build --no-start "${SERVICE}"
+        DOCKER_BUILDKIT=0 docker compose -f docker-compose.yml up --build --no-start "${SERVICE}"
     - name: Tag images
       id: tag-images
       if: env.need_to_build == 'true'

--- a/.github/actions/gn/action.yaml
+++ b/.github/actions/gn/action.yaml
@@ -7,16 +7,13 @@ runs:
       shell: bash
       run: |
         echo "PYTHONPATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
-    - name: Set up Cloud SDK
-      if: startsWith(${{matrix.target_platform}}, 'android')
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
     - name: Configure Android Environment
       shell: bash
       if: startsWith(${{matrix.target_platform}}, 'android')
       run: |
         echo "ANDROID_HOME=/root/starboard-toolchains/AndroidSdk/" >> $GITHUB_ENV
         echo "COBALT_GRADLE_BUILD_COUNT=24" >> $GITHUB_ENV
-        PROJECT_NAME=$(gcloud config get-value project)
+        PROJECT_NAME=$(curl -s -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
         echo "GCS_NIGHTLY_PATH=gs://${PROJECT_NAME}-build-artifacts" >> $GITHUB_ENV
     - name: GN
       run: |

--- a/.github/actions/gn/action.yaml
+++ b/.github/actions/gn/action.yaml
@@ -13,7 +13,11 @@ runs:
       run: |
         echo "ANDROID_HOME=/root/starboard-toolchains/AndroidSdk/" >> $GITHUB_ENV
         echo "COBALT_GRADLE_BUILD_COUNT=24" >> $GITHUB_ENV
-        PROJECT_NAME=$(curl -s -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
+        PROJECT_NAME=$(curl --fail --connect-timeout 2 -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/project/project-id 2>/dev/null || gcloud config get-value project 2>/dev/null)
+        if [[ -z "${PROJECT_NAME}" ]]; then
+          echo "Failed to retrieve Google Cloud project ID"
+          exit 1
+        fi
         echo "GCS_NIGHTLY_PATH=gs://${PROJECT_NAME}-build-artifacts" >> $GITHUB_ENV
     - name: GN
       run: |

--- a/.github/actions/on_device_tests/action.yaml
+++ b/.github/actions/on_device_tests/action.yaml
@@ -16,7 +16,11 @@ runs:
       env:
         WORKFLOW: ${{ github.workflow }}
       run: |
-        PROJECT_NAME=$(curl -s -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
+        PROJECT_NAME=$(curl --fail --connect-timeout 2 -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/project/project-id 2>/dev/null || gcloud config get-value project 2>/dev/null)
+        if [[ -z "${PROJECT_NAME}" ]]; then
+          echo "Failed to retrieve Google Cloud project ID"
+          exit 1
+        fi
         echo "PROJECT_NAME=${PROJECT_NAME}" >> $GITHUB_ENV
         echo "GITHUB_RUN_NUMBER=${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
         echo "WORKFLOW=${WORKFLOW}" >> $GITHUB_ENV

--- a/.github/actions/on_device_tests/action.yaml
+++ b/.github/actions/on_device_tests/action.yaml
@@ -12,13 +12,12 @@ runs:
       run: |
         python -m grpc_tools.protoc -Itools/ --python_out=tools/ --grpc_python_out=tools/ tools/on_device_tests_gateway.proto
       shell: bash
-    - name: Set up Cloud SDK
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
     - name: Set env vars
       env:
         WORKFLOW: ${{ github.workflow }}
       run: |
-        echo "PROJECT_NAME=$(gcloud config get-value project)" >> $GITHUB_ENV
+        PROJECT_NAME=$(curl -s -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
+        echo "PROJECT_NAME=${PROJECT_NAME}" >> $GITHUB_ENV
         echo "GITHUB_RUN_NUMBER=${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
         echo "WORKFLOW=${WORKFLOW}" >> $GITHUB_ENV
 

--- a/.github/actions/on_host_test/action.yaml
+++ b/.github/actions/on_host_test/action.yaml
@@ -7,6 +7,8 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@v2
     - name: Configure Environment
       id: configure-environment
       shell: bash

--- a/.github/actions/on_host_test/action.yaml
+++ b/.github/actions/on_host_test/action.yaml
@@ -7,8 +7,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up Cloud SDK
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
     - name: Configure Environment
       id: configure-environment
       shell: bash
@@ -27,8 +25,8 @@ runs:
         WORKFLOW: ${{ github.workflow }}
       run: |
         set -x
-        PROJECT_NAME=$(gcloud config get-value project)
-        gsutil cp gs://${PROJECT_NAME}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}_${{matrix.config}}/${{matrix.platform}}_${{matrix.config}}.${ARCHIVE_EXTENSION} ${GITHUB_WORKSPACE}/out/tmp/${{matrix.platform}}_${{matrix.config}}.${ARCHIVE_EXTENSION}
+        PROJECT_NAME=$(curl -s -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
+        gcloud storage cp gs://${PROJECT_NAME}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}_${{matrix.config}}/${{matrix.platform}}_${{matrix.config}}.${ARCHIVE_EXTENSION} ${GITHUB_WORKSPACE}/out/tmp/${{matrix.platform}}_${{matrix.config}}.${ARCHIVE_EXTENSION}
     - name: Extract Archive
       shell: bash
       run: |
@@ -46,8 +44,8 @@ runs:
         WORKFLOW: ${{ github.workflow }}
       run: |
         set -x
-        PROJECT_NAME=$(gcloud config get-value project)
-        gsutil cp gs://${PROJECT_NAME}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}_${{matrix.config}}/${COBALT_EVERGREEN_LOADER}_${{matrix.config}}.${ARCHIVE_EXTENSION} ${GITHUB_WORKSPACE}/out/tmp/${COBALT_EVERGREEN_LOADER}_${{matrix.config}}.${ARCHIVE_EXTENSION}
+        PROJECT_NAME=$(curl -s -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
+        gcloud storage cp gs://${PROJECT_NAME}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}_${{matrix.config}}/${COBALT_EVERGREEN_LOADER}_${{matrix.config}}.${ARCHIVE_EXTENSION} ${GITHUB_WORKSPACE}/out/tmp/${COBALT_EVERGREEN_LOADER}_${{matrix.config}}.${ARCHIVE_EXTENSION}
     - name: Extract Evergreen loader Archive
       if: ${{ env.COBALT_EVERGREEN_LOADER != null && env.COBALT_EVERGREEN_LOADER != 'null' }}
       shell: bash

--- a/.github/actions/on_host_test/action.yaml
+++ b/.github/actions/on_host_test/action.yaml
@@ -7,8 +7,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v2
     - name: Configure Environment
       id: configure-environment
       shell: bash
@@ -27,7 +25,11 @@ runs:
         WORKFLOW: ${{ github.workflow }}
       run: |
         set -x
-        PROJECT_NAME=$(curl -s -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
+        PROJECT_NAME=$(curl --fail --connect-timeout 2 -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/project/project-id 2>/dev/null || gcloud config get-value project 2>/dev/null)
+        if [[ -z "${PROJECT_NAME}" ]]; then
+          echo "Failed to retrieve Google Cloud project ID"
+          exit 1
+        fi
         gcloud storage cp gs://${PROJECT_NAME}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}_${{matrix.config}}/${{matrix.platform}}_${{matrix.config}}.${ARCHIVE_EXTENSION} ${GITHUB_WORKSPACE}/out/tmp/${{matrix.platform}}_${{matrix.config}}.${ARCHIVE_EXTENSION}
     - name: Extract Archive
       shell: bash
@@ -46,7 +48,11 @@ runs:
         WORKFLOW: ${{ github.workflow }}
       run: |
         set -x
-        PROJECT_NAME=$(curl -s -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
+        PROJECT_NAME=$(curl --fail --connect-timeout 2 -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/project/project-id 2>/dev/null || gcloud config get-value project 2>/dev/null)
+        if [[ -z "${PROJECT_NAME}" ]]; then
+          echo "Failed to retrieve Google Cloud project ID"
+          exit 1
+        fi
         gcloud storage cp gs://${PROJECT_NAME}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}_${{matrix.config}}/${COBALT_EVERGREEN_LOADER}_${{matrix.config}}.${ARCHIVE_EXTENSION} ${GITHUB_WORKSPACE}/out/tmp/${COBALT_EVERGREEN_LOADER}_${{matrix.config}}.${ARCHIVE_EXTENSION}
     - name: Extract Evergreen loader Archive
       if: ${{ env.COBALT_EVERGREEN_LOADER != null && env.COBALT_EVERGREEN_LOADER != 'null' }}

--- a/.github/actions/on_host_test/action.yaml
+++ b/.github/actions/on_host_test/action.yaml
@@ -7,6 +7,9 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Set up Cloud SDK
+      if: runner.os == 'Windows'
+      uses: google-github-actions/setup-gcloud@f0990588f1e5b5af6827153b93673613abdc6ec7 # v2.1.1
     - name: Configure Environment
       id: configure-environment
       shell: bash

--- a/.github/actions/upload_nightly_artifacts/action.yaml
+++ b/.github/actions/upload_nightly_artifacts/action.yaml
@@ -3,6 +3,8 @@ description: Archives and uploads nightly artifacts to GCS bucket.
 runs:
   using: "composite"
   steps:
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@v2
     - name: Set env vars
       env:
         WORKFLOW: ${{github.workflow}}

--- a/.github/actions/upload_nightly_artifacts/action.yaml
+++ b/.github/actions/upload_nightly_artifacts/action.yaml
@@ -3,6 +3,9 @@ description: Archives and uploads nightly artifacts to GCS bucket.
 runs:
   using: "composite"
   steps:
+    - name: Set up Cloud SDK
+      if: runner.os == 'Windows'
+      uses: google-github-actions/setup-gcloud@f0990588f1e5b5af6827153b93673613abdc6ec7 # v2.1.1
     - name: Set env vars
       env:
         WORKFLOW: ${{github.workflow}}

--- a/.github/actions/upload_nightly_artifacts/action.yaml
+++ b/.github/actions/upload_nightly_artifacts/action.yaml
@@ -3,15 +3,14 @@ description: Archives and uploads nightly artifacts to GCS bucket.
 runs:
   using: "composite"
   steps:
-    - name: Set up Cloud SDK
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
     - name: Set env vars
       env:
         WORKFLOW: ${{github.workflow}}
       run: |
         echo "ARCHIVE_FILE=cobalt-${{matrix.platform}}_${{matrix.config}}.tar.gz" >> $GITHUB_ENV
         echo "ARCHIVE_PATH=$GITHUB_WORKSPACE/cobalt-${{matrix.platform}}_${{matrix.config}}.tar.gz" >> $GITHUB_ENV
-        echo "PROJECT_NAME=$(gcloud config get-value project)" >> $GITHUB_ENV
+        PROJECT_NAME=$(curl -s -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
+        echo "PROJECT_NAME=${PROJECT_NAME}" >> $GITHUB_ENV
         echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
         echo "GITHUB_RUN_NUMBER=${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
         echo "WORKFLOW=${WORKFLOW}" >> $GITHUB_ENV
@@ -36,4 +35,4 @@ runs:
       shell: bash
       run: |
         set -uex
-        gsutil -d cp "${ARCHIVE_PATH}" "gs://${PROJECT_NAME}-build-artifacts/${WORKFLOW}/${TODAY}/${GITHUB_RUN_NUMBER}/"
+        gcloud storage cp "${ARCHIVE_PATH}" "gs://${PROJECT_NAME}-build-artifacts/${WORKFLOW}/${TODAY}/${GITHUB_RUN_NUMBER}/"

--- a/.github/actions/upload_nightly_artifacts/action.yaml
+++ b/.github/actions/upload_nightly_artifacts/action.yaml
@@ -3,15 +3,17 @@ description: Archives and uploads nightly artifacts to GCS bucket.
 runs:
   using: "composite"
   steps:
-    - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v2
     - name: Set env vars
       env:
         WORKFLOW: ${{github.workflow}}
       run: |
         echo "ARCHIVE_FILE=cobalt-${{matrix.platform}}_${{matrix.config}}.tar.gz" >> $GITHUB_ENV
         echo "ARCHIVE_PATH=$GITHUB_WORKSPACE/cobalt-${{matrix.platform}}_${{matrix.config}}.tar.gz" >> $GITHUB_ENV
-        PROJECT_NAME=$(curl -s -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
+        PROJECT_NAME=$(curl --fail --connect-timeout 2 -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/project/project-id 2>/dev/null || gcloud config get-value project 2>/dev/null)
+        if [[ -z "${PROJECT_NAME}" ]]; then
+          echo "Failed to retrieve Google Cloud project ID"
+          exit 1
+        fi
         echo "PROJECT_NAME=${PROJECT_NAME}" >> $GITHUB_ENV
         echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
         echo "GITHUB_RUN_NUMBER=${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV

--- a/.github/actions/upload_test_artifacts/action.yaml
+++ b/.github/actions/upload_test_artifacts/action.yaml
@@ -10,14 +10,12 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up Cloud SDK
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
     - name: Configure Environment
       env:
         WORKFLOW: ${{ github.workflow }}
       run: |
         set -x
-        project_name=$(gcloud config get-value project)
+        project_name=$(curl -s -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
         if [ -z ${COBALT_EVERGREEN_LOADER+x} ]
         then
           PLATFORM=${{matrix.platform}}
@@ -47,7 +45,6 @@ runs:
         fi
 
         echo "PYTHONPATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
-        project_name=$(gcloud config get-value project)
       shell: bash
     - name: Create Test Files Archive
       run: |
@@ -75,4 +72,4 @@ runs:
       shell: bash
       run: |
         set -eux
-        gsutil -d cp "${ARCHIVE_PATH}" "gs://${DESTINATION}"
+        gcloud storage cp "${ARCHIVE_PATH}" "gs://${DESTINATION}"

--- a/.github/actions/upload_test_artifacts/action.yaml
+++ b/.github/actions/upload_test_artifacts/action.yaml
@@ -10,14 +10,16 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v2
     - name: Configure Environment
       env:
         WORKFLOW: ${{ github.workflow }}
       run: |
         set -x
-        project_name=$(curl -s -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
+        project_name=$(curl --fail --connect-timeout 2 -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/project/project-id 2>/dev/null || gcloud config get-value project 2>/dev/null)
+        if [[ -z "${project_name}" ]]; then
+          echo "Failed to retrieve Google Cloud project ID"
+          exit 1
+        fi
         if [ -z ${COBALT_EVERGREEN_LOADER+x} ]
         then
           PLATFORM=${{matrix.platform}}

--- a/.github/actions/upload_test_artifacts/action.yaml
+++ b/.github/actions/upload_test_artifacts/action.yaml
@@ -10,6 +10,9 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Set up Cloud SDK
+      if: runner.os == 'Windows'
+      uses: google-github-actions/setup-gcloud@f0990588f1e5b5af6827153b93673613abdc6ec7 # v2.1.1
     - name: Configure Environment
       env:
         WORKFLOW: ${{ github.workflow }}

--- a/.github/actions/upload_test_artifacts/action.yaml
+++ b/.github/actions/upload_test_artifacts/action.yaml
@@ -10,6 +10,8 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@v2
     - name: Configure Environment
       env:
         WORKFLOW: ${{ github.workflow }}

--- a/.github/config/evergreen-arm-softfp.json
+++ b/.github/config/evergreen-arm-softfp.json
@@ -1,5 +1,5 @@
 {
-  "docker_service": "build-android",
+  "docker_service": "build-android-evergreen",
   "evergreen_loader": "android-arm",
   "on_device_test": {
     "enabled": false,

--- a/.github/config/evergreen-arm-softfp.json
+++ b/.github/config/evergreen-arm-softfp.json
@@ -1,5 +1,5 @@
 {
-  "docker_service": "build-android-evergreen",
+  "docker_service": "build-android",
   "evergreen_loader": "android-arm",
   "on_device_test": {
     "enabled": false,

--- a/.github/config/evergreen-arm-softfp.json
+++ b/.github/config/evergreen-arm-softfp.json
@@ -1,5 +1,5 @@
 {
-  "docker_service": "build-android-evergreen",
+  "docker_service": "build-android",
   "evergreen_loader": "android-arm",
   "on_device_test": {
     "enabled": false,
@@ -17,30 +17,30 @@
   ],
   "includes": [
     {
-      "name":"sbversion-14",
-      "platform":"evergreen-arm-softfp-sbversion-14",
-      "target_platform":"evergreen-arm-softfp",
-      "target_cpu":"target_cpu=\\\"arm\\\"",
-      "extra_gn_arguments":"use_asan=false",
-      "sb_api_version":"14",
+      "name": "sbversion-14",
+      "platform": "evergreen-arm-softfp-sbversion-14",
+      "target_platform": "evergreen-arm-softfp",
+      "target_cpu": "target_cpu=\\\"arm\\\"",
+      "extra_gn_arguments": "use_asan=false",
+      "sb_api_version": "14",
       "evergreen_loader_extra_gn_arguments": "target_os=\\\"android\\\" sb_is_evergreen_compatible=true"
     },
     {
-      "name":"sbversion-15",
-      "platform":"evergreen-arm-softfp-sbversion-15",
-      "target_platform":"evergreen-arm-softfp",
-      "target_cpu":"target_cpu=\\\"arm\\\"",
-      "extra_gn_arguments":"use_asan=false",
-      "sb_api_version":"15",
+      "name": "sbversion-15",
+      "platform": "evergreen-arm-softfp-sbversion-15",
+      "target_platform": "evergreen-arm-softfp",
+      "target_cpu": "target_cpu=\\\"arm\\\"",
+      "extra_gn_arguments": "use_asan=false",
+      "sb_api_version": "15",
       "evergreen_loader_extra_gn_arguments": "target_os=\\\"android\\\" sb_is_evergreen_compatible=true"
     },
     {
-      "name":"sbversion-16",
-      "platform":"evergreen-arm-softfp-sbversion-16",
-      "target_platform":"evergreen-arm-softfp",
-      "target_cpu":"target_cpu=\\\"arm\\\"",
-      "extra_gn_arguments":"use_asan=false",
-      "sb_api_version":"16",
+      "name": "sbversion-16",
+      "platform": "evergreen-arm-softfp-sbversion-16",
+      "target_platform": "evergreen-arm-softfp",
+      "target_cpu": "target_cpu=\\\"arm\\\"",
+      "extra_gn_arguments": "use_asan=false",
+      "sb_api_version": "16",
       "evergreen_loader_extra_gn_arguments": "target_os=\\\"android\\\" sb_is_evergreen_compatible=true"
     }
   ]

--- a/.github/config/evergreen-arm64.json
+++ b/.github/config/evergreen-arm64.json
@@ -1,5 +1,5 @@
 {
-  "docker_service": "build-android-evergreen",
+  "docker_service": "build-android",
   "evergreen_loader": "android-arm64",
   "platforms": [
     "evergreen-arm64-sbversion-14",

--- a/.github/config/evergreen-arm64.json
+++ b/.github/config/evergreen-arm64.json
@@ -1,5 +1,5 @@
 {
-  "docker_service": "build-android",
+  "docker_service": "build-android-evergreen",
   "evergreen_loader": "android-arm64",
   "platforms": [
     "evergreen-arm64-sbversion-14",

--- a/.github/config/evergreen-arm64.json
+++ b/.github/config/evergreen-arm64.json
@@ -1,5 +1,5 @@
 {
-  "docker_service": "build-android-evergreen",
+  "docker_service": "build-android",
   "evergreen_loader": "android-arm64",
   "platforms": [
     "evergreen-arm64-sbversion-14",
@@ -8,30 +8,30 @@
   ],
   "includes": [
     {
-      "name":"sbversion-14",
-      "platform":"evergreen-arm64-sbversion-14",
-      "target_platform":"evergreen-arm64",
-      "target_cpu":"target_cpu=\\\"arm64\\\"",
-      "extra_gn_arguments":"use_asan=false",
-      "sb_api_version":"14",
+      "name": "sbversion-14",
+      "platform": "evergreen-arm64-sbversion-14",
+      "target_platform": "evergreen-arm64",
+      "target_cpu": "target_cpu=\\\"arm64\\\"",
+      "extra_gn_arguments": "use_asan=false",
+      "sb_api_version": "14",
       "evergreen_loader_extra_gn_arguments": "target_os=\\\"android\\\" sb_is_evergreen_compatible=true"
     },
     {
-      "name":"sbversion-15",
-      "platform":"evergreen-arm64-sbversion-15",
-      "target_platform":"evergreen-arm64",
-      "target_cpu":"target_cpu=\\\"arm64\\\"",
-      "extra_gn_arguments":"use_asan=false",
-      "sb_api_version":"15",
+      "name": "sbversion-15",
+      "platform": "evergreen-arm64-sbversion-15",
+      "target_platform": "evergreen-arm64",
+      "target_cpu": "target_cpu=\\\"arm64\\\"",
+      "extra_gn_arguments": "use_asan=false",
+      "sb_api_version": "15",
       "evergreen_loader_extra_gn_arguments": "target_os=\\\"android\\\" sb_is_evergreen_compatible=true"
     },
     {
-      "name":"sbversion-16",
-      "platform":"evergreen-arm64-sbversion-16",
-      "target_platform":"evergreen-arm64",
-      "target_cpu":"target_cpu=\\\"arm64\\\"",
-      "extra_gn_arguments":"use_asan=false",
-      "sb_api_version":"16",
+      "name": "sbversion-16",
+      "platform": "evergreen-arm64-sbversion-16",
+      "target_platform": "evergreen-arm64",
+      "target_cpu": "target_cpu=\\\"arm64\\\"",
+      "extra_gn_arguments": "use_asan=false",
+      "sb_api_version": "16",
       "evergreen_loader_extra_gn_arguments": "target_os=\\\"android\\\" sb_is_evergreen_compatible=true"
     }
   ]

--- a/.github/workflows/gradle_25.lts.1+.yaml
+++ b/.github/workflows/gradle_25.lts.1+.yaml
@@ -27,10 +27,7 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@ccb4328a959376b642e027874838f60f8e596de3 #v1.0.6
         with:
-          allow-list: |
-            c5a643cf80162e665cc228f7b16f343fef868e47d3a4836f62e18b7e17ac018a
-            3dc39ad650d40f6c029bd8ff605c6d95865d657dbfdeacdb079db0ddfffedf9f
-            96f793a18e056c23ffeec67c1f3bb8eccff5a4a407fc9ceac183527e7eedf4b6
+          allow-checksums: c5a643cf80162e665cc228f7b16f343fef868e47d3a4836f62e18b7e17ac018a,3dc39ad650d40f6c029bd8ff605c6d95865d657dbfdeacdb079db0ddfffedf9f,96f793a18e056c23ffeec67c1f3bb8eccff5a4a407fc9ceac183527e7eedf4b6
       - name: Build with Gradle
         uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629 #v2.4.2
         with:

--- a/.github/workflows/gradle_25.lts.1+.yaml
+++ b/.github/workflows/gradle_25.lts.1+.yaml
@@ -27,7 +27,10 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@ccb4328a959376b642e027874838f60f8e596de3 #v1.0.6
         with:
-          allow-checksums: c5a643cf80162e665cc228f7b16f343fef868e47d3a4836f62e18b7e17ac018a,3dc39ad650d40f6c029bd8ff605c6d95865d657dbfdeacdb079db0ddfffedf9f,96f793a18e056c23ffeec67c1f3bb8eccff5a4a407fc9ceac183527e7eedf4b6
+          allow-list: |
+            c5a643cf80162e665cc228f7b16f343fef868e47d3a4836f62e18b7e17ac018a
+            3dc39ad650d40f6c029bd8ff605c6d95865d657dbfdeacdb079db0ddfffedf9f
+            96f793a18e056c23ffeec67c1f3bb8eccff5a4a407fc9ceac183527e7eedf4b6
       - name: Build with Gradle
         uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629 #v2.4.2
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -151,7 +151,7 @@ jobs:
     runs-on: [self-hosted, linux-runner]
     permissions:
       packages: write
-    timeout-minutes: 60
+    timeout-minutes: 30
     steps:
       - name: Checkout files
         uses: kaidokert/checkout@v3.5.999
@@ -188,13 +188,13 @@ jobs:
     permissions:
       packages: write
     runs-on: [self-hosted, linux-runner]
-    timeout-minutes: 60
+    timeout-minutes: 30
     steps:
       - name: Checkout files
         uses: kaidokert/checkout@v3.5.999
         timeout-minutes: 30
         with:
-          fetch-depth: 0
+          fetch-depth: 2
           persist-credentials: false
       - name: Login to Docker Registry ${{env.REGISTRY}}
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -151,7 +151,7 @@ jobs:
     runs-on: [self-hosted, linux-runner]
     permissions:
       packages: write
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - name: Checkout files
         uses: kaidokert/checkout@v3.5.999
@@ -188,7 +188,7 @@ jobs:
     permissions:
       packages: write
     runs-on: [self-hosted, linux-runner]
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - name: Checkout files
         uses: kaidokert/checkout@v3.5.999

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -194,7 +194,7 @@ jobs:
         uses: kaidokert/checkout@v3.5.999
         timeout-minutes: 30
         with:
-          fetch-depth: 2
+          fetch-depth: 0
           persist-credentials: false
       - name: Login to Docker Registry ${{env.REGISTRY}}
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0

--- a/docker/linux/android/Dockerfile
+++ b/docker/linux/android/Dockerfile
@@ -21,6 +21,7 @@ RUN apt update -qqy \
         libxml2-dev \
         default-jdk \
         binutils-arm-linux-gnueabi \
+        binutils-aarch64-linux-gnu \
         g++-multilib \
     && /opt/clean-after-apt.sh
 

--- a/docker/linux/android/Dockerfile
+++ b/docker/linux/android/Dockerfile
@@ -15,12 +15,12 @@
 ARG FROM_IMAGE
 FROM ${FROM_IMAGE:-cobalt-build-base}
 
+# TODO: b/309157124 - add --no-install-recommends.
 RUN apt update -qqy \
-    && apt install -qqy --no-install-recommends \
+    && apt install -qqy \
         libxml2-dev \
-        default-jdk-headless \
+        default-jdk \
         binutils-arm-linux-gnueabi \
-        binutils-aarch64-linux-gnu \
         g++-multilib \
     && /opt/clean-after-apt.sh
 
@@ -47,7 +47,7 @@ RUN cd /tmp \
   && curl --silent -O -J  ${CMDLINE_URL} \
   && unzip ${TOOLS} -d ${ANDROID_SDK_ROOT} \
   && rm ${TOOLS} \
-  && echo yes | JAVA_TOOL_OPTIONS="-Xmx2g" ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager \
+  && echo yes | ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager \
       --sdk_root=${ANDROID_SDK_ROOT} \
     "build-tools;30.0.0" \
     "build-tools;31.0.0" \

--- a/docker/linux/android/Dockerfile
+++ b/docker/linux/android/Dockerfile
@@ -20,6 +20,7 @@ RUN apt update -qqy \
         libxml2-dev \
         default-jdk-headless \
         binutils-arm-linux-gnueabi \
+        binutils-aarch64-linux-gnu \
         g++-multilib \
     && /opt/clean-after-apt.sh
 

--- a/docker/linux/android/Dockerfile
+++ b/docker/linux/android/Dockerfile
@@ -46,7 +46,7 @@ RUN cd /tmp \
   && curl --silent -O -J  ${CMDLINE_URL} \
   && unzip ${TOOLS} -d ${ANDROID_SDK_ROOT} \
   && rm ${TOOLS} \
-  && echo yes | ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager \
+  && echo yes | JAVA_TOOL_OPTIONS="-Xmx2g" ${ANDROID_SDK_ROOT}/tools/bin/sdkmanager \
       --sdk_root=${ANDROID_SDK_ROOT} \
     "build-tools;30.0.0" \
     "build-tools;31.0.0" \

--- a/docker/linux/android/Dockerfile
+++ b/docker/linux/android/Dockerfile
@@ -15,11 +15,10 @@
 ARG FROM_IMAGE
 FROM ${FROM_IMAGE:-cobalt-build-base}
 
-# TODO: b/309157124 - add --no-install-recommends.
 RUN apt update -qqy \
-    && apt install -qqy \
+    && apt install -qqy --no-install-recommends \
         libxml2-dev \
-        default-jdk \
+        default-jdk-headless \
         binutils-arm-linux-gnueabi \
         g++-multilib \
     && /opt/clean-after-apt.sh

--- a/docker/linux/base/Dockerfile
+++ b/docker/linux/base/Dockerfile
@@ -14,7 +14,7 @@
 
 ARG BASE_OS
 ARG BASE_OS_TAG
-FROM ${BASE_OS:-gcr.io/cloud-marketplace-containers/google/debian11}:${BASE_OS_TAG:-latest}
+FROM ${BASE_OS:-marketplace.gcr.io/google/debian11}:${BASE_OS_TAG:-latest}
 
 COPY base/clean-after-apt.sh /opt/clean-after-apt.sh
 

--- a/docker/linux/base/Dockerfile
+++ b/docker/linux/base/Dockerfile
@@ -36,7 +36,7 @@ RUN apt update -qqy \
 ARG GCLOUD_VERSION=465.0.0
 ENV PATH="/opt/google-cloud-sdk/bin:${PATH}"
 RUN cd /tmp \
-    && curl -sSLf -O "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${GCLOUD_VERSION}-linux-x86_64.tar.gz" \
+    && curl -sSLf --connect-timeout 5 -O "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${GCLOUD_VERSION}-linux-x86_64.tar.gz" \
     && tar xf "google-cloud-cli-${GCLOUD_VERSION}-linux-x86_64.tar.gz" -C /opt \
     && rm "google-cloud-cli-${GCLOUD_VERSION}-linux-x86_64.tar.gz" \
     && gcloud --version

--- a/docker/linux/base/Dockerfile
+++ b/docker/linux/base/Dockerfile
@@ -14,7 +14,7 @@
 
 ARG BASE_OS
 ARG BASE_OS_TAG
-FROM ${BASE_OS:-marketplace.gcr.io/google/debian11}:${BASE_OS_TAG:-latest}
+FROM ${BASE_OS:-gcr.io/cloud-marketplace-containers/google/debian11}:${BASE_OS_TAG:-latest}
 
 COPY base/clean-after-apt.sh /opt/clean-after-apt.sh
 
@@ -32,5 +32,13 @@ RUN apt update -qqy \
         git ccache \
         curl xz-utils \
     && /opt/clean-after-apt.sh
+
+ARG GCLOUD_VERSION=465.0.0
+ENV PATH="/opt/google-cloud-sdk/bin:${PATH}"
+RUN cd /tmp \
+    && curl -sSLf -O "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${GCLOUD_VERSION}-linux-x86_64.tar.gz" \
+    && tar xf "google-cloud-cli-${GCLOUD_VERSION}-linux-x86_64.tar.gz" -C /opt \
+    && rm "google-cloud-cli-${GCLOUD_VERSION}-linux-x86_64.tar.gz" \
+    && gcloud --version
 
 CMD ["/usr/bin/python3","--version"]

--- a/docker/linux/base/build/Dockerfile
+++ b/docker/linux/base/build/Dockerfile
@@ -37,7 +37,7 @@ ENV NODE_VERSION 16.19.1
 RUN curl --silent -o- ${NVM_URL} \
   | base64 -d > /tmp/install.sh \
    && echo ${NVM_SHA256SUM} | sha256sum --check \
-   && . /tmp/install.sh
+   && bash /tmp/install.sh
 
 # === Pinned Node version to v16, as this is latest one that will work on
 # legacy Debian systems

--- a/docker/linux/base/build/Dockerfile
+++ b/docker/linux/base/build/Dockerfile
@@ -37,7 +37,7 @@ ENV NODE_VERSION 16.19.1
 RUN curl --silent -o- ${NVM_URL} \
   | base64 -d > /tmp/install.sh \
    && echo ${NVM_SHA256SUM} | sha256sum --check \
-   && bash /tmp/install.sh
+   && . /tmp/install.sh
 
 # === Pinned Node version to v16, as this is latest one that will work on
 # legacy Debian systems

--- a/docker/linux/unittest/Dockerfile
+++ b/docker/linux/unittest/Dockerfile
@@ -16,6 +16,10 @@ FROM cobalt-base
 
 ARG HOME=/root
 
+RUN echo deb http://deb.debian.org/debian-debug \
+    $(. /etc/os-release && echo "${VERSION_CODENAME}")-debug main \
+    >> /etc/apt/sources.list
+
 RUN apt update -qqy \
     && apt install -qqy --no-install-recommends \
         libasound2 \
@@ -33,6 +37,13 @@ RUN apt update -qqy \
         unzip \
         xauth \
         xvfb \
+        libasound2-dbgsym \
+        libegl1-dbgsym \
+        libgl1-mesa-dri-dbgsym \
+        libglapi-mesa-dbgsym \
+        libgles2-dbgsym \
+        libglx-mesa0-dbgsym \
+        libglx0-dbgsym \
     && /opt/clean-after-apt.sh
 
 COPY ./unittest/requirements.txt /opt/requirements.txt

--- a/docker/linux/unittest/Dockerfile
+++ b/docker/linux/unittest/Dockerfile
@@ -16,10 +16,6 @@ FROM cobalt-base
 
 ARG HOME=/root
 
-RUN echo deb http://deb.debian.org/debian-debug \
-    $(. /etc/os-release && echo "${VERSION_CODENAME}")-debug main \
-    >> /etc/apt/sources.list
-
 RUN apt update -qqy \
     && apt install -qqy --no-install-recommends \
         libasound2 \
@@ -37,13 +33,6 @@ RUN apt update -qqy \
         unzip \
         xauth \
         xvfb \
-        libasound2-dbgsym \
-        libegl1-dbgsym \
-        libgl1-mesa-dri-dbgsym \
-        libglapi-mesa-dbgsym \
-        libgles2-dbgsym \
-        libglx-mesa0-dbgsym \
-        libglx0-dbgsym \
     && /opt/clean-after-apt.sh
 
 COPY ./unittest/requirements.txt /opt/requirements.txt


### PR DESCRIPTION
Install Google Cloud SDK directly into docker/linux/base/Dockerfile into /opt/google-cloud-sdk with pinned version for containerized CI builds. Remove setup-gcloud action from composite actions and replace legacy gsutil invocations with gcloud storage.

Tag: agy
Conv: 70b5d567-b68d-4195-bdf1-c26cc84a47b8
Bug: 543494079