### PR TITLE
ci(24.lts): Install gcloud in base Docker image, remove setup-gcloud, use gcloud storage

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -7,7 +7,11 @@ runs:
       if: startsWith(${{matrix.target_platform}}, 'android')
       run: |
         echo "ANDROID_HOME=/root/starboard-toolchains/AndroidSdk/" >> $GITHUB_ENV
-        PROJECT_NAME=$(curl -sS -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
+        PROJECT_NAME=$(curl -sS -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id' 2>/dev/null || gcloud config get-value project 2>/dev/null)
+        if [ -z "${PROJECT_NAME}" ]; then
+          echo "PROJECT_NAME is empty or unset"
+          exit 1
+        fi
         echo "GCS_NIGHTLY_PATH=gs://${PROJECT_NAME}-build-artifacts" >> $GITHUB_ENV
       shell: bash
     - name: Build

--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -3,14 +3,11 @@ description: Builds Cobalt targets
 runs:
   using: "composite"
   steps:
-    - name: Set up Cloud SDK
-      if: startsWith(${{matrix.target_platform}}, 'android')
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
     - name: Set Android env vars
       if: startsWith(${{matrix.target_platform}}, 'android')
       run: |
         echo "ANDROID_HOME=/root/starboard-toolchains/AndroidSdk/" >> $GITHUB_ENV
-        PROJECT_NAME=$(gcloud config get-value project)
+        PROJECT_NAME=$(curl -sS -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
         echo "GCS_NIGHTLY_PATH=gs://${PROJECT_NAME}-build-artifacts" >> $GITHUB_ENV
       shell: bash
     - name: Build

--- a/.github/actions/docker/action.yaml
+++ b/.github/actions/docker/action.yaml
@@ -57,8 +57,12 @@ runs:
       if: ${{ (steps.changed-files.outputs.any_changed == 'true') && (github.event_name == 'pull_request') && (github.event.pull_request.head.repo.fork) }}
       run: |
         # Need to login to GCR to be able to push images created by fork based PR workflows.
-        PROJECT_NAME=$(curl -sS -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
-        METADATA="http://metadata.google.internal./computeMetadata/v1"
+        PROJECT_NAME=$(curl -sS -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id' 2>/dev/null || gcloud config get-value project 2>/dev/null)
+        if [ -z "${PROJECT_NAME}" ]; then
+          echo "PROJECT_NAME is empty or unset"
+          exit 1
+        fi
+        METADATA="http://metadata.google.internal/computeMetadata/v1"
         SVC_ACCT="${METADATA}/instance/service-accounts/default"
         ACCESS_TOKEN=$(curl -H 'Metadata-Flavor: Google' ${SVC_ACCT}/token | cut -d'"' -f 4)
         printf ${ACCESS_TOKEN} | docker login -u oauth2accesstoken --password-stdin https://gcr.io

--- a/.github/actions/docker/action.yaml
+++ b/.github/actions/docker/action.yaml
@@ -50,12 +50,6 @@ runs:
       if: ${{ (steps.changed-files.outputs.any_changed == 'false') && (github.event_name == 'pull_request') }}
       run: echo "DOCKER_TAG=ghcr.io/${REPO}/${{inputs.docker_image}}:${GITHUB_BASE_REF%.1+}" >> $GITHUB_ENV
       shell: bash
-    - name: Set up Cloud SDK
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
-    - name: Configure Docker auth for GCloud
-      shell: bash
-      run: |
-        gcloud auth configure-docker
     - name: Set Docker Tag
       id: set-docker-tag-presubmit-fork
       env:
@@ -63,7 +57,7 @@ runs:
       if: ${{ (steps.changed-files.outputs.any_changed == 'true') && (github.event_name == 'pull_request') && (github.event.pull_request.head.repo.fork) }}
       run: |
         # Need to login to GCR to be able to push images created by fork based PR workflows.
-        PROJECT_NAME=$(gcloud config get-value project)
+        PROJECT_NAME=$(curl -sS -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
         METADATA="http://metadata.google.internal./computeMetadata/v1"
         SVC_ACCT="${METADATA}/instance/service-accounts/default"
         ACCESS_TOKEN=$(curl -H 'Metadata-Flavor: Google' ${SVC_ACCT}/token | cut -d'"' -f 4)

--- a/.github/actions/gn/action.yaml
+++ b/.github/actions/gn/action.yaml
@@ -7,16 +7,13 @@ runs:
       shell: bash
       run: |
         echo "PYTHONPATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
-    - name: Set up Cloud SDK
-      if: startsWith(${{matrix.target_platform}}, 'android')
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
     - name: Configure Android Environment
       shell: bash
       if: startsWith(${{matrix.target_platform}}, 'android')
       run: |
         echo "ANDROID_HOME=/root/starboard-toolchains/AndroidSdk/" >> $GITHUB_ENV
         echo "COBALT_GRADLE_BUILD_COUNT=24" >> $GITHUB_ENV
-        PROJECT_NAME=$(gcloud config get-value project)
+        PROJECT_NAME=$(curl -sS -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
         echo "GCS_NIGHTLY_PATH=gs://${PROJECT_NAME}-build-artifacts" >> $GITHUB_ENV
     - name: GN
       run: |

--- a/.github/actions/gn/action.yaml
+++ b/.github/actions/gn/action.yaml
@@ -13,7 +13,11 @@ runs:
       run: |
         echo "ANDROID_HOME=/root/starboard-toolchains/AndroidSdk/" >> $GITHUB_ENV
         echo "COBALT_GRADLE_BUILD_COUNT=24" >> $GITHUB_ENV
-        PROJECT_NAME=$(curl -sS -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
+        PROJECT_NAME=$(curl -sS -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id' 2>/dev/null || gcloud config get-value project 2>/dev/null)
+        if [ -z "${PROJECT_NAME}" ]; then
+          echo "PROJECT_NAME is empty or unset"
+          exit 1
+        fi
         echo "GCS_NIGHTLY_PATH=gs://${PROJECT_NAME}-build-artifacts" >> $GITHUB_ENV
     - name: GN
       run: |

--- a/.github/actions/on_device_tests/action.yaml
+++ b/.github/actions/on_device_tests/action.yaml
@@ -17,11 +17,15 @@ runs:
       run: |
         python -m grpc_tools.protoc -Itools/ --python_out=tools/ --grpc_python_out=tools/ tools/on_device_tests_gateway.proto
       shell: bash
-    - name: Set Up Cloud SDK
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@f0990588f1e5b5af6827153b93673613abdc6ec7 # v2.1.1
     - name: Set env vars
       run: |
-        echo "PROJECT_NAME=$(gcloud config get-value project)" >> $GITHUB_ENV
+        PROJECT_NAME=$(gcloud config get-value project 2>/dev/null)
+        if [ -z "$PROJECT_NAME" ]; then
+          PROJECT_NAME=$(curl -sS -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
+        fi
+        echo "PROJECT_NAME=${PROJECT_NAME}" >> $GITHUB_ENV
 
         # Test results and logs
         echo "GCS_RESULTS_PATH=gs://cobalt-unittest-storage/results/${{ matrix.name }}/${{ github.run_id }}_${{ matrix.shard }}" >> $GITHUB_ENV
@@ -124,9 +128,9 @@ runs:
           COBALT_INFO_LOG_FILENAME="webDriverTestLog.INFO"
 
           # This command will fail until the results have been uploaded.
-          gsutil cp "${GCS_RESULTS_PATH}/${COBALT_ERROR_LOG_FILENAME}" .
-          gsutil cp "${GCS_RESULTS_PATH}/${COBALT_INFO_LOG_FILENAME}" .
-          gsutil cp "${GCS_RESULTS_PATH}/${COBALT_XMLS_FILENAME}" .
+          gcloud storage cp "${GCS_RESULTS_PATH}/${COBALT_ERROR_LOG_FILENAME}" .
+          gcloud storage cp "${GCS_RESULTS_PATH}/${COBALT_INFO_LOG_FILENAME}" .
+          gcloud storage cp "${GCS_RESULTS_PATH}/${COBALT_XMLS_FILENAME}" .
 
           # Break if all files were downloaded.
           if [[ -f "${COBALT_XMLS_FILENAME}" && -f "${COBALT_ERROR_LOG_FILENAME}" && -f "${COBALT_INFO_LOG_FILENAME}" ]]; then

--- a/.github/actions/on_device_tests/action.yaml
+++ b/.github/actions/on_device_tests/action.yaml
@@ -17,13 +17,12 @@ runs:
       run: |
         python -m grpc_tools.protoc -Itools/ --python_out=tools/ --grpc_python_out=tools/ tools/on_device_tests_gateway.proto
       shell: bash
-    - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@f0990588f1e5b5af6827153b93673613abdc6ec7 # v2.1.1
     - name: Set env vars
       run: |
-        PROJECT_NAME=$(gcloud config get-value project 2>/dev/null)
-        if [ -z "$PROJECT_NAME" ]; then
-          PROJECT_NAME=$(curl -sS -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
+        PROJECT_NAME=$(curl -sS -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id' 2>/dev/null || gcloud config get-value project 2>/dev/null)
+        if [ -z "${PROJECT_NAME}" ]; then
+          echo "PROJECT_NAME is empty or unset"
+          exit 1
         fi
         echo "PROJECT_NAME=${PROJECT_NAME}" >> $GITHUB_ENV
 

--- a/.github/actions/on_host_test/action.yaml
+++ b/.github/actions/on_host_test/action.yaml
@@ -7,9 +7,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up Cloud SDK
-      if: runner.os == 'Windows'
-      uses: google-github-actions/setup-gcloud@f0990588f1e5b5af6827153b93673613abdc6ec7 # v2.1.1
     - name: Configure Environment
       id: configure-environment
       shell: bash

--- a/.github/actions/on_host_test/action.yaml
+++ b/.github/actions/on_host_test/action.yaml
@@ -8,7 +8,8 @@ runs:
   using: "composite"
   steps:
     - name: Set up Cloud SDK
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
+      if: runner.os == 'Windows'
+      uses: google-github-actions/setup-gcloud@f0990588f1e5b5af6827153b93673613abdc6ec7 # v2.1.1
     - name: Configure Environment
       id: configure-environment
       shell: bash
@@ -27,8 +28,11 @@ runs:
         WORKFLOW: ${{ github.workflow }}
       run: |
         set -x
-        PROJECT_NAME=$(gcloud config get-value project)
-        gsutil cp gs://${PROJECT_NAME}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}_${{matrix.config}}/${{matrix.platform}}_${{matrix.config}}.${ARCHIVE_EXTENSION} ${GITHUB_WORKSPACE}/out/tmp/${{matrix.platform}}_${{matrix.config}}.${ARCHIVE_EXTENSION}
+        PROJECT_NAME=$(gcloud config get-value project 2>/dev/null)
+        if [ -z "$PROJECT_NAME" ]; then
+          PROJECT_NAME=$(curl -sS -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
+        fi
+        gcloud storage cp gs://${PROJECT_NAME}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}_${{matrix.config}}/${{matrix.platform}}_${{matrix.config}}.${ARCHIVE_EXTENSION} ${GITHUB_WORKSPACE}/out/tmp/${{matrix.platform}}_${{matrix.config}}.${ARCHIVE_EXTENSION}
     - name: Extract Archive
       shell: bash
       run: |
@@ -46,8 +50,11 @@ runs:
         WORKFLOW: ${{ github.workflow }}
       run: |
         set -x
-        PROJECT_NAME=$(gcloud config get-value project)
-        gsutil cp gs://${PROJECT_NAME}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}_${{matrix.config}}/${COBALT_EVERGREEN_LOADER}_${{matrix.config}}.${ARCHIVE_EXTENSION} ${GITHUB_WORKSPACE}/out/tmp/${COBALT_EVERGREEN_LOADER}_${{matrix.config}}.${ARCHIVE_EXTENSION}
+        PROJECT_NAME=$(gcloud config get-value project 2>/dev/null)
+        if [ -z "$PROJECT_NAME" ]; then
+          PROJECT_NAME=$(curl -sS -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
+        fi
+        gcloud storage cp gs://${PROJECT_NAME}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}_${{matrix.config}}/${COBALT_EVERGREEN_LOADER}_${{matrix.config}}.${ARCHIVE_EXTENSION} ${GITHUB_WORKSPACE}/out/tmp/${COBALT_EVERGREEN_LOADER}_${{matrix.config}}.${ARCHIVE_EXTENSION}
     - name: Extract Evergreen loader Archive
       if: ${{ env.COBALT_EVERGREEN_LOADER != null && env.COBALT_EVERGREEN_LOADER != 'null' }}
       shell: bash

--- a/.github/actions/on_host_test/action.yaml
+++ b/.github/actions/on_host_test/action.yaml
@@ -28,9 +28,10 @@ runs:
         WORKFLOW: ${{ github.workflow }}
       run: |
         set -x
-        PROJECT_NAME=$(gcloud config get-value project 2>/dev/null)
-        if [ -z "$PROJECT_NAME" ]; then
-          PROJECT_NAME=$(curl -sS -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
+        PROJECT_NAME=$(curl -sS -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id' 2>/dev/null || gcloud config get-value project 2>/dev/null)
+        if [ -z "${PROJECT_NAME}" ]; then
+          echo "PROJECT_NAME is empty or unset"
+          exit 1
         fi
         gcloud storage cp gs://${PROJECT_NAME}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}_${{matrix.config}}/${{matrix.platform}}_${{matrix.config}}.${ARCHIVE_EXTENSION} ${GITHUB_WORKSPACE}/out/tmp/${{matrix.platform}}_${{matrix.config}}.${ARCHIVE_EXTENSION}
     - name: Extract Archive
@@ -50,9 +51,10 @@ runs:
         WORKFLOW: ${{ github.workflow }}
       run: |
         set -x
-        PROJECT_NAME=$(gcloud config get-value project 2>/dev/null)
-        if [ -z "$PROJECT_NAME" ]; then
-          PROJECT_NAME=$(curl -sS -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
+        PROJECT_NAME=$(curl -sS -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id' 2>/dev/null || gcloud config get-value project 2>/dev/null)
+        if [ -z "${PROJECT_NAME}" ]; then
+          echo "PROJECT_NAME is empty or unset"
+          exit 1
         fi
         gcloud storage cp gs://${PROJECT_NAME}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}_${{matrix.config}}/${COBALT_EVERGREEN_LOADER}_${{matrix.config}}.${ARCHIVE_EXTENSION} ${GITHUB_WORKSPACE}/out/tmp/${COBALT_EVERGREEN_LOADER}_${{matrix.config}}.${ARCHIVE_EXTENSION}
     - name: Extract Evergreen loader Archive

--- a/.github/actions/on_host_test/action.yaml
+++ b/.github/actions/on_host_test/action.yaml
@@ -7,6 +7,9 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Set up Cloud SDK
+      if: runner.os == 'Windows'
+      uses: google-github-actions/setup-gcloud@f0990588f1e5b5af6827153b93673613abdc6ec7 # v2.1.1
     - name: Configure Environment
       id: configure-environment
       shell: bash

--- a/.github/actions/upload_nightly_artifacts/action.yaml
+++ b/.github/actions/upload_nightly_artifacts/action.yaml
@@ -12,9 +12,10 @@ runs:
       run: |
         echo "ARCHIVE_FILE=cobalt-${{matrix.platform}}_${{matrix.config}}.tar.gz" >> $GITHUB_ENV
         echo "ARCHIVE_PATH=$GITHUB_WORKSPACE/cobalt-${{matrix.platform}}_${{matrix.config}}.tar.gz" >> $GITHUB_ENV
-        PROJECT_NAME=$(gcloud config get-value project 2>/dev/null)
-        if [ -z "$PROJECT_NAME" ]; then
-          PROJECT_NAME=$(curl -sS -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
+        PROJECT_NAME=$(curl -sS -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id' 2>/dev/null || gcloud config get-value project 2>/dev/null)
+        if [ -z "${PROJECT_NAME}" ]; then
+          echo "PROJECT_NAME is empty or unset"
+          exit 1
         fi
         echo "PROJECT_NAME=${PROJECT_NAME}" >> $GITHUB_ENV
         echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV

--- a/.github/actions/upload_nightly_artifacts/action.yaml
+++ b/.github/actions/upload_nightly_artifacts/action.yaml
@@ -3,6 +3,9 @@ description: Archives and uploads nightly artifacts to GCS bucket.
 runs:
   using: "composite"
   steps:
+    - name: Set up Cloud SDK
+      if: runner.os == 'Windows'
+      uses: google-github-actions/setup-gcloud@f0990588f1e5b5af6827153b93673613abdc6ec7 # v2.1.1
     - name: Set env vars
       env:
         WORKFLOW: ${{github.workflow}}

--- a/.github/actions/upload_nightly_artifacts/action.yaml
+++ b/.github/actions/upload_nightly_artifacts/action.yaml
@@ -4,14 +4,19 @@ runs:
   using: "composite"
   steps:
     - name: Set up Cloud SDK
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
+      if: runner.os == 'Windows'
+      uses: google-github-actions/setup-gcloud@f0990588f1e5b5af6827153b93673613abdc6ec7 # v2.1.1
     - name: Set env vars
       env:
         WORKFLOW: ${{github.workflow}}
       run: |
         echo "ARCHIVE_FILE=cobalt-${{matrix.platform}}_${{matrix.config}}.tar.gz" >> $GITHUB_ENV
         echo "ARCHIVE_PATH=$GITHUB_WORKSPACE/cobalt-${{matrix.platform}}_${{matrix.config}}.tar.gz" >> $GITHUB_ENV
-        echo "PROJECT_NAME=$(gcloud config get-value project)" >> $GITHUB_ENV
+        PROJECT_NAME=$(gcloud config get-value project 2>/dev/null)
+        if [ -z "$PROJECT_NAME" ]; then
+          PROJECT_NAME=$(curl -sS -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
+        fi
+        echo "PROJECT_NAME=${PROJECT_NAME}" >> $GITHUB_ENV
         echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
         echo "GITHUB_RUN_NUMBER=${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
         echo "WORKFLOW=${WORKFLOW}" >> $GITHUB_ENV
@@ -36,4 +41,4 @@ runs:
       shell: bash
       run: |
         set -uex
-        gsutil -d cp "${ARCHIVE_PATH}" "gs://${PROJECT_NAME}-build-artifacts/${WORKFLOW}/${TODAY}/${GITHUB_RUN_NUMBER}/"
+        gcloud storage cp "${ARCHIVE_PATH}" "gs://${PROJECT_NAME}-build-artifacts/${WORKFLOW}/${TODAY}/${GITHUB_RUN_NUMBER}/"

--- a/.github/actions/upload_nightly_artifacts/action.yaml
+++ b/.github/actions/upload_nightly_artifacts/action.yaml
@@ -3,9 +3,6 @@ description: Archives and uploads nightly artifacts to GCS bucket.
 runs:
   using: "composite"
   steps:
-    - name: Set up Cloud SDK
-      if: runner.os == 'Windows'
-      uses: google-github-actions/setup-gcloud@f0990588f1e5b5af6827153b93673613abdc6ec7 # v2.1.1
     - name: Set env vars
       env:
         WORKFLOW: ${{github.workflow}}

--- a/.github/actions/upload_test_artifacts/action.yaml
+++ b/.github/actions/upload_test_artifacts/action.yaml
@@ -11,13 +11,17 @@ runs:
   using: "composite"
   steps:
     - name: Set up Cloud SDK
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
+      if: runner.os == 'Windows'
+      uses: google-github-actions/setup-gcloud@f0990588f1e5b5af6827153b93673613abdc6ec7 # v2.1.1
     - name: Configure Environment
       env:
         WORKFLOW: ${{ github.workflow }}
       run: |
         set -x
-        project_name=$(gcloud config get-value project)
+        project_name=$(gcloud config get-value project 2>/dev/null)
+        if [ -z "$project_name" ]; then
+          project_name=$(curl -sS -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
+        fi
         if [ -z ${COBALT_EVERGREEN_LOADER+x} ]
         then
           PLATFORM=${{matrix.platform}}
@@ -47,7 +51,6 @@ runs:
         fi
 
         echo "PYTHONPATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
-        project_name=$(gcloud config get-value project)
       shell: bash
     - name: Create Test Files Archive
       run: |
@@ -75,4 +78,4 @@ runs:
       shell: bash
       run: |
         set -eux
-        gsutil -d cp "${ARCHIVE_PATH}" "gs://${DESTINATION}"
+        gcloud storage cp "${ARCHIVE_PATH}" "gs://${DESTINATION}"

--- a/.github/actions/upload_test_artifacts/action.yaml
+++ b/.github/actions/upload_test_artifacts/action.yaml
@@ -10,6 +10,9 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Set up Cloud SDK
+      if: runner.os == 'Windows'
+      uses: google-github-actions/setup-gcloud@f0990588f1e5b5af6827153b93673613abdc6ec7 # v2.1.1
     - name: Configure Environment
       env:
         WORKFLOW: ${{ github.workflow }}

--- a/.github/actions/upload_test_artifacts/action.yaml
+++ b/.github/actions/upload_test_artifacts/action.yaml
@@ -10,9 +10,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up Cloud SDK
-      if: runner.os == 'Windows'
-      uses: google-github-actions/setup-gcloud@f0990588f1e5b5af6827153b93673613abdc6ec7 # v2.1.1
     - name: Configure Environment
       env:
         WORKFLOW: ${{ github.workflow }}

--- a/.github/actions/upload_test_artifacts/action.yaml
+++ b/.github/actions/upload_test_artifacts/action.yaml
@@ -18,9 +18,10 @@ runs:
         WORKFLOW: ${{ github.workflow }}
       run: |
         set -x
-        project_name=$(gcloud config get-value project 2>/dev/null)
-        if [ -z "$project_name" ]; then
-          project_name=$(curl -sS -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
+        project_name=$(curl -sS -f --connect-timeout 5 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id' 2>/dev/null || gcloud config get-value project 2>/dev/null)
+        if [ -z "${project_name}" ]; then
+          echo "project_name is empty or unset"
+          exit 1
         fi
         if [ -z ${COBALT_EVERGREEN_LOADER+x} ]
         then

--- a/docker/linux/base/Dockerfile
+++ b/docker/linux/base/Dockerfile
@@ -14,7 +14,7 @@
 
 ARG BASE_OS
 ARG BASE_OS_TAG
-FROM ${BASE_OS:-marketplace.gcr.io/google/debian10}:${BASE_OS_TAG:-latest}
+FROM ${BASE_OS:-gcr.io/cloud-marketplace-containers/google/debian10}:${BASE_OS_TAG:-latest}
 
 COPY base/clean-after-apt.sh /opt/clean-after-apt.sh
 
@@ -36,5 +36,14 @@ RUN apt update -qqy \
         git ccache \
         curl xz-utils \
     && /opt/clean-after-apt.sh
+
+ARG GCLOUD=google-cloud-cli-412.0.0-linux-x86_64.tar.gz
+RUN cd /tmp \
+    && curl -sSLf -O "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${GCLOUD}" \
+    && tar xf "${GCLOUD}" -C /usr/local \
+    && rm "${GCLOUD}" \
+    && ln -s /usr/local/google-cloud-sdk/bin/gcloud /usr/local/bin/gcloud \
+    && ln -s /usr/local/google-cloud-sdk/bin/gsutil /usr/local/bin/gsutil \
+    && gcloud --version
 
 CMD ["/usr/bin/python","--version"]


### PR DESCRIPTION
Install Google Cloud SDK directly into docker/linux/base/Dockerfile for containerized CI builds. Remove setup-gcloud action from Linux composite actions and retain setup-gcloud for Windows/host runners, replacing legacy gsutil invocations with gcloud storage. Update default base image repository to gcr.io/cloud-marketplace-containers/google/debian10.

Tag: agy
Conv: 70b5d567-b68d-4195-bdf1-c26cc84a47b8
Bug: 543494079