### PR TITLE
ci(22.lts): Install gcloud in base Docker image, remove setup-gcloud, use gcloud storage

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -7,14 +7,11 @@ runs:
       shell: bash
       run: |
         echo "PYTHONPATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
-    - name: Set up Cloud SDK
-      if: startsWith(${{matrix.target_platform}}, 'android')
-      uses: google-github-actions/setup-gcloud@v1
     - name: Set Android env vars
       if: startsWith(${{matrix.target_platform}}, 'android')
       run: |
         echo "COBALT_GRADLE_BUILD_COUNT=4" >> $GITHUB_ENV
-        PROJECT_NAME=$(gcloud config get-value project)
+        PROJECT_NAME=$(curl -s -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
         echo "GCS_NIGHTLY_PATH=gs://${PROJECT_NAME}-build-artifacts" >> $GITHUB_ENV
       shell: bash
     - name: Build

--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -11,7 +11,7 @@ runs:
       if: startsWith(${{matrix.target_platform}}, 'android')
       run: |
         echo "COBALT_GRADLE_BUILD_COUNT=4" >> $GITHUB_ENV
-        PROJECT_NAME=$(curl -s -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
+        PROJECT_NAME=$(curl -s --connect-timeout 2 -m 10 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
         echo "GCS_NIGHTLY_PATH=gs://${PROJECT_NAME}-build-artifacts" >> $GITHUB_ENV
       shell: bash
     - name: Build

--- a/.github/actions/docker/action.yaml
+++ b/.github/actions/docker/action.yaml
@@ -53,10 +53,10 @@ runs:
       if: ${{ (steps.changed-files.outputs.any_changed == 'true') && (github.event_name == 'pull_request') && (github.event.pull_request.head.repo.fork) }}
       run: |
         # Need to login to GCR to be able to push images created by fork based PR workflows.
-        PROJECT_NAME=$(curl -s -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
+        PROJECT_NAME=$(curl -s --connect-timeout 2 -m 10 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
         METADATA="http://metadata.google.internal./computeMetadata/v1"
         SVC_ACCT="${METADATA}/instance/service-accounts/default"
-        ACCESS_TOKEN=$(curl -H 'Metadata-Flavor: Google' ${SVC_ACCT}/token | cut -d'"' -f 4)
+        ACCESS_TOKEN=$(curl -s --connect-timeout 2 -m 10 -H 'Metadata-Flavor: Google' ${SVC_ACCT}/token | cut -d'"' -f 4)
         printf ${ACCESS_TOKEN} | docker login -u oauth2accesstoken --password-stdin https://gcr.io
         echo "DOCKER_TAG=gcr.io/${PROJECT_NAME}/${{inputs.docker_image}}:pr-${GITHUB_EVENT_NUMBER}" >> $GITHUB_ENV
       shell: bash
@@ -65,7 +65,7 @@ runs:
       run: |
         METADATA="http://metadata.google.internal./computeMetadata/v1"
         SVC_ACCT="${METADATA}/instance/service-accounts/default"
-        ACCESS_TOKEN=$(curl -s -f -H 'Metadata-Flavor: Google' ${SVC_ACCT}/token 2>/dev/null | cut -d'"' -f 4 || true)
+        ACCESS_TOKEN=$(curl -s -f --connect-timeout 2 -m 10 -H 'Metadata-Flavor: Google' ${SVC_ACCT}/token 2>/dev/null | cut -d'"' -f 4 || true)
         if [[ -n "${ACCESS_TOKEN}" ]]; then
           printf ${ACCESS_TOKEN} | docker login -u oauth2accesstoken --password-stdin https://marketplace.gcr.io || true
         fi

--- a/.github/actions/docker/action.yaml
+++ b/.github/actions/docker/action.yaml
@@ -46,12 +46,6 @@ runs:
       if: ${{ (steps.changed-files.outputs.any_changed == 'false') && (github.event_name == 'pull_request') }}
       run: echo "DOCKER_TAG=ghcr.io/${REPO}/${{inputs.docker_image}}:${GITHUB_BASE_REF%.1+}" >> $GITHUB_ENV
       shell: bash
-    - name: Set up Cloud SDK
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
-    - name: Configure Docker auth for GCloud
-      shell: bash
-      run: |
-        gcloud auth configure-docker
     - name: Set Docker Tag
       id: set-docker-tag-presubmit-fork
       env:
@@ -59,12 +53,22 @@ runs:
       if: ${{ (steps.changed-files.outputs.any_changed == 'true') && (github.event_name == 'pull_request') && (github.event.pull_request.head.repo.fork) }}
       run: |
         # Need to login to GCR to be able to push images created by fork based PR workflows.
-        PROJECT_NAME=$(gcloud config get-value project)
+        PROJECT_NAME=$(curl -s -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
         METADATA="http://metadata.google.internal./computeMetadata/v1"
         SVC_ACCT="${METADATA}/instance/service-accounts/default"
         ACCESS_TOKEN=$(curl -H 'Metadata-Flavor: Google' ${SVC_ACCT}/token | cut -d'"' -f 4)
         printf ${ACCESS_TOKEN} | docker login -u oauth2accesstoken --password-stdin https://gcr.io
         echo "DOCKER_TAG=gcr.io/${PROJECT_NAME}/${{inputs.docker_image}}:pr-${GITHUB_EVENT_NUMBER}" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Login to Marketplace GCR
+      run: |
+        METADATA="http://metadata.google.internal./computeMetadata/v1"
+        SVC_ACCT="${METADATA}/instance/service-accounts/default"
+        ACCESS_TOKEN=$(curl -s -f -H 'Metadata-Flavor: Google' ${SVC_ACCT}/token 2>/dev/null | cut -d'"' -f 4 || true)
+        if [[ -n "${ACCESS_TOKEN}" ]]; then
+          printf ${ACCESS_TOKEN} | docker login -u oauth2accesstoken --password-stdin https://marketplace.gcr.io || true
+        fi
       shell: bash
     - name: Process Docker metadata
       id: process-docker-metadata

--- a/.github/actions/on_host_test/action.yaml
+++ b/.github/actions/on_host_test/action.yaml
@@ -15,6 +15,7 @@ runs:
         WORKFLOW: ${{ github.workflow }}
       run: |
         set -x
+        gcloud config set storage/check_hashes never
         PROJECT_NAME=$(curl -s --connect-timeout 2 -m 10 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
         gcloud storage cp gs://${PROJECT_NAME}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}_${{matrix.config}}/${{matrix.platform}}_${{matrix.config}}.${ARCHIVE_EXTENSION} ${GITHUB_WORKSPACE}/out/tmp/${{matrix.platform}}_${{matrix.config}}.${ARCHIVE_EXTENSION}
     - name: Extract Archive
@@ -30,6 +31,7 @@ runs:
         WORKFLOW: ${{ github.workflow }}
       run: |
         set -x
+        gcloud config set storage/check_hashes never
         PROJECT_NAME=$(curl -s --connect-timeout 2 -m 10 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
         gcloud storage cp gs://${PROJECT_NAME}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}_${{matrix.config}}/${COBALT_BOOTLOADER}_${{matrix.config}}.${ARCHIVE_EXTENSION} ${GITHUB_WORKSPACE}/out/tmp/${COBALT_BOOTLOADER}_${{matrix.config}}.${ARCHIVE_EXTENSION}
     - name: Extract Bootloader Archive

--- a/.github/actions/on_host_test/action.yaml
+++ b/.github/actions/on_host_test/action.yaml
@@ -15,7 +15,7 @@ runs:
         WORKFLOW: ${{ github.workflow }}
       run: |
         set -x
-        PROJECT_NAME=$(curl -s -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
+        PROJECT_NAME=$(curl -s --connect-timeout 2 -m 10 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
         gcloud storage cp gs://${PROJECT_NAME}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}_${{matrix.config}}/${{matrix.platform}}_${{matrix.config}}.${ARCHIVE_EXTENSION} ${GITHUB_WORKSPACE}/out/tmp/${{matrix.platform}}_${{matrix.config}}.${ARCHIVE_EXTENSION}
     - name: Extract Archive
       shell: bash
@@ -30,7 +30,7 @@ runs:
         WORKFLOW: ${{ github.workflow }}
       run: |
         set -x
-        PROJECT_NAME=$(curl -s -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
+        PROJECT_NAME=$(curl -s --connect-timeout 2 -m 10 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
         gcloud storage cp gs://${PROJECT_NAME}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}_${{matrix.config}}/${COBALT_BOOTLOADER}_${{matrix.config}}.${ARCHIVE_EXTENSION} ${GITHUB_WORKSPACE}/out/tmp/${COBALT_BOOTLOADER}_${{matrix.config}}.${ARCHIVE_EXTENSION}
     - name: Extract Bootloader Archive
       if: ${{ env.COBALT_BOOTLOADER != null && env.COBALT_BOOTLOADER != 'null' }}

--- a/.github/actions/on_host_test/action.yaml
+++ b/.github/actions/on_host_test/action.yaml
@@ -3,8 +3,6 @@ description: Runs on-host tests.
 runs:
   using: "composite"
   steps:
-    - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v0.6.0
     - name: Configure Environment
       id: configure-environment
       shell: bash
@@ -17,8 +15,8 @@ runs:
         WORKFLOW: ${{ github.workflow }}
       run: |
         set -x
-        PROJECT_NAME=$(gcloud config get-value project)
-        gsutil cp gs://${PROJECT_NAME}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}_${{matrix.config}}/${{matrix.platform}}_${{matrix.config}}.${ARCHIVE_EXTENSION} ${GITHUB_WORKSPACE}/out/tmp/${{matrix.platform}}_${{matrix.config}}.${ARCHIVE_EXTENSION}
+        PROJECT_NAME=$(curl -s -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
+        gcloud storage cp gs://${PROJECT_NAME}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}_${{matrix.config}}/${{matrix.platform}}_${{matrix.config}}.${ARCHIVE_EXTENSION} ${GITHUB_WORKSPACE}/out/tmp/${{matrix.platform}}_${{matrix.config}}.${ARCHIVE_EXTENSION}
     - name: Extract Archive
       shell: bash
       run: |
@@ -32,8 +30,8 @@ runs:
         WORKFLOW: ${{ github.workflow }}
       run: |
         set -x
-        PROJECT_NAME=$(gcloud config get-value project)
-        gsutil cp gs://${PROJECT_NAME}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}_${{matrix.config}}/${COBALT_BOOTLOADER}_${{matrix.config}}.${ARCHIVE_EXTENSION} ${GITHUB_WORKSPACE}/out/tmp/${COBALT_BOOTLOADER}_${{matrix.config}}.${ARCHIVE_EXTENSION}
+        PROJECT_NAME=$(curl -s -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
+        gcloud storage cp gs://${PROJECT_NAME}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}_${{matrix.config}}/${COBALT_BOOTLOADER}_${{matrix.config}}.${ARCHIVE_EXTENSION} ${GITHUB_WORKSPACE}/out/tmp/${COBALT_BOOTLOADER}_${{matrix.config}}.${ARCHIVE_EXTENSION}
     - name: Extract Bootloader Archive
       if: ${{ env.COBALT_BOOTLOADER != null && env.COBALT_BOOTLOADER != 'null' }}
       shell: bash

--- a/.github/actions/upload_nightly_artifacts/action.yaml
+++ b/.github/actions/upload_nightly_artifacts/action.yaml
@@ -9,7 +9,7 @@ runs:
       run: |
         echo "ARCHIVE_FILE=cobalt-${{matrix.platform}}_${{matrix.config}}.tar.gz" >> $GITHUB_ENV
         echo "ARCHIVE_PATH=$GITHUB_WORKSPACE/cobalt-${{matrix.platform}}_${{matrix.config}}.tar.gz" >> $GITHUB_ENV
-        echo "PROJECT_NAME=$(curl -s -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')" >> $GITHUB_ENV
+        echo "PROJECT_NAME=$(curl -s --connect-timeout 2 -m 10 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')" >> $GITHUB_ENV
         echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
         echo "GITHUB_RUN_NUMBER=${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
         echo "WORKFLOW=${WORKFLOW}" >> $GITHUB_ENV

--- a/.github/actions/upload_nightly_artifacts/action.yaml
+++ b/.github/actions/upload_nightly_artifacts/action.yaml
@@ -3,15 +3,13 @@ description: Archives and uploads nightly artifacts to GCS bucket.
 runs:
   using: "composite"
   steps:
-    - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v0.6.2
     - name: Set env vars
       env:
         WORKFLOW: ${{github.workflow}}
       run: |
         echo "ARCHIVE_FILE=cobalt-${{matrix.platform}}_${{matrix.config}}.tar.gz" >> $GITHUB_ENV
         echo "ARCHIVE_PATH=$GITHUB_WORKSPACE/cobalt-${{matrix.platform}}_${{matrix.config}}.tar.gz" >> $GITHUB_ENV
-        echo "PROJECT_NAME=$(gcloud config get-value project)" >> $GITHUB_ENV
+        echo "PROJECT_NAME=$(curl -s -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')" >> $GITHUB_ENV
         echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
         echo "GITHUB_RUN_NUMBER=${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
         echo "WORKFLOW=${WORKFLOW}" >> $GITHUB_ENV
@@ -35,4 +33,4 @@ runs:
       shell: bash
       run: |
         set -uex
-        gsutil -d cp "${ARCHIVE_PATH}" "gs://${PROJECT_NAME}-build-artifacts/${WORKFLOW}/${TODAY}/${GITHUB_RUN_NUMBER}/"
+        gcloud storage cp "${ARCHIVE_PATH}" "gs://${PROJECT_NAME}-build-artifacts/${WORKFLOW}/${TODAY}/${GITHUB_RUN_NUMBER}/"

--- a/.github/actions/upload_nightly_artifacts/action.yaml
+++ b/.github/actions/upload_nightly_artifacts/action.yaml
@@ -33,4 +33,5 @@ runs:
       shell: bash
       run: |
         set -uex
+        gcloud config set storage/check_hashes never
         gcloud storage cp "${ARCHIVE_PATH}" "gs://${PROJECT_NAME}-build-artifacts/${WORKFLOW}/${TODAY}/${GITHUB_RUN_NUMBER}/"

--- a/.github/actions/upload_test_artifacts/action.yaml
+++ b/.github/actions/upload_test_artifacts/action.yaml
@@ -12,7 +12,7 @@ runs:
         WORKFLOW: ${{ github.workflow }}
       run: |
         set -x
-        project_name=$(curl -s -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
+        project_name=$(curl -s --connect-timeout 2 -m 10 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
         if [ -z ${COBALT_BOOTLOADER+x} ]
         then
           PLATFORM=${{matrix.platform}}
@@ -34,7 +34,6 @@ runs:
           echo "DESTINATION=${project_name}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}_${{matrix.config}}/" >> $GITHUB_ENV
         fi
         echo "PYTHONPATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
-        project_name=$(curl -s -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
       shell: bash
     - name: Create Test Files Archive
       run: |

--- a/.github/actions/upload_test_artifacts/action.yaml
+++ b/.github/actions/upload_test_artifacts/action.yaml
@@ -57,4 +57,5 @@ runs:
       shell: bash
       run: |
         set -eux
+        gcloud config set storage/check_hashes never
         gcloud storage cp "${ARCHIVE_PATH}" "gs://${DESTINATION}"

--- a/.github/actions/upload_test_artifacts/action.yaml
+++ b/.github/actions/upload_test_artifacts/action.yaml
@@ -7,14 +7,12 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v0.6.2
     - name: Configure Environment
       env:
         WORKFLOW: ${{ github.workflow }}
       run: |
         set -x
-        project_name=$(gcloud config get-value project)
+        project_name=$(curl -s -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
         if [ -z ${COBALT_BOOTLOADER+x} ]
         then
           PLATFORM=${{matrix.platform}}
@@ -36,7 +34,7 @@ runs:
           echo "DESTINATION=${project_name}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}_${{matrix.config}}/" >> $GITHUB_ENV
         fi
         echo "PYTHONPATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
-        project_name=$(gcloud config get-value project)
+        project_name=$(curl -s -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')
       shell: bash
     - name: Create Test Files Archive
       run: |
@@ -60,4 +58,4 @@ runs:
       shell: bash
       run: |
         set -eux
-        gsutil -d cp "${ARCHIVE_PATH}" "gs://${DESTINATION}"
+        gcloud storage cp "${ARCHIVE_PATH}" "gs://${DESTINATION}"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -194,7 +194,7 @@ jobs:
         shell: bash
       - name: Set env vars
         run: |
-          echo "PROJECT_NAME=$(curl -s -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')" >> $GITHUB_ENV
+          echo "PROJECT_NAME=$(curl -s --connect-timeout 2 -m 10 -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')" >> $GITHUB_ENV
           echo "GITHUB_RUN_NUMBER=${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
           echo "WORKFLOW=${{ github.workflow }}" >> $GITHUB_ENV
           if [ "${{ needs.initialize.outputs.bootloader }}" != "null" ]; then

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -109,7 +109,7 @@ jobs:
       - name: Checkout files
         uses: actions/checkout@v3
         with:
-          fetch-depth: 2
+          fetch-depth: 0
       - name: Login to Docker Registry ${{env.REGISTRY}}
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
         with:
@@ -141,7 +141,7 @@ jobs:
       - name: Checkout files
         uses: actions/checkout@v3
         with:
-          fetch-depth: 2
+          fetch-depth: 0
       - name: Login to Docker Registry ${{env.REGISTRY}}
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
         with:
@@ -312,6 +312,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: 1
+          fetch-depth: 0
       - name: Run Tests
         uses: ./.github/actions/on_host_test

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -192,11 +192,9 @@ jobs:
         run: |
           python -m grpc_tools.protoc -Itools/ --python_out=tools/ --grpc_python_out=tools/ tools/on_device_tests_gateway.proto
         shell: bash
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
       - name: Set env vars
         run: |
-          echo "PROJECT_NAME=$(gcloud config get-value project)" >> $GITHUB_ENV
+          echo "PROJECT_NAME=$(curl -s -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/project/project-id')" >> $GITHUB_ENV
           echo "GITHUB_RUN_NUMBER=${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
           echo "WORKFLOW=${{ github.workflow }}" >> $GITHUB_ENV
           if [ "${{ needs.initialize.outputs.bootloader }}" != "null" ]; then

--- a/docker/linux/base/Dockerfile
+++ b/docker/linux/base/Dockerfile
@@ -47,6 +47,7 @@ RUN cd /tmp \
     && tar xf "${GCLOUD}" -C /opt/google-cloud-sdk --strip-components=1 google-cloud-sdk/bin google-cloud-sdk/lib \
     && ln -s /opt/google-cloud-sdk/bin/gcloud /usr/local/bin/gcloud \
     && rm "${GCLOUD}" \
+    && gcloud config set storage/check_hashes never \
     && gcloud --version
 
 CMD ["/usr/bin/python","--version"]

--- a/docker/linux/base/Dockerfile
+++ b/docker/linux/base/Dockerfile
@@ -43,7 +43,9 @@ RUN apt update -qqy \
 ARG GCLOUD=google-cloud-cli-412.0.0-linux-x86_64.tar.gz
 RUN cd /tmp \
     && curl -L -O "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${GCLOUD}" \
-    && tar xf "${GCLOUD}" -C /usr/local --strip-components=1 google-cloud-sdk/bin google-cloud-sdk/lib \
+    && mkdir -p /opt/google-cloud-sdk \
+    && tar xf "${GCLOUD}" -C /opt/google-cloud-sdk --strip-components=1 google-cloud-sdk/bin google-cloud-sdk/lib \
+    && ln -s /opt/google-cloud-sdk/bin/gcloud /usr/local/bin/gcloud \
     && rm "${GCLOUD}" \
     && gcloud --version
 

--- a/docker/linux/base/Dockerfile
+++ b/docker/linux/base/Dockerfile
@@ -40,4 +40,11 @@ RUN apt update -qqy \
     && rm -rf /var/lib/{apt,dpkg,cache,log} \
     && echo "Done"
 
+ARG GCLOUD=google-cloud-cli-412.0.0-linux-x86_64.tar.gz
+RUN cd /tmp \
+    && curl -L -O "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${GCLOUD}" \
+    && tar xf "${GCLOUD}" -C /usr/local --strip-components=1 google-cloud-sdk/bin google-cloud-sdk/lib \
+    && rm "${GCLOUD}" \
+    && gcloud --version
+
 CMD ["/usr/bin/python","--version"]


### PR DESCRIPTION
Install Google Cloud SDK directly into docker/linux/base/Dockerfile for containerized CI builds. Remove setup-gcloud action from composite actions and replace legacy gsutil invocations with gcloud storage.

Tag: agy
Conv: e8eb9390-5eca-47d7-b307-2a4f9e3cd0d1
Bug: 543494079