### PR TITLE
android: Disable SetVideoSurfaceBounds for decode-to-texture

### DIFF
--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -29,6 +29,7 @@
 #include "starboard/android/shared/media_capabilities_cache.h"
 #include "starboard/android/shared/media_codec_video_decoder_helpers.h"
 #include "starboard/android/shared/media_common.h"
+#include "starboard/android/shared/starboard_bridge.h"
 #include "starboard/android/shared/video_render_algorithm_android.h"
 #include "starboard/android/shared/video_surface_texture_bridge.h"
 #include "starboard/common/check_op.h"
@@ -228,8 +229,10 @@ class MediaCodecVideoDecoder::Sink : public VideoRendererSink {
  public:
   typedef std::function<void(double playback_rate)> PlaybackRateChangedCB;
 
-  Sink(PlaybackRateChangedCB playback_rate_changed_cb)
-      : playback_rate_changed_cb_(playback_rate_changed_cb) {}
+  Sink(SbPlayerOutputMode output_mode,
+       PlaybackRateChangedCB playback_rate_changed_cb)
+      : output_mode_(output_mode),
+        playback_rate_changed_cb_(playback_rate_changed_cb) {}
 
   bool Render() {
     SB_DCHECK(render_cb_);
@@ -253,7 +256,13 @@ class MediaCodecVideoDecoder::Sink : public VideoRendererSink {
     render_cb_ = render_cb;
   }
 
-  void SetBounds(int z_index, const Rect& rect) override {}
+  void SetBounds(int z_index, const Rect& rect) override {
+    if (output_mode_ != kSbPlayerOutputModeDecodeToTexture) {
+      JNIEnv* env = jni_zero::AttachCurrentThread();
+      StarboardBridge::GetInstance()->SetVideoSurfaceBounds(
+          env, rect.x, rect.y, rect.size.width, rect.size.height);
+    }
+  }
 
   DrawFrameStatus DrawFrame(const scoped_refptr<VideoFrame>& frame,
                             int64_t release_time_in_nanoseconds) {
@@ -264,6 +273,7 @@ class MediaCodecVideoDecoder::Sink : public VideoRendererSink {
     return kReleased;
   }
 
+  SbPlayerOutputMode output_mode_;
   PlaybackRateChangedCB playback_rate_changed_cb_;
   RenderCB render_cb_;
   bool rendered_;
@@ -457,6 +467,7 @@ MediaCodecVideoDecoder::~MediaCodecVideoDecoder() {
 scoped_refptr<VideoRendererSink> MediaCodecVideoDecoder::GetSink() {
   if (sink_ == nullptr) {
     sink_ = make_scoped_refptr<Sink>(
+        output_mode_,
         std::bind(&MediaCodecVideoDecoder::SetPlaybackRate, this, _1));
   }
   return sink_;

--- a/starboard/android/shared/player_set_bounds.cc
+++ b/starboard/android/shared/player_set_bounds.cc
@@ -35,8 +35,5 @@ void SbPlayerSetBounds(SbPlayer player,
     return;
   }
 
-  JNIEnv* env = jni_zero::AttachCurrentThread();
-  starboard::StarboardBridge::GetInstance()->SetVideoSurfaceBounds(
-      env, x, y, width, height);
   player->SetBounds(z_index, starboard::Rect(x, y, width, height));
 }


### PR DESCRIPTION
This change moves the SetVideoSurfaceBounds call into the video
decoder sink and ensures it is only invoked when the player is not
using decode-to-texture mode. This can help prevent layering and display issues
with dual playback videos when the smaller video is using
decode-to-texture. Decode-to-texture should not need to call this
function to properly display the video.

As a sanity check, I forced enabled `decode-to-texture` locally with
these changes in place, and verified that the app still functioned
properly without any visual issues.

Bug: 505747981
Bug: 548031519