### PR TITLE
media: Extract shared MockSbPlayerInterface and add ScopedSbPlayerInterfaceForTesting

### DIFF
--- a/media/BUILD.gn
+++ b/media/BUILD.gn
@@ -184,6 +184,9 @@ source_set("test_support") {
     "//media/renderers:test_support",
     "//media/video:test_support",
   ]
+  if (use_starboard_media) {
+    public_deps += [ "//media/starboard:test_support" ]
+  }
 }
 
 if (is_ios) {

--- a/media/starboard/BUILD.gn
+++ b/media/starboard/BUILD.gn
@@ -106,12 +106,14 @@ source_set("test_support") {
     ]
   }
   configs += [ "//media:media_config" ]
-  deps = [
-    ":starboard",
-    "//base",
-    "//starboard:starboard_group",
-    "//testing/gmock",
-  ]
+  deps = [ "//base" ]
+  if (use_starboard_media) {
+    deps += [
+      ":starboard",
+      "//starboard:starboard_group",
+      "//testing/gmock",
+    ]
+  }
 }
 
 source_set("unit_tests") {

--- a/media/starboard/BUILD.gn
+++ b/media/starboard/BUILD.gn
@@ -28,7 +28,10 @@ config("disable_unreachable_warnings") {
 }
 
 source_set("starboard") {
-  visibility = [ "//media" ]
+  visibility = [
+    "//media",
+    "//media/starboard:*",
+  ]
 
   sources = []
   deps = []
@@ -93,6 +96,24 @@ source_set("starboard") {
   ]
 }
 
+source_set("test_support") {
+  testonly = true
+  sources = []
+  if (use_starboard_media) {
+    sources += [
+      "mock_sbplayer_interface.cc",
+      "mock_sbplayer_interface.h",
+    ]
+  }
+  configs += [ "//media:media_config" ]
+  deps = [
+    ":starboard",
+    "//base",
+    "//starboard:starboard_group",
+    "//testing/gmock",
+  ]
+}
+
 source_set("unit_tests") {
   testonly = true
   sources = []
@@ -109,6 +130,7 @@ source_set("unit_tests") {
   }
   configs += [ "//media:media_config" ]
   deps = [
+    ":test_support",
     "//base",
     "//base/test:test_support",
     "//media:test_support",

--- a/media/starboard/mock_sbplayer_interface.cc
+++ b/media/starboard/mock_sbplayer_interface.cc
@@ -1,0 +1,22 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "media/starboard/mock_sbplayer_interface.h"
+
+namespace media {
+
+MockSbPlayerInterface::MockSbPlayerInterface() = default;
+MockSbPlayerInterface::~MockSbPlayerInterface() = default;
+
+}  // namespace media

--- a/media/starboard/mock_sbplayer_interface.cc
+++ b/media/starboard/mock_sbplayer_interface.cc
@@ -16,8 +16,43 @@
 
 namespace media {
 
-MockSbPlayerInterface::MockSbPlayerInterface() = default;
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::Return;
+
+MockSbPlayerInterface::MockSbPlayerInterface() {
+  SetupDefaultExpectations();
+}
 
 MockSbPlayerInterface::~MockSbPlayerInterface() = default;
+
+void MockSbPlayerInterface::SetupDefaultExpectations() {
+  ON_CALL(*this, GetPreferredOutputMode(_))
+      .WillByDefault(Return(kSbPlayerOutputModePunchOut));
+  ON_CALL(*this, Destroy(_)).WillByDefault(Invoke([](SbPlayer player) {
+    if (player) {
+      delete reinterpret_cast<MockSbPlayer*>(player);
+    }
+  }));
+  ON_CALL(*this, GetMaximumNumberOfSamplesPerWrite(_, _))
+      .WillByDefault(Return(1));
+  ON_CALL(*this, SetPlaybackRate(_, _)).WillByDefault(Return(true));
+  ON_CALL(*this, SetVolume(_, _)).WillByDefault(Return());
+  ON_CALL(*this, GetCurrentFrame(_))
+      .WillByDefault(Return(kSbDecodeTargetInvalid));
+#if BUILDFLAG(IS_IOS_TVOS)
+  ON_CALL(*this, GetUrlPlayerOutputModeSupported(_))
+      .WillByDefault(Return(true));
+#endif  // BUILDFLAG(IS_IOS_TVOS)
+  ON_CALL(*this, GetAudioConfiguration(_, _, _))
+      .WillByDefault(
+          Invoke([](SbPlayer /*player*/, int /*index*/,
+                    SbMediaAudioConfiguration* out_audio_configuration) {
+            if (out_audio_configuration) {
+              *out_audio_configuration = {};
+            }
+            return true;
+          }));
+}
 
 }  // namespace media

--- a/media/starboard/mock_sbplayer_interface.cc
+++ b/media/starboard/mock_sbplayer_interface.cc
@@ -16,7 +16,11 @@
 
 namespace media {
 
-MockSbPlayerInterface::MockSbPlayerInterface() = default;
+MockSbPlayerInterface::MockSbPlayerInterface() {
+  ON_CALL(*this, GetPreferredOutputMode(testing::_))
+      .WillByDefault(testing::Return(kSbPlayerOutputModePunchOut));
+}
+
 MockSbPlayerInterface::~MockSbPlayerInterface() = default;
 
 }  // namespace media

--- a/media/starboard/mock_sbplayer_interface.cc
+++ b/media/starboard/mock_sbplayer_interface.cc
@@ -16,10 +16,7 @@
 
 namespace media {
 
-MockSbPlayerInterface::MockSbPlayerInterface() {
-  ON_CALL(*this, GetPreferredOutputMode(testing::_))
-      .WillByDefault(testing::Return(kSbPlayerOutputModePunchOut));
-}
+MockSbPlayerInterface::MockSbPlayerInterface() = default;
 
 MockSbPlayerInterface::~MockSbPlayerInterface() = default;
 

--- a/media/starboard/mock_sbplayer_interface.cc
+++ b/media/starboard/mock_sbplayer_interface.cc
@@ -17,6 +17,7 @@
 namespace media {
 
 using ::testing::_;
+using ::testing::AnyNumber;
 using ::testing::Invoke;
 using ::testing::Return;
 
@@ -27,25 +28,36 @@ MockSbPlayerInterface::MockSbPlayerInterface() {
 MockSbPlayerInterface::~MockSbPlayerInterface() = default;
 
 void MockSbPlayerInterface::SetupDefaultExpectations() {
-  ON_CALL(*this, GetPreferredOutputMode(_))
-      .WillByDefault(Return(kSbPlayerOutputModePunchOut));
-  ON_CALL(*this, Destroy(_)).WillByDefault(Invoke([](SbPlayer player) {
-    if (player) {
-      delete reinterpret_cast<MockSbPlayer*>(player);
-    }
-  }));
-  ON_CALL(*this, GetMaximumNumberOfSamplesPerWrite(_, _))
-      .WillByDefault(Return(1));
-  ON_CALL(*this, SetPlaybackRate(_, _)).WillByDefault(Return(true));
-  ON_CALL(*this, SetVolume(_, _)).WillByDefault(Return());
-  ON_CALL(*this, GetCurrentFrame(_))
-      .WillByDefault(Return(kSbDecodeTargetInvalid));
+  EXPECT_CALL(*this, GetPreferredOutputMode(_))
+      .Times(AnyNumber())
+      .WillRepeatedly(Return(kSbPlayerOutputModePunchOut));
+  EXPECT_CALL(*this, Destroy(_))
+      .Times(AnyNumber())
+      .WillRepeatedly(Invoke([](SbPlayer player) {
+        if (player) {
+          delete reinterpret_cast<MockSbPlayer*>(player);
+        }
+      }));
+  EXPECT_CALL(*this, GetMaximumNumberOfSamplesPerWrite(_, _))
+      .Times(AnyNumber())
+      .WillRepeatedly(Return(1));
+  EXPECT_CALL(*this, SetPlaybackRate(_, _))
+      .Times(AnyNumber())
+      .WillRepeatedly(Return(true));
+  EXPECT_CALL(*this, SetVolume(_, _))
+      .Times(AnyNumber())
+      .WillRepeatedly(Return());
+  EXPECT_CALL(*this, GetCurrentFrame(_))
+      .Times(AnyNumber())
+      .WillRepeatedly(Return(kSbDecodeTargetInvalid));
 #if BUILDFLAG(IS_IOS_TVOS)
-  ON_CALL(*this, GetUrlPlayerOutputModeSupported(_))
-      .WillByDefault(Return(true));
+  EXPECT_CALL(*this, GetUrlPlayerOutputModeSupported(_))
+      .Times(AnyNumber())
+      .WillRepeatedly(Return(true));
 #endif  // BUILDFLAG(IS_IOS_TVOS)
-  ON_CALL(*this, GetAudioConfiguration(_, _, _))
-      .WillByDefault(
+  EXPECT_CALL(*this, GetAudioConfiguration(_, _, _))
+      .Times(AnyNumber())
+      .WillRepeatedly(
           Invoke([](SbPlayer /*player*/, int /*index*/,
                     SbMediaAudioConfiguration* out_audio_configuration) {
             if (out_audio_configuration) {

--- a/media/starboard/mock_sbplayer_interface.h
+++ b/media/starboard/mock_sbplayer_interface.h
@@ -19,17 +19,16 @@
 #include "media/starboard/sbplayer_interface.h"
 #include "testing/gmock/include/gmock/gmock.h"
 
-struct SbPlayerPrivate {
- public:
-  SbPlayerPrivate() = default;
-
-  SbPlayerPrivate(const SbPlayerPrivate&) = delete;
-  SbPlayerPrivate& operator=(const SbPlayerPrivate&) = delete;
-
-  ~SbPlayerPrivate() = default;
-};
-
 namespace media {
+
+// A lightweight mock player structure used to back opaque SbPlayer handles in
+// tests without conflicting with the global SbPlayerPrivate definition.
+struct MockSbPlayer {
+  MockSbPlayer() = default;
+  MockSbPlayer(const MockSbPlayer&) = delete;
+  MockSbPlayer& operator=(const MockSbPlayer&) = delete;
+  ~MockSbPlayer() = default;
+};
 
 // A mock implementation of SbPlayerInterface used for testing the media
 // pipeline's interaction with the Starboard player. This class is typically
@@ -57,7 +56,7 @@ class MockSbPlayerInterface : public SbPlayerInterface {
   }
   void Destroy(SbPlayer player) override {
     if (player) {
-      delete player;
+      delete reinterpret_cast<MockSbPlayer*>(player);
     }
   }
   MOCK_METHOD(void, Seek, (SbPlayer, base::TimeDelta, int), (override));

--- a/media/starboard/mock_sbplayer_interface.h
+++ b/media/starboard/mock_sbplayer_interface.h
@@ -91,15 +91,14 @@ class MockSbPlayerInterface : public SbPlayerInterface {
                void*),
               (override));
   MOCK_METHOD(void, SetUrlPlayerDrmSystem, (SbPlayer, SbDrmSystem), (override));
-  MOCK_METHOD(void,
-              GetUrlPlayerExtraInfo,
-              (SbPlayer, SbUrlPlayerExtraInfo*),
-              (override));
-
   bool GetUrlPlayerOutputModeSupported(
       SbPlayerOutputMode /*output_mode*/) override {
     return true;
   }
+  MOCK_METHOD(void,
+              GetUrlPlayerExtraInfo,
+              (SbPlayer, SbUrlPlayerExtraInfo*),
+              (override));
 #endif  // BUILDFLAG(IS_IOS_TVOS)
 
   bool GetAudioConfiguration(

--- a/media/starboard/mock_sbplayer_interface.h
+++ b/media/starboard/mock_sbplayer_interface.h
@@ -16,7 +16,6 @@
 #define MEDIA_STARBOARD_MOCK_SBPLAYER_INTERFACE_H_
 
 #include "build/build_config.h"
-#include "media/base/media_export.h"
 #include "media/starboard/sbplayer_interface.h"
 #include "testing/gmock/include/gmock/gmock.h"
 
@@ -35,7 +34,7 @@ struct MockSbPlayer {
 // pipeline's interaction with the Starboard player. This class is typically
 // owned by the test fixture or instantiated as a local variable within a test,
 // and is thread-safe.
-class MEDIA_EXPORT MockSbPlayerInterface : public SbPlayerInterface {
+class MockSbPlayerInterface : public SbPlayerInterface {
  public:
   MockSbPlayerInterface();
   ~MockSbPlayerInterface() override;

--- a/media/starboard/mock_sbplayer_interface.h
+++ b/media/starboard/mock_sbplayer_interface.h
@@ -64,18 +64,18 @@ class MockSbPlayerInterface : public SbPlayerInterface {
               WriteSamples,
               (SbPlayer, SbMediaType, const SbPlayerSampleInfo*, int),
               (override));
-  int GetMaximumNumberOfSamplesPerWrite(SbPlayer player,
-                                        SbMediaType sample_type) override {
+  int GetMaximumNumberOfSamplesPerWrite(SbPlayer /*player*/,
+                                        SbMediaType /*sample_type*/) override {
     return 1;
   }
   MOCK_METHOD(void, WriteEndOfStream, (SbPlayer, SbMediaType), (override));
   MOCK_METHOD(void, SetBounds, (SbPlayer, int, int, int, int, int), (override));
-  bool SetPlaybackRate(SbPlayer player, double playback_rate) override {
+  bool SetPlaybackRate(SbPlayer /*player*/, double /*playback_rate*/) override {
     return true;
   }
-  void SetVolume(SbPlayer player, double volume) override {}
+  void SetVolume(SbPlayer /*player*/, double /*volume*/) override {}
   MOCK_METHOD(void, GetInfo, (SbPlayer, SbPlayerInfo*), (override));
-  SbDecodeTarget GetCurrentFrame(SbPlayer player) override {
+  SbDecodeTarget GetCurrentFrame(SbPlayer /*player*/) override {
     return kSbDecodeTargetInvalid;
   }
 
@@ -96,14 +96,14 @@ class MockSbPlayerInterface : public SbPlayerInterface {
               (override));
 
   bool GetUrlPlayerOutputModeSupported(
-      SbPlayerOutputMode output_mode) override {
+      SbPlayerOutputMode /*output_mode*/) override {
     return true;
   }
 #endif  // BUILDFLAG(IS_IOS_TVOS)
 
   bool GetAudioConfiguration(
-      SbPlayer player,
-      int index,
+      SbPlayer /*player*/,
+      int /*index*/,
       SbMediaAudioConfiguration* out_audio_configuration) override {
     if (out_audio_configuration) {
       *out_audio_configuration = {};

--- a/media/starboard/mock_sbplayer_interface.h
+++ b/media/starboard/mock_sbplayer_interface.h
@@ -51,10 +51,10 @@ class MockSbPlayerInterface : public SbPlayerInterface {
                void*,
                SbDecodeTargetGraphicsContextProvider*),
               (override));
-  MOCK_METHOD(SbPlayerOutputMode,
-              GetPreferredOutputMode,
-              (const SbPlayerCreationParam*),
-              (override));
+  SbPlayerOutputMode GetPreferredOutputMode(
+      const SbPlayerCreationParam* /*creation_param*/) override {
+    return kSbPlayerOutputModePunchOut;
+  }
   void Destroy(SbPlayer player) override {
     if (player) {
       delete reinterpret_cast<MockSbPlayer*>(player);

--- a/media/starboard/mock_sbplayer_interface.h
+++ b/media/starboard/mock_sbplayer_interface.h
@@ -40,6 +40,8 @@ class MockSbPlayerInterface : public SbPlayerInterface {
   MockSbPlayerInterface();
   ~MockSbPlayerInterface() override;
 
+  void SetupDefaultExpectations();
+
   MOCK_METHOD(SbPlayer,
               Create,
               (SbWindow,
@@ -51,34 +53,26 @@ class MockSbPlayerInterface : public SbPlayerInterface {
                void*,
                SbDecodeTargetGraphicsContextProvider*),
               (override));
-  SbPlayerOutputMode GetPreferredOutputMode(
-      const SbPlayerCreationParam* /*creation_param*/) override {
-    return kSbPlayerOutputModePunchOut;
-  }
-  void Destroy(SbPlayer player) override {
-    if (player) {
-      delete reinterpret_cast<MockSbPlayer*>(player);
-    }
-  }
+  MOCK_METHOD(SbPlayerOutputMode,
+              GetPreferredOutputMode,
+              (const SbPlayerCreationParam*),
+              (override));
+  MOCK_METHOD(void, Destroy, (SbPlayer), (override));
   MOCK_METHOD(void, Seek, (SbPlayer, base::TimeDelta, int), (override));
   MOCK_METHOD(void,
               WriteSamples,
               (SbPlayer, SbMediaType, const SbPlayerSampleInfo*, int),
               (override));
-  int GetMaximumNumberOfSamplesPerWrite(SbPlayer /*player*/,
-                                        SbMediaType /*sample_type*/) override {
-    return 1;
-  }
+  MOCK_METHOD(int,
+              GetMaximumNumberOfSamplesPerWrite,
+              (SbPlayer, SbMediaType),
+              (override));
   MOCK_METHOD(void, WriteEndOfStream, (SbPlayer, SbMediaType), (override));
   MOCK_METHOD(void, SetBounds, (SbPlayer, int, int, int, int, int), (override));
-  bool SetPlaybackRate(SbPlayer /*player*/, double /*playback_rate*/) override {
-    return true;
-  }
-  void SetVolume(SbPlayer /*player*/, double /*volume*/) override {}
+  MOCK_METHOD(bool, SetPlaybackRate, (SbPlayer, double), (override));
+  MOCK_METHOD(void, SetVolume, (SbPlayer, double), (override));
   MOCK_METHOD(void, GetInfo, (SbPlayer, SbPlayerInfo*), (override));
-  SbDecodeTarget GetCurrentFrame(SbPlayer /*player*/) override {
-    return kSbDecodeTargetInvalid;
-  }
+  MOCK_METHOD(SbDecodeTarget, GetCurrentFrame, (SbPlayer), (override));
 
 #if BUILDFLAG(IS_IOS_TVOS)
   MOCK_METHOD(SbPlayer,
@@ -91,25 +85,20 @@ class MockSbPlayerInterface : public SbPlayerInterface {
                void*),
               (override));
   MOCK_METHOD(void, SetUrlPlayerDrmSystem, (SbPlayer, SbDrmSystem), (override));
-  bool GetUrlPlayerOutputModeSupported(
-      SbPlayerOutputMode /*output_mode*/) override {
-    return true;
-  }
+  MOCK_METHOD(bool,
+              GetUrlPlayerOutputModeSupported,
+              (SbPlayerOutputMode),
+              (override));
   MOCK_METHOD(void,
               GetUrlPlayerExtraInfo,
               (SbPlayer, SbUrlPlayerExtraInfo*),
               (override));
 #endif  // BUILDFLAG(IS_IOS_TVOS)
 
-  bool GetAudioConfiguration(
-      SbPlayer /*player*/,
-      int /*index*/,
-      SbMediaAudioConfiguration* out_audio_configuration) override {
-    if (out_audio_configuration) {
-      *out_audio_configuration = {};
-    }
-    return true;
-  }
+  MOCK_METHOD(bool,
+              GetAudioConfiguration,
+              (SbPlayer, int, SbMediaAudioConfiguration*),
+              (override));
 };
 
 }  // namespace media

--- a/media/starboard/mock_sbplayer_interface.h
+++ b/media/starboard/mock_sbplayer_interface.h
@@ -1,0 +1,118 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MEDIA_STARBOARD_MOCK_SBPLAYER_INTERFACE_H_
+#define MEDIA_STARBOARD_MOCK_SBPLAYER_INTERFACE_H_
+
+#include "build/build_config.h"
+#include "media/starboard/sbplayer_interface.h"
+#include "testing/gmock/include/gmock/gmock.h"
+
+struct SbPlayerPrivate {
+ public:
+  SbPlayerPrivate() = default;
+
+  SbPlayerPrivate(const SbPlayerPrivate&) = delete;
+  SbPlayerPrivate& operator=(const SbPlayerPrivate&) = delete;
+
+  ~SbPlayerPrivate() = default;
+};
+
+namespace media {
+
+// A mock implementation of SbPlayerInterface used for testing the media
+// pipeline's interaction with the Starboard player. This class is typically
+// owned by the test fixture or instantiated as a local variable within a test,
+// and is thread-safe.
+class MockSbPlayerInterface : public SbPlayerInterface {
+ public:
+  MockSbPlayerInterface();
+  ~MockSbPlayerInterface() override;
+
+  MOCK_METHOD(SbPlayer,
+              Create,
+              (SbWindow,
+               const SbPlayerCreationParam*,
+               SbPlayerDeallocateSampleFunc,
+               SbPlayerDecoderStatusFunc,
+               SbPlayerStatusFunc,
+               SbPlayerErrorFunc,
+               void*,
+               SbDecodeTargetGraphicsContextProvider*),
+              (override));
+  SbPlayerOutputMode GetPreferredOutputMode(
+      const SbPlayerCreationParam* creation_param) override {
+    return kSbPlayerOutputModePunchOut;
+  }
+  void Destroy(SbPlayer player) override {
+    if (player) {
+      delete player;
+    }
+  }
+  MOCK_METHOD(void, Seek, (SbPlayer, base::TimeDelta, int), (override));
+  MOCK_METHOD(void,
+              WriteSamples,
+              (SbPlayer, SbMediaType, const SbPlayerSampleInfo*, int),
+              (override));
+  int GetMaximumNumberOfSamplesPerWrite(SbPlayer player,
+                                        SbMediaType sample_type) override {
+    return 1;
+  }
+  MOCK_METHOD(void, WriteEndOfStream, (SbPlayer, SbMediaType), (override));
+  MOCK_METHOD(void, SetBounds, (SbPlayer, int, int, int, int, int), (override));
+  bool SetPlaybackRate(SbPlayer player, double playback_rate) override {
+    return true;
+  }
+  void SetVolume(SbPlayer player, double volume) override {}
+  MOCK_METHOD(void, GetInfo, (SbPlayer, SbPlayerInfo*), (override));
+  SbDecodeTarget GetCurrentFrame(SbPlayer player) override {
+    return kSbDecodeTargetInvalid;
+  }
+
+#if BUILDFLAG(IS_IOS_TVOS)
+  MOCK_METHOD(SbPlayer,
+              CreateUrlPlayer,
+              (const char*,
+               SbWindow,
+               SbPlayerStatusFunc,
+               SbPlayerEncryptedMediaInitDataEncounteredCB,
+               SbPlayerErrorFunc,
+               void*),
+              (override));
+  MOCK_METHOD(void, SetUrlPlayerDrmSystem, (SbPlayer, SbDrmSystem), (override));
+  MOCK_METHOD(void,
+              GetUrlPlayerExtraInfo,
+              (SbPlayer, SbUrlPlayerExtraInfo*),
+              (override));
+
+  bool GetUrlPlayerOutputModeSupported(
+      SbPlayerOutputMode output_mode) override {
+    return true;
+  }
+#endif  // BUILDFLAG(IS_IOS_TVOS)
+
+  bool GetAudioConfiguration(
+      SbPlayer player,
+      int index,
+      SbMediaAudioConfiguration* out_audio_configuration) override {
+    if (out_audio_configuration) {
+      *out_audio_configuration = {};
+    }
+    return true;
+  }
+};
+
+}  // namespace media
+
+#endif  // MEDIA_STARBOARD_MOCK_SBPLAYER_INTERFACE_H_

--- a/media/starboard/mock_sbplayer_interface.h
+++ b/media/starboard/mock_sbplayer_interface.h
@@ -16,6 +16,7 @@
 #define MEDIA_STARBOARD_MOCK_SBPLAYER_INTERFACE_H_
 
 #include "build/build_config.h"
+#include "media/base/media_export.h"
 #include "media/starboard/sbplayer_interface.h"
 #include "testing/gmock/include/gmock/gmock.h"
 
@@ -34,7 +35,7 @@ struct MockSbPlayer {
 // pipeline's interaction with the Starboard player. This class is typically
 // owned by the test fixture or instantiated as a local variable within a test,
 // and is thread-safe.
-class MockSbPlayerInterface : public SbPlayerInterface {
+class MEDIA_EXPORT MockSbPlayerInterface : public SbPlayerInterface {
  public:
   MockSbPlayerInterface();
   ~MockSbPlayerInterface() override;

--- a/media/starboard/mock_sbplayer_interface.h
+++ b/media/starboard/mock_sbplayer_interface.h
@@ -15,6 +15,7 @@
 #ifndef MEDIA_STARBOARD_MOCK_SBPLAYER_INTERFACE_H_
 #define MEDIA_STARBOARD_MOCK_SBPLAYER_INTERFACE_H_
 
+#include "base/time/time.h"
 #include "build/build_config.h"
 #include "media/starboard/sbplayer_interface.h"
 #include "testing/gmock/include/gmock/gmock.h"

--- a/media/starboard/mock_sbplayer_interface.h
+++ b/media/starboard/mock_sbplayer_interface.h
@@ -50,10 +50,10 @@ class MockSbPlayerInterface : public SbPlayerInterface {
                void*,
                SbDecodeTargetGraphicsContextProvider*),
               (override));
-  SbPlayerOutputMode GetPreferredOutputMode(
-      const SbPlayerCreationParam* creation_param) override {
-    return kSbPlayerOutputModePunchOut;
-  }
+  MOCK_METHOD(SbPlayerOutputMode,
+              GetPreferredOutputMode,
+              (const SbPlayerCreationParam*),
+              (override));
   void Destroy(SbPlayer player) override {
     if (player) {
       delete reinterpret_cast<MockSbPlayer*>(player);

--- a/media/starboard/sbplayer_interface.cc
+++ b/media/starboard/sbplayer_interface.cc
@@ -194,4 +194,14 @@ SbPlayerInterface* GetSbPlayerInterfaceForTesting() {
   return g_sbplayer_interface_for_testing.load(std::memory_order_acquire);
 }
 
+ScopedSbPlayerInterfaceForTesting::ScopedSbPlayerInterfaceForTesting(
+    SbPlayerInterface* interface)
+    : previous_interface_(GetSbPlayerInterfaceForTesting()) {
+  SetSbPlayerInterfaceForTesting(interface);
+}
+
+ScopedSbPlayerInterfaceForTesting::~ScopedSbPlayerInterfaceForTesting() {
+  SetSbPlayerInterfaceForTesting(previous_interface_);
+}
+
 }  // namespace media

--- a/media/starboard/sbplayer_interface.cc
+++ b/media/starboard/sbplayer_interface.cc
@@ -14,12 +14,20 @@
 
 #include "media/starboard/sbplayer_interface.h"
 
+#include <atomic>
 #include <string>
 
 #include "base/logging.h"
+#include "base/no_destructor.h"
 #include "starboard/system.h"
 
 namespace media {
+
+namespace {
+
+std::atomic<SbPlayerInterface*> g_sbplayer_interface_for_testing{nullptr};
+
+}  // namespace
 
 SbPlayer DefaultSbPlayerInterface::Create(
     SbWindow window,
@@ -177,6 +185,20 @@ bool DefaultSbPlayerInterface::GetAudioConfiguration(
   media_metrics_provider_.EndTrackingAction(
       MediaAction::SBPLAYER_GET_AUDIO_CONFIG);
   return audio_configuration;
+}
+
+SbPlayerInterface* GetSbPlayerInterface() {
+  SbPlayerInterface* testing_interface =
+      g_sbplayer_interface_for_testing.load(std::memory_order_acquire);
+  if (testing_interface) {
+    return testing_interface;
+  }
+  static base::NoDestructor<DefaultSbPlayerInterface> default_interface;
+  return default_interface.get();
+}
+
+void SetSbPlayerInterfaceForTesting(SbPlayerInterface* interface) {
+  g_sbplayer_interface_for_testing.store(interface, std::memory_order_release);
 }
 
 }  // namespace media

--- a/media/starboard/sbplayer_interface.cc
+++ b/media/starboard/sbplayer_interface.cc
@@ -18,7 +18,6 @@
 #include <string>
 
 #include "base/logging.h"
-#include "base/no_destructor.h"
 #include "starboard/system.h"
 
 namespace media {

--- a/media/starboard/sbplayer_interface.cc
+++ b/media/starboard/sbplayer_interface.cc
@@ -187,16 +187,6 @@ bool DefaultSbPlayerInterface::GetAudioConfiguration(
   return audio_configuration;
 }
 
-SbPlayerInterface* GetSbPlayerInterface() {
-  SbPlayerInterface* testing_interface =
-      g_sbplayer_interface_for_testing.load(std::memory_order_acquire);
-  if (testing_interface) {
-    return testing_interface;
-  }
-  static base::NoDestructor<DefaultSbPlayerInterface> default_interface;
-  return default_interface.get();
-}
-
 void SetSbPlayerInterfaceForTesting(SbPlayerInterface* interface) {
   g_sbplayer_interface_for_testing.store(interface, std::memory_order_release);
 }

--- a/media/starboard/sbplayer_interface.cc
+++ b/media/starboard/sbplayer_interface.cc
@@ -201,4 +201,8 @@ void SetSbPlayerInterfaceForTesting(SbPlayerInterface* interface) {
   g_sbplayer_interface_for_testing.store(interface, std::memory_order_release);
 }
 
+SbPlayerInterface* GetSbPlayerInterfaceForTesting() {
+  return g_sbplayer_interface_for_testing.load(std::memory_order_acquire);
+}
+
 }  // namespace media

--- a/media/starboard/sbplayer_interface.h
+++ b/media/starboard/sbplayer_interface.h
@@ -193,10 +193,6 @@ class MEDIA_EXPORT DefaultSbPlayerInterface final : public SbPlayerInterface {
       SbMediaAudioConfiguration* out_audio_configuration) override;
 };
 
-// Returns a pointer to the global SbPlayerInterface instance.
-// By default, this returns a DefaultSbPlayerInterface instance.
-MEDIA_EXPORT SbPlayerInterface* GetSbPlayerInterface();
-
 // Sets a custom SbPlayerInterface for testing.
 MEDIA_EXPORT void SetSbPlayerInterfaceForTesting(SbPlayerInterface* interface);
 

--- a/media/starboard/sbplayer_interface.h
+++ b/media/starboard/sbplayer_interface.h
@@ -15,6 +15,7 @@
 #ifndef MEDIA_STARBOARD_SBPLAYER_INTERFACE_H_
 #define MEDIA_STARBOARD_SBPLAYER_INTERFACE_H_
 
+#include "base/memory/raw_ptr.h"
 #include "base/time/time.h"
 #include "build/build_config.h"
 #include "media/base/media_export.h"
@@ -199,20 +200,34 @@ MEDIA_EXPORT SbPlayerInterface* GetSbPlayerInterface();
 // Sets a custom SbPlayerInterface for testing.
 MEDIA_EXPORT void SetSbPlayerInterfaceForTesting(SbPlayerInterface* interface);
 
-// Helper class to automatically register and reset a mock SbPlayerInterface
+// Returns the current testing SbPlayerInterface instance, or nullptr if none.
+MEDIA_EXPORT SbPlayerInterface* GetSbPlayerInterfaceForTesting();
+
+// Helper class to automatically register and restore a custom SbPlayerInterface
 // for testing using RAII.
+//
+// Lifetime and ownership:
+// This object is typically instantiated as a local or member variable within a
+// test scope. It does not own the passed SbPlayerInterface pointer.
+//
+// Threading model:
+// Should be instantiated on the test thread before initiating media playback.
 class MEDIA_EXPORT ScopedSbPlayerInterfaceForTesting {
  public:
-  explicit ScopedSbPlayerInterfaceForTesting(SbPlayerInterface* interface) {
+  explicit ScopedSbPlayerInterfaceForTesting(SbPlayerInterface* interface)
+      : previous_interface_(GetSbPlayerInterfaceForTesting()) {
     SetSbPlayerInterfaceForTesting(interface);
   }
   ~ScopedSbPlayerInterfaceForTesting() {
-    SetSbPlayerInterfaceForTesting(nullptr);
+    SetSbPlayerInterfaceForTesting(previous_interface_);
   }
   ScopedSbPlayerInterfaceForTesting(const ScopedSbPlayerInterfaceForTesting&) =
       delete;
   ScopedSbPlayerInterfaceForTesting& operator=(
       const ScopedSbPlayerInterfaceForTesting&) = delete;
+
+ private:
+  raw_ptr<SbPlayerInterface> previous_interface_;
 };
 
 }  // namespace media

--- a/media/starboard/sbplayer_interface.h
+++ b/media/starboard/sbplayer_interface.h
@@ -208,6 +208,9 @@ MEDIA_EXPORT SbPlayerInterface* GetSbPlayerInterfaceForTesting();
 //
 // Threading model:
 // Should be instantiated on the test thread before initiating media playback.
+// The media pipeline or renderer using the mocked interface must be
+// completely stopped or destroyed before this scoped object (and the underlying
+// mock interface) is destroyed to avoid use-after-free on the media thread.
 class MEDIA_EXPORT ScopedSbPlayerInterfaceForTesting {
  public:
   explicit ScopedSbPlayerInterfaceForTesting(SbPlayerInterface* interface)

--- a/media/starboard/sbplayer_interface.h
+++ b/media/starboard/sbplayer_interface.h
@@ -17,6 +17,7 @@
 
 #include "base/time/time.h"
 #include "build/build_config.h"
+#include "media/base/media_export.h"
 #include "media/starboard/buildflags.h"
 #include "starboard/player.h"
 
@@ -33,7 +34,7 @@
 
 namespace media {
 
-class SbPlayerInterface {
+class MEDIA_EXPORT SbPlayerInterface {
  public:
   virtual ~SbPlayerInterface() {}
 
@@ -135,7 +136,7 @@ class SbPlayerInterface {
   MediaMetricsProvider media_metrics_provider_;
 };
 
-class DefaultSbPlayerInterface final : public SbPlayerInterface {
+class MEDIA_EXPORT DefaultSbPlayerInterface final : public SbPlayerInterface {
  public:
   SbPlayer Create(
       SbWindow window,
@@ -190,6 +191,13 @@ class DefaultSbPlayerInterface final : public SbPlayerInterface {
       int index,
       SbMediaAudioConfiguration* out_audio_configuration) override;
 };
+
+// Returns a pointer to the global SbPlayerInterface instance.
+// By default, this returns a DefaultSbPlayerInterface instance.
+MEDIA_EXPORT SbPlayerInterface* GetSbPlayerInterface();
+
+// Sets a custom SbPlayerInterface for testing.
+MEDIA_EXPORT void SetSbPlayerInterfaceForTesting(SbPlayerInterface* interface);
 
 }  // namespace media
 

--- a/media/starboard/sbplayer_interface.h
+++ b/media/starboard/sbplayer_interface.h
@@ -15,7 +15,6 @@
 #ifndef MEDIA_STARBOARD_SBPLAYER_INTERFACE_H_
 #define MEDIA_STARBOARD_SBPLAYER_INTERFACE_H_
 
-#include "base/memory/raw_ptr.h"
 #include "base/time/time.h"
 #include "build/build_config.h"
 #include "media/base/media_export.h"
@@ -226,7 +225,7 @@ class MEDIA_EXPORT ScopedSbPlayerInterfaceForTesting {
       const ScopedSbPlayerInterfaceForTesting&) = delete;
 
  private:
-  raw_ptr<SbPlayerInterface> previous_interface_;
+  SbPlayerInterface* previous_interface_;
 };
 
 }  // namespace media

--- a/media/starboard/sbplayer_interface.h
+++ b/media/starboard/sbplayer_interface.h
@@ -212,13 +212,8 @@ MEDIA_EXPORT SbPlayerInterface* GetSbPlayerInterfaceForTesting();
 // mock interface) is destroyed to avoid use-after-free on the media thread.
 class MEDIA_EXPORT ScopedSbPlayerInterfaceForTesting {
  public:
-  explicit ScopedSbPlayerInterfaceForTesting(SbPlayerInterface* interface)
-      : previous_interface_(GetSbPlayerInterfaceForTesting()) {
-    SetSbPlayerInterfaceForTesting(interface);
-  }
-  ~ScopedSbPlayerInterfaceForTesting() {
-    SetSbPlayerInterfaceForTesting(previous_interface_);
-  }
+  explicit ScopedSbPlayerInterfaceForTesting(SbPlayerInterface* interface);
+  ~ScopedSbPlayerInterfaceForTesting();
   ScopedSbPlayerInterfaceForTesting(const ScopedSbPlayerInterfaceForTesting&) =
       delete;
   ScopedSbPlayerInterfaceForTesting& operator=(

--- a/media/starboard/sbplayer_interface.h
+++ b/media/starboard/sbplayer_interface.h
@@ -199,6 +199,22 @@ MEDIA_EXPORT SbPlayerInterface* GetSbPlayerInterface();
 // Sets a custom SbPlayerInterface for testing.
 MEDIA_EXPORT void SetSbPlayerInterfaceForTesting(SbPlayerInterface* interface);
 
+// Helper class to automatically register and reset a mock SbPlayerInterface
+// for testing using RAII.
+class MEDIA_EXPORT ScopedSbPlayerInterfaceForTesting {
+ public:
+  explicit ScopedSbPlayerInterfaceForTesting(SbPlayerInterface* interface) {
+    SetSbPlayerInterfaceForTesting(interface);
+  }
+  ~ScopedSbPlayerInterfaceForTesting() {
+    SetSbPlayerInterfaceForTesting(nullptr);
+  }
+  ScopedSbPlayerInterfaceForTesting(const ScopedSbPlayerInterfaceForTesting&) =
+      delete;
+  ScopedSbPlayerInterfaceForTesting& operator=(
+      const ScopedSbPlayerInterfaceForTesting&) = delete;
+};
+
 }  // namespace media
 
 #endif  // MEDIA_STARBOARD_SBPLAYER_INTERFACE_H_

--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -646,8 +646,12 @@ void StarboardRenderer::OnOverlayInfoChanged(const OverlayInfo& overlay_info) {
 #endif  // BUILDFLAG(IS_ANDROID)
 
 SbPlayerInterface* StarboardRenderer::GetSbPlayerInterface() {
-  SbPlayerInterface* testing_interface = GetSbPlayerInterfaceForTesting();
-  return testing_interface ? testing_interface : &sbplayer_interface_;
+  if (!resolved_sbplayer_interface_) {
+    SbPlayerInterface* testing_interface = GetSbPlayerInterfaceForTesting();
+    resolved_sbplayer_interface_ =
+        testing_interface ? testing_interface : &sbplayer_interface_;
+  }
+  return resolved_sbplayer_interface_;
 }
 
 void StarboardRenderer::UpdateAudioWriteDuration() {

--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -157,10 +157,11 @@ StarboardRenderer::StarboardRenderer(
       ,
       android_overlay_factory_cb_(std::move(android_overlay_factory_cb))
 #endif  // BUILDFLAG(IS_ANDROID)
-      ,
-      sbplayer_interface_ptr_(GetSbPlayerInterfaceForTesting()
-                                  ? GetSbPlayerInterfaceForTesting()
-                                  : &sbplayer_interface_) {
+{
+  SbPlayerInterface* testing_interface = GetSbPlayerInterfaceForTesting();
+  sbplayer_interface_ptr_ =
+      testing_interface ? testing_interface : &sbplayer_interface_;
+
   DCHECK(task_runner_);
   DCHECK(media_log_);
   CHECK_GT(max_samples_per_write_, 0);

--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -158,10 +158,6 @@ StarboardRenderer::StarboardRenderer(
       android_overlay_factory_cb_(std::move(android_overlay_factory_cb))
 #endif  // BUILDFLAG(IS_ANDROID)
 {
-  SbPlayerInterface* testing_interface = GetSbPlayerInterfaceForTesting();
-  sbplayer_interface_ptr_ =
-      testing_interface ? testing_interface : &sbplayer_interface_;
-
   DCHECK(task_runner_);
   DCHECK(media_log_);
   CHECK_GT(max_samples_per_write_, 0);
@@ -650,7 +646,8 @@ void StarboardRenderer::OnOverlayInfoChanged(const OverlayInfo& overlay_info) {
 #endif  // BUILDFLAG(IS_ANDROID)
 
 SbPlayerInterface* StarboardRenderer::GetSbPlayerInterface() {
-  return sbplayer_interface_ptr_;
+  SbPlayerInterface* testing_interface = GetSbPlayerInterfaceForTesting();
+  return testing_interface ? testing_interface : &sbplayer_interface_;
 }
 
 void StarboardRenderer::UpdateAudioWriteDuration() {

--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -157,7 +157,10 @@ StarboardRenderer::StarboardRenderer(
       ,
       android_overlay_factory_cb_(std::move(android_overlay_factory_cb))
 #endif  // BUILDFLAG(IS_ANDROID)
-{
+      ,
+      sbplayer_interface_ptr_(GetSbPlayerInterfaceForTesting()
+                                  ? GetSbPlayerInterfaceForTesting()
+                                  : &sbplayer_interface_) {
   DCHECK(task_runner_);
   DCHECK(media_log_);
   CHECK_GT(max_samples_per_write_, 0);
@@ -646,10 +649,7 @@ void StarboardRenderer::OnOverlayInfoChanged(const OverlayInfo& overlay_info) {
 #endif  // BUILDFLAG(IS_ANDROID)
 
 SbPlayerInterface* StarboardRenderer::GetSbPlayerInterface() {
-  if (auto* testing_interface = GetSbPlayerInterfaceForTesting()) {
-    return testing_interface;
-  }
-  return &sbplayer_interface_;
+  return sbplayer_interface_ptr_;
 }
 
 void StarboardRenderer::UpdateAudioWriteDuration() {

--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -646,7 +646,7 @@ void StarboardRenderer::OnOverlayInfoChanged(const OverlayInfo& overlay_info) {
 #endif  // BUILDFLAG(IS_ANDROID)
 
 SbPlayerInterface* StarboardRenderer::GetSbPlayerInterface() {
-  if (auto* testing_interface = media::GetSbPlayerInterfaceForTesting()) {
+  if (auto* testing_interface = GetSbPlayerInterfaceForTesting()) {
     return testing_interface;
   }
   return &sbplayer_interface_;

--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -646,10 +646,14 @@ void StarboardRenderer::OnOverlayInfoChanged(const OverlayInfo& overlay_info) {
 #endif  // BUILDFLAG(IS_ANDROID)
 
 SbPlayerInterface* StarboardRenderer::GetSbPlayerInterface() {
-  if (auto* testing_interface = GetSbPlayerInterfaceForTesting()) {
-    return testing_interface;
+  if (!sbplayer_interface_ptr_) {
+    if (auto* testing_interface = GetSbPlayerInterfaceForTesting()) {
+      sbplayer_interface_ptr_ = testing_interface;
+    } else {
+      sbplayer_interface_ptr_ = &sbplayer_interface_;
+    }
   }
-  return &sbplayer_interface_;
+  return sbplayer_interface_ptr_;
 }
 
 void StarboardRenderer::UpdateAudioWriteDuration() {

--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -646,12 +646,8 @@ void StarboardRenderer::OnOverlayInfoChanged(const OverlayInfo& overlay_info) {
 #endif  // BUILDFLAG(IS_ANDROID)
 
 SbPlayerInterface* StarboardRenderer::GetSbPlayerInterface() {
-  if (!resolved_sbplayer_interface_) {
-    SbPlayerInterface* testing_interface = GetSbPlayerInterfaceForTesting();
-    resolved_sbplayer_interface_ =
-        testing_interface ? testing_interface : &sbplayer_interface_;
-  }
-  return resolved_sbplayer_interface_;
+  SbPlayerInterface* testing_interface = GetSbPlayerInterfaceForTesting();
+  return testing_interface ? testing_interface : &sbplayer_interface_;
 }
 
 void StarboardRenderer::UpdateAudioWriteDuration() {

--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -649,7 +649,7 @@ SbPlayerInterface* StarboardRenderer::GetSbPlayerInterface() {
   if (test_sbplayer_interface_) {
     return test_sbplayer_interface_;
   }
-  return &sbplayer_interface_;
+  return media::GetSbPlayerInterface();
 }
 
 void StarboardRenderer::UpdateAudioWriteDuration() {

--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -646,9 +646,6 @@ void StarboardRenderer::OnOverlayInfoChanged(const OverlayInfo& overlay_info) {
 #endif  // BUILDFLAG(IS_ANDROID)
 
 SbPlayerInterface* StarboardRenderer::GetSbPlayerInterface() {
-  if (test_sbplayer_interface_) {
-    return test_sbplayer_interface_;
-  }
   return media::GetSbPlayerInterface();
 }
 

--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -646,14 +646,10 @@ void StarboardRenderer::OnOverlayInfoChanged(const OverlayInfo& overlay_info) {
 #endif  // BUILDFLAG(IS_ANDROID)
 
 SbPlayerInterface* StarboardRenderer::GetSbPlayerInterface() {
-  if (!sbplayer_interface_ptr_) {
-    if (auto* testing_interface = GetSbPlayerInterfaceForTesting()) {
-      sbplayer_interface_ptr_ = testing_interface;
-    } else {
-      sbplayer_interface_ptr_ = &sbplayer_interface_;
-    }
+  if (auto* testing_interface = GetSbPlayerInterfaceForTesting()) {
+    return testing_interface;
   }
-  return sbplayer_interface_ptr_;
+  return &sbplayer_interface_;
 }
 
 void StarboardRenderer::UpdateAudioWriteDuration() {

--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -646,7 +646,10 @@ void StarboardRenderer::OnOverlayInfoChanged(const OverlayInfo& overlay_info) {
 #endif  // BUILDFLAG(IS_ANDROID)
 
 SbPlayerInterface* StarboardRenderer::GetSbPlayerInterface() {
-  return media::GetSbPlayerInterface();
+  if (auto* testing_interface = media::GetSbPlayerInterfaceForTesting()) {
+    return testing_interface;
+  }
+  return &sbplayer_interface_;
 }
 
 void StarboardRenderer::UpdateAudioWriteDuration() {

--- a/media/starboard/starboard_renderer.h
+++ b/media/starboard/starboard_renderer.h
@@ -251,7 +251,6 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
   PipelineStatusCallback init_cb_;
 
   DefaultSbPlayerInterface sbplayer_interface_;
-  raw_ptr<SbPlayerInterface> sbplayer_interface_ptr_ = nullptr;
 
   TimeDelta seek_time_;
 

--- a/media/starboard/starboard_renderer.h
+++ b/media/starboard/starboard_renderer.h
@@ -143,10 +143,6 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
 
   SbPlayerInterface* GetSbPlayerInterface();
 
-  void SetSbPlayerInterfaceForTesting(SbPlayerInterface* sbplayer_interface) {
-    media::SetSbPlayerInterfaceForTesting(sbplayer_interface);
-  }
-
  private:
   enum State {
     STATE_UNINITIALIZED,

--- a/media/starboard/starboard_renderer.h
+++ b/media/starboard/starboard_renderer.h
@@ -251,7 +251,6 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
   PipelineStatusCallback init_cb_;
 
   DefaultSbPlayerInterface sbplayer_interface_;
-  raw_ptr<SbPlayerInterface> resolved_sbplayer_interface_ = nullptr;
 
   TimeDelta seek_time_;
 

--- a/media/starboard/starboard_renderer.h
+++ b/media/starboard/starboard_renderer.h
@@ -251,6 +251,7 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
   PipelineStatusCallback init_cb_;
 
   DefaultSbPlayerInterface sbplayer_interface_;
+  raw_ptr<SbPlayerInterface> resolved_sbplayer_interface_ = nullptr;
 
   TimeDelta seek_time_;
 

--- a/media/starboard/starboard_renderer.h
+++ b/media/starboard/starboard_renderer.h
@@ -144,7 +144,7 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
   SbPlayerInterface* GetSbPlayerInterface();
 
   void SetSbPlayerInterfaceForTesting(SbPlayerInterface* sbplayer_interface) {
-    test_sbplayer_interface_ = sbplayer_interface;
+    media::SetSbPlayerInterfaceForTesting(sbplayer_interface);
   }
 
  private:
@@ -296,8 +296,6 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
   uint32_t last_video_frames_dropped_ = 0;
 
   SbWindow sb_window_ = kSbWindowInvalid;
-
-  raw_ptr<SbPlayerInterface> test_sbplayer_interface_;
 
   // Call to get the SbDecodeTargetGraphicsContextProvider for SbPlayerCreate().
   GetDecodeTargetGraphicsContextProviderFunc

--- a/media/starboard/starboard_renderer.h
+++ b/media/starboard/starboard_renderer.h
@@ -251,6 +251,7 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
   PipelineStatusCallback init_cb_;
 
   DefaultSbPlayerInterface sbplayer_interface_;
+  raw_ptr<SbPlayerInterface> sbplayer_interface_ptr_ = nullptr;
 
   TimeDelta seek_time_;
 

--- a/media/starboard/starboard_renderer_unittest.cc
+++ b/media/starboard/starboard_renderer_unittest.cc
@@ -418,6 +418,7 @@ TEST_F(StarboardRendererTest,
       .WillOnce(Invoke([&](SbPlayer /*player*/, SbMediaType /*type*/,
                            const SbPlayerSampleInfo* sample_infos,
                            int number_of_sample_infos) {
+        ASSERT_NE(sample_infos, nullptr);
         ASSERT_GT(number_of_sample_infos, 0);
         if (sample_infos[0].audio_sample_info.stream_info.mime) {
           written_audio_mime =
@@ -450,6 +451,7 @@ TEST_F(StarboardRendererTest,
       .WillOnce(Invoke([&](SbPlayer /*player*/, SbMediaType /*type*/,
                            const SbPlayerSampleInfo* sample_infos,
                            int number_of_sample_infos) {
+        ASSERT_NE(sample_infos, nullptr);
         ASSERT_GT(number_of_sample_infos, 0);
         if (sample_infos[0].video_sample_info.stream_info.mime) {
           written_video_mime =

--- a/media/starboard/starboard_renderer_unittest.cc
+++ b/media/starboard/starboard_renderer_unittest.cc
@@ -428,7 +428,8 @@ TEST_F(StarboardRendererTest,
       }));
 
   decoder_status_cb_(player, context_, kSbMediaTypeAudio,
-                     kSbPlayerDecoderStateNeedsData, SB_PLAYER_INITIAL_TICKET);
+                     kSbPlayerDecoderStateNeedsData,
+                     SB_PLAYER_INITIAL_TICKET + 1);
   task_environment_.RunUntilIdle();
 
   ASSERT_FALSE(audio_read_cb.is_null());
@@ -462,7 +463,8 @@ TEST_F(StarboardRendererTest,
       }));
 
   decoder_status_cb_(player, context_, kSbMediaTypeVideo,
-                     kSbPlayerDecoderStateNeedsData, SB_PLAYER_INITIAL_TICKET);
+                     kSbPlayerDecoderStateNeedsData,
+                     SB_PLAYER_INITIAL_TICKET + 1);
   task_environment_.RunUntilIdle();
 
   ASSERT_FALSE(video_read_cb.is_null());

--- a/media/starboard/starboard_renderer_unittest.cc
+++ b/media/starboard/starboard_renderer_unittest.cc
@@ -51,6 +51,20 @@ namespace {
 class StarboardRendererTest : public testing::Test {
  protected:
   StarboardRendererTest() {
+    renderer_ = std::make_unique<StarboardRenderer>(
+        task_environment_.GetMainThreadTaskRunner(),
+        std::make_unique<NullMediaLog>(),
+        /*overlay_plane_id=*/base::UnguessableToken::Create(),
+        /*audio_write_duration_local=*/base::Seconds(1),
+        /*audio_write_duration_remote=*/base::Seconds(1),
+        /*max_video_capabilities=*/"",
+        StarboardRendererConfig::ExperimentalFeatures{},
+        /*viewport_size=*/gfx::Size()
+#if BUILDFLAG(IS_ANDROID)
+            ,
+        /*android_overlay_factory_cb=*/AndroidOverlayMojoFactoryCB()
+#endif  // BUILDFLAG(IS_ANDROID)
+    );
     renderer_->SetStarboardRendererCallbacks(
         /*paint_video_hole_frame_cb=*/base::DoNothing(),
         /*update_starboard_rendering_mode_cb=*/base::DoNothing(),
@@ -128,21 +142,7 @@ class StarboardRendererTest : public testing::Test {
   void* context_ = nullptr;
   SbDecodeTargetGraphicsContextProvider
       decode_target_graphics_context_provider_;
-  std::unique_ptr<StarboardRenderer> renderer_ =
-      std::make_unique<StarboardRenderer>(
-          task_environment_.GetMainThreadTaskRunner(),
-          std::make_unique<NullMediaLog>(),
-          /*overlay_plane_id=*/base::UnguessableToken::Create(),
-          /*audio_write_duration_local=*/base::Seconds(1),
-          /*audio_write_duration_remote=*/base::Seconds(1),
-          /*max_video_capabilities=*/"",
-          StarboardRendererConfig::ExperimentalFeatures{},
-          /*viewport_size=*/gfx::Size()
-#if BUILDFLAG(IS_ANDROID)
-              ,
-          /*android_overlay_factory_cb=*/AndroidOverlayMojoFactoryCB()
-#endif  // BUILDFLAG(IS_ANDROID)
-      );
+  std::unique_ptr<StarboardRenderer> renderer_;
 };
 
 TEST_F(StarboardRendererTest, InitializeWithClearContent) {

--- a/media/starboard/starboard_renderer_unittest.cc
+++ b/media/starboard/starboard_renderer_unittest.cc
@@ -364,7 +364,7 @@ TEST_F(StarboardRendererTest,
   video_stream->set_video_decoder_config(video_config);
   streams_.push_back(std::move(video_stream));
 
-  SbPlayer player = reinterpret_cast<SbPlayer>(new MockSbPlayer());
+  SbPlayer player = nullptr;
   std::string created_audio_mime;
   std::string created_video_mime;
 
@@ -388,6 +388,7 @@ TEST_F(StarboardRendererTest,
                 created_video_mime = creation_param->video_stream_info.mime;
               }
             }
+            player = reinterpret_cast<SbPlayer>(new MockSbPlayer());
             return player;
           }));
 

--- a/media/starboard/starboard_renderer_unittest.cc
+++ b/media/starboard/starboard_renderer_unittest.cc
@@ -25,10 +25,12 @@
 #include "base/test/mock_callback.h"
 #include "base/test/task_environment.h"
 #include "build/build_config.h"
+#include "media/base/decoder_buffer.h"
 #include "media/base/demuxer_stream.h"
 #include "media/base/media_util.h"
 #include "media/base/mock_filters.h"
 #include "media/base/test_helpers.h"
+#include "media/starboard/mock_sbplayer_interface.h"
 #include "media/starboard/sbplayer_interface.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -42,82 +44,9 @@ using ::testing::Return;
 using ::testing::SaveArg;
 using ::testing::StrictMock;
 
-struct SbPlayerPrivate {
- public:
-  SbPlayerPrivate() = default;
-
-  SbPlayerPrivate(const SbPlayerPrivate&) = delete;
-  SbPlayerPrivate& operator=(const SbPlayerPrivate&) = delete;
-
-  ~SbPlayerPrivate() = default;
-};
-
 namespace media {
 
 namespace {
-
-class MockSbPlayerInterface : public SbPlayerInterface {
- public:
-  MOCK_METHOD8(Create,
-               SbPlayer(SbWindow,
-                        const SbPlayerCreationParam*,
-                        SbPlayerDeallocateSampleFunc,
-                        SbPlayerDecoderStatusFunc,
-                        SbPlayerStatusFunc,
-                        SbPlayerErrorFunc,
-                        void*,
-                        SbDecodeTargetGraphicsContextProvider*));
-  SbPlayerOutputMode GetPreferredOutputMode(
-      const SbPlayerCreationParam* creation_param) override {
-    return kSbPlayerOutputModePunchOut;
-  }
-  void Destroy(SbPlayer player) override {
-    if (player) {
-      delete player;
-    }
-  }
-  MOCK_METHOD3(Seek, void(SbPlayer, base::TimeDelta, int));
-  MOCK_METHOD4(WriteSamples,
-               void(SbPlayer, SbMediaType, const SbPlayerSampleInfo*, int));
-  int GetMaximumNumberOfSamplesPerWrite(SbPlayer player,
-                                        SbMediaType sample_type) override {
-    return 1;
-  }
-  MOCK_METHOD2(WriteEndOfStream, void(SbPlayer, SbMediaType));
-  MOCK_METHOD6(SetBounds, void(SbPlayer, int, int, int, int, int));
-  bool SetPlaybackRate(SbPlayer player, double playback_rate) override {
-    return true;
-  }
-  void SetVolume(SbPlayer player, double volume) override {}
-  MOCK_METHOD2(GetInfo, void(SbPlayer, SbPlayerInfo*));
-  SbDecodeTarget GetCurrentFrame(SbPlayer player) override {
-    return kSbDecodeTargetInvalid;
-  }
-
-#if BUILDFLAG(IS_IOS_TVOS)
-  MOCK_METHOD6(CreateUrlPlayer,
-               SbPlayer(const char*,
-                        SbWindow,
-                        SbPlayerStatusFunc,
-                        SbPlayerEncryptedMediaInitDataEncounteredCB,
-                        SbPlayerErrorFunc,
-                        void*));
-  MOCK_METHOD2(SetUrlPlayerDrmSystem, void(SbPlayer, SbDrmSystem));
-  MOCK_METHOD2(GetUrlPlayerExtraInfo, void(SbPlayer, SbUrlPlayerExtraInfo*));
-
-  bool GetUrlPlayerOutputModeSupported(
-      SbPlayerOutputMode output_mode) override {
-    return true;
-  }
-#endif  // BUILDFLAG(IS_IOS_TVOS)
-
-  bool GetAudioConfiguration(
-      SbPlayer player,
-      int index,
-      SbMediaAudioConfiguration* out_audio_configuration) {
-    return true;
-  }
-};
 
 class StarboardRendererTest : public testing::Test {
  protected:
@@ -409,6 +338,135 @@ TEST_F(StarboardRendererTest, RejectCdmSwitching) {
   EXPECT_CALL(second_set_cdm_cb, Run(false));
   renderer_->SetCdm(&cdm_context_, second_set_cdm_cb.Get());
   task_environment_.RunUntilIdle();
+}
+
+TEST_F(StarboardRendererTest,
+       CustomMimeTypesPassedToSbPlayerCreateAndWriteSamples) {
+  const std::string kCustomAudioMime =
+      "audio/mp4; codecs=\"mp4a.40.2\"; channels=8; bitrate=768000; "
+      "audiopassthrough=true; enableresetaudiodecoder=true;";
+  const std::string kCustomVideoMime =
+      "video/mp4; codecs=\"avc1.64002a\"; width=3840; height=2160; "
+      "tunnelmode=true; hdr=hdr10plus; framerate=60;";
+
+  auto audio_stream =
+      std::make_unique<StrictMock<MockDemuxerStream>>(DemuxerStream::AUDIO);
+  AudioDecoderConfig audio_config = TestAudioConfig::Normal();
+  audio_config.set_mime_type(kCustomAudioMime);
+  audio_stream->set_audio_decoder_config(audio_config);
+  streams_.push_back(std::move(audio_stream));
+
+  auto video_stream =
+      std::make_unique<StrictMock<MockDemuxerStream>>(DemuxerStream::VIDEO);
+  VideoDecoderConfig video_config = TestVideoConfig::Normal();
+  video_config.set_mime_type(kCustomVideoMime);
+  video_stream->set_video_decoder_config(video_config);
+  streams_.push_back(std::move(video_stream));
+
+  SbPlayer player = new SbPlayerPrivate();
+  std::string created_audio_mime;
+  std::string created_video_mime;
+
+  EXPECT_CALL(mock_sbplayer_interface_, Create(_, _, _, _, _, _, _, _))
+      .WillOnce(Invoke(
+          [&](SbWindow /*window*/, const SbPlayerCreationParam* creation_param,
+              SbPlayerDeallocateSampleFunc /*sample_deallocate_func*/,
+              SbPlayerDecoderStatusFunc decoder_status_func,
+              SbPlayerStatusFunc player_status_func,
+              SbPlayerErrorFunc player_error_func, void* context,
+              SbDecodeTargetGraphicsContextProvider* /*context_provider*/) {
+            decoder_status_cb_ = decoder_status_func;
+            player_status_cb_ = player_status_func;
+            player_error_cb_ = player_error_func;
+            context_ = context;
+            if (creation_param) {
+              if (creation_param->audio_stream_info.mime) {
+                created_audio_mime = creation_param->audio_stream_info.mime;
+              }
+              if (creation_param->video_stream_info.mime) {
+                created_video_mime = creation_param->video_stream_info.mime;
+              }
+            }
+            return player;
+          }));
+
+  EXPECT_CALL(renderer_init_cb_, Run(HasStatusCode(PIPELINE_OK)));
+  renderer_->Initialize(&media_resource_, &renderer_client_,
+                        renderer_init_cb_.Get());
+  task_environment_.RunUntilIdle();
+
+  // Verify that SbPlayerCreate received the custom MIME strings.
+  EXPECT_EQ(created_audio_mime, kCustomAudioMime);
+  EXPECT_EQ(created_video_mime, kCustomVideoMime);
+
+  ASSERT_TRUE(player_status_cb_);
+  player_status_cb_(player, context_, kSbPlayerStateInitialized,
+                    SB_PLAYER_INITIAL_TICKET);
+  task_environment_.RunUntilIdle();
+
+  // Verify WriteSamples for Audio with custom MIME parameters.
+  DemuxerStream::ReadCB audio_read_cb;
+  EXPECT_CALL(*streams_[0], OnRead(_))
+      .WillOnce(Invoke(
+          [&](DemuxerStream::ReadCB& cb) { audio_read_cb = std::move(cb); }));
+
+  std::string written_audio_mime;
+  EXPECT_CALL(mock_sbplayer_interface_,
+              WriteSamples(player, kSbMediaTypeAudio, _, _))
+      .WillOnce(Invoke([&](SbPlayer /*player*/, SbMediaType /*type*/,
+                           const SbPlayerSampleInfo* sample_infos,
+                           int number_of_sample_infos) {
+        ASSERT_GT(number_of_sample_infos, 0);
+        if (sample_infos[0].audio_sample_info.stream_info.mime) {
+          written_audio_mime =
+              sample_infos[0].audio_sample_info.stream_info.mime;
+        }
+      }));
+
+  decoder_status_cb_(player, context_, kSbMediaTypeAudio,
+                     kSbPlayerDecoderStateNeedsData, SB_PLAYER_INITIAL_TICKET);
+  task_environment_.RunUntilIdle();
+
+  ASSERT_FALSE(audio_read_cb.is_null());
+  const uint8_t kAudioData[] = {0x01, 0x02, 0x03, 0x04};
+  scoped_refptr<DecoderBuffer> audio_buffer =
+      DecoderBuffer::CopyFrom(kAudioData);
+  std::move(audio_read_cb).Run(DemuxerStream::kOk, {audio_buffer});
+  task_environment_.RunUntilIdle();
+
+  EXPECT_EQ(written_audio_mime, kCustomAudioMime);
+
+  // Verify WriteSamples for Video with custom MIME parameters.
+  DemuxerStream::ReadCB video_read_cb;
+  EXPECT_CALL(*streams_[1], OnRead(_))
+      .WillOnce(Invoke(
+          [&](DemuxerStream::ReadCB& cb) { video_read_cb = std::move(cb); }));
+
+  std::string written_video_mime;
+  EXPECT_CALL(mock_sbplayer_interface_,
+              WriteSamples(player, kSbMediaTypeVideo, _, _))
+      .WillOnce(Invoke([&](SbPlayer /*player*/, SbMediaType /*type*/,
+                           const SbPlayerSampleInfo* sample_infos,
+                           int number_of_sample_infos) {
+        ASSERT_GT(number_of_sample_infos, 0);
+        if (sample_infos[0].video_sample_info.stream_info.mime) {
+          written_video_mime =
+              sample_infos[0].video_sample_info.stream_info.mime;
+        }
+      }));
+
+  decoder_status_cb_(player, context_, kSbMediaTypeVideo,
+                     kSbPlayerDecoderStateNeedsData, SB_PLAYER_INITIAL_TICKET);
+  task_environment_.RunUntilIdle();
+
+  ASSERT_FALSE(video_read_cb.is_null());
+  const uint8_t kVideoData[] = {0x00, 0x00, 0x00, 0x01};
+  scoped_refptr<DecoderBuffer> video_buffer =
+      DecoderBuffer::CopyFrom(kVideoData);
+  std::move(video_read_cb).Run(DemuxerStream::kOk, {video_buffer});
+  task_environment_.RunUntilIdle();
+
+  EXPECT_EQ(written_video_mime, kCustomVideoMime);
 }
 
 }  // namespace

--- a/media/starboard/starboard_renderer_unittest.cc
+++ b/media/starboard/starboard_renderer_unittest.cc
@@ -133,7 +133,7 @@ class StarboardRendererTest : public testing::Test {
   NiceMock<MockMediaResource> media_resource_;
   NiceMock<MockRendererClient> renderer_client_;
   std::vector<std::unique_ptr<StrictMock<MockDemuxerStream>>> streams_;
-  StrictMock<MockSbPlayerInterface> mock_sbplayer_interface_;
+  NiceMock<MockSbPlayerInterface> mock_sbplayer_interface_;
   ScopedSbPlayerInterfaceForTesting scoped_sbplayer_interface_{
       &mock_sbplayer_interface_};
   SbPlayerDecoderStatusFunc decoder_status_cb_ = nullptr;

--- a/media/starboard/starboard_renderer_unittest.cc
+++ b/media/starboard/starboard_renderer_unittest.cc
@@ -85,7 +85,7 @@ class StarboardRendererTest : public testing::Test {
         .WillRepeatedly(Invoke(this, &StarboardRendererTest::GetAllStreams));
   }
 
-  ~StarboardRendererTest() override { renderer_.reset(); }
+  ~StarboardRendererTest() override = default;
 
   void AddStream(DemuxerStream::Type type, bool encrypted) {
     streams_.push_back(CreateMockDemuxerStream(type, encrypted));

--- a/media/starboard/starboard_renderer_unittest.cc
+++ b/media/starboard/starboard_renderer_unittest.cc
@@ -418,9 +418,10 @@ TEST_F(StarboardRendererTest,
       .WillOnce(Invoke([&](SbPlayer /*player*/, SbMediaType /*type*/,
                            const SbPlayerSampleInfo* sample_infos,
                            int number_of_sample_infos) {
-        ASSERT_NE(sample_infos, nullptr);
-        ASSERT_GT(number_of_sample_infos, 0);
-        if (sample_infos[0].audio_sample_info.stream_info.mime) {
+        EXPECT_NE(sample_infos, nullptr);
+        EXPECT_GT(number_of_sample_infos, 0);
+        if (sample_infos && number_of_sample_infos > 0 &&
+            sample_infos[0].audio_sample_info.stream_info.mime) {
           written_audio_mime =
               sample_infos[0].audio_sample_info.stream_info.mime;
         }
@@ -451,9 +452,10 @@ TEST_F(StarboardRendererTest,
       .WillOnce(Invoke([&](SbPlayer /*player*/, SbMediaType /*type*/,
                            const SbPlayerSampleInfo* sample_infos,
                            int number_of_sample_infos) {
-        ASSERT_NE(sample_infos, nullptr);
-        ASSERT_GT(number_of_sample_infos, 0);
-        if (sample_infos[0].video_sample_info.stream_info.mime) {
+        EXPECT_NE(sample_infos, nullptr);
+        EXPECT_GT(number_of_sample_infos, 0);
+        if (sample_infos && number_of_sample_infos > 0 &&
+            sample_infos[0].video_sample_info.stream_info.mime) {
           written_video_mime =
               sample_infos[0].video_sample_info.stream_info.mime;
         }

--- a/media/starboard/starboard_renderer_unittest.cc
+++ b/media/starboard/starboard_renderer_unittest.cc
@@ -401,11 +401,6 @@ TEST_F(StarboardRendererTest,
   EXPECT_EQ(created_audio_mime, kCustomAudioMime);
   EXPECT_EQ(created_video_mime, kCustomVideoMime);
 
-  ASSERT_TRUE(player_status_cb_);
-  player_status_cb_(player, context_, kSbPlayerStateInitialized,
-                    SB_PLAYER_INITIAL_TICKET);
-  task_environment_.RunUntilIdle();
-
   // Verify WriteSamples for Audio with custom MIME parameters.
   DemuxerStream::ReadCB audio_read_cb;
   EXPECT_CALL(*streams_[0], OnRead(_))
@@ -428,8 +423,7 @@ TEST_F(StarboardRendererTest,
       }));
 
   decoder_status_cb_(player, context_, kSbMediaTypeAudio,
-                     kSbPlayerDecoderStateNeedsData,
-                     SB_PLAYER_INITIAL_TICKET + 1);
+                     kSbPlayerDecoderStateNeedsData, SB_PLAYER_INITIAL_TICKET);
   task_environment_.RunUntilIdle();
 
   ASSERT_FALSE(audio_read_cb.is_null());
@@ -463,8 +457,7 @@ TEST_F(StarboardRendererTest,
       }));
 
   decoder_status_cb_(player, context_, kSbMediaTypeVideo,
-                     kSbPlayerDecoderStateNeedsData,
-                     SB_PLAYER_INITIAL_TICKET + 1);
+                     kSbPlayerDecoderStateNeedsData, SB_PLAYER_INITIAL_TICKET);
   task_environment_.RunUntilIdle();
 
   ASSERT_FALSE(video_read_cb.is_null());
@@ -475,6 +468,11 @@ TEST_F(StarboardRendererTest,
   task_environment_.RunUntilIdle();
 
   EXPECT_EQ(written_video_mime, kCustomVideoMime);
+
+  ASSERT_TRUE(player_status_cb_);
+  player_status_cb_(player, context_, kSbPlayerStateInitialized,
+                    SB_PLAYER_INITIAL_TICKET);
+  task_environment_.RunUntilIdle();
 }
 
 }  // namespace

--- a/media/starboard/starboard_renderer_unittest.cc
+++ b/media/starboard/starboard_renderer_unittest.cc
@@ -51,7 +51,6 @@ namespace {
 class StarboardRendererTest : public testing::Test {
  protected:
   StarboardRendererTest() {
-    renderer_->SetSbPlayerInterfaceForTesting(&mock_sbplayer_interface_);
     renderer_->SetStarboardRendererCallbacks(
         /*paint_video_hole_frame_cb=*/base::DoNothing(),
         /*update_starboard_rendering_mode_cb=*/base::DoNothing(),

--- a/media/starboard/starboard_renderer_unittest.cc
+++ b/media/starboard/starboard_renderer_unittest.cc
@@ -71,7 +71,7 @@ class StarboardRendererTest : public testing::Test {
         .WillRepeatedly(Invoke(this, &StarboardRendererTest::GetAllStreams));
   }
 
-  ~StarboardRendererTest() override {}
+  ~StarboardRendererTest() override { renderer_.reset(); }
 
   void AddStream(DemuxerStream::Type type, bool encrypted) {
     streams_.push_back(CreateMockDemuxerStream(type, encrypted));
@@ -128,7 +128,7 @@ class StarboardRendererTest : public testing::Test {
   void* context_ = nullptr;
   SbDecodeTargetGraphicsContextProvider
       decode_target_graphics_context_provider_;
-  const std::unique_ptr<StarboardRenderer> renderer_ =
+  std::unique_ptr<StarboardRenderer> renderer_ =
       std::make_unique<StarboardRenderer>(
           task_environment_.GetMainThreadTaskRunner(),
           std::make_unique<NullMediaLog>(),

--- a/media/starboard/starboard_renderer_unittest.cc
+++ b/media/starboard/starboard_renderer_unittest.cc
@@ -90,7 +90,7 @@ class StarboardRendererTest : public testing::Test {
     AddStream(DemuxerStream::AUDIO, encrypted);
     AddStream(DemuxerStream::VIDEO, encrypted);
 
-    SbPlayer player = new SbPlayerPrivate();
+    SbPlayer player = reinterpret_cast<SbPlayer>(new MockSbPlayer());
     EXPECT_CALL(mock_sbplayer_interface_, Create(_, _, _, _, _, _, _, _))
         .WillOnce(DoAll(SaveArg<3>(&decoder_status_cb_),
                         SaveArg<4>(&player_status_cb_),
@@ -121,6 +121,8 @@ class StarboardRendererTest : public testing::Test {
   NiceMock<MockRendererClient> renderer_client_;
   std::vector<std::unique_ptr<StrictMock<MockDemuxerStream>>> streams_;
   StrictMock<MockSbPlayerInterface> mock_sbplayer_interface_;
+  ScopedSbPlayerInterfaceForTesting scoped_sbplayer_interface_{
+      &mock_sbplayer_interface_};
   SbPlayerDecoderStatusFunc decoder_status_cb_ = nullptr;
   SbPlayerStatusFunc player_status_cb_ = nullptr;
   SbPlayerErrorFunc player_error_cb_ = nullptr;
@@ -176,7 +178,7 @@ TEST_F(StarboardRendererTest, InitializeThenSetCdm) {
   AddStream(DemuxerStream::AUDIO, /*encrypted=*/true);
   AddStream(DemuxerStream::VIDEO, /*encrypted=*/true);
 
-  SbPlayer player = new SbPlayerPrivate();
+  SbPlayer player = reinterpret_cast<SbPlayer>(new MockSbPlayer());
   EXPECT_CALL(mock_sbplayer_interface_, Create(_, _, _, _, _, _, _, _))
       .WillOnce(DoAll(SaveArg<3>(&decoder_status_cb_),
                       SaveArg<4>(&player_status_cb_),
@@ -268,7 +270,7 @@ TEST_F(StarboardRendererTest, OnErrorDuringInitialization) {
   AddStream(DemuxerStream::AUDIO, /*encrypted=*/false);
   AddStream(DemuxerStream::VIDEO, /*encrypted=*/false);
 
-  SbPlayer player = new SbPlayerPrivate();
+  SbPlayer player = reinterpret_cast<SbPlayer>(new MockSbPlayer());
   EXPECT_CALL(mock_sbplayer_interface_, Create(_, _, _, _, _, _, _, _))
       .WillOnce(DoAll(SaveArg<3>(&decoder_status_cb_),
                       SaveArg<4>(&player_status_cb_),
@@ -294,7 +296,7 @@ TEST_F(StarboardRendererTest, OnDemuxerErrorDuringInitialization) {
   AddStream(DemuxerStream::AUDIO, /*encrypted=*/false);
   AddStream(DemuxerStream::VIDEO, /*encrypted=*/false);
 
-  SbPlayer player = new SbPlayerPrivate();
+  SbPlayer player = reinterpret_cast<SbPlayer>(new MockSbPlayer());
   EXPECT_CALL(mock_sbplayer_interface_, Create(_, _, _, _, _, _, _, _))
       .WillOnce(DoAll(SaveArg<3>(&decoder_status_cb_),
                       SaveArg<4>(&player_status_cb_),
@@ -363,7 +365,7 @@ TEST_F(StarboardRendererTest,
   video_stream->set_video_decoder_config(video_config);
   streams_.push_back(std::move(video_stream));
 
-  SbPlayer player = new SbPlayerPrivate();
+  SbPlayer player = reinterpret_cast<SbPlayer>(new MockSbPlayer());
   std::string created_audio_mime;
   std::string created_video_mime;
 

--- a/media/starboard/starboard_renderer_unittest.cc
+++ b/media/starboard/starboard_renderer_unittest.cc
@@ -364,7 +364,7 @@ TEST_F(StarboardRendererTest,
   video_stream->set_video_decoder_config(video_config);
   streams_.push_back(std::move(video_stream));
 
-  SbPlayer player = nullptr;
+  SbPlayer player = reinterpret_cast<SbPlayer>(new MockSbPlayer());
   std::string created_audio_mime;
   std::string created_video_mime;
 
@@ -388,7 +388,6 @@ TEST_F(StarboardRendererTest,
                 created_video_mime = creation_param->video_stream_info.mime;
               }
             }
-            player = reinterpret_cast<SbPlayer>(new MockSbPlayer());
             return player;
           }));
 

--- a/media/starboard/starboard_renderer_unittest.cc
+++ b/media/starboard/starboard_renderer_unittest.cc
@@ -133,7 +133,7 @@ class StarboardRendererTest : public testing::Test {
   NiceMock<MockMediaResource> media_resource_;
   NiceMock<MockRendererClient> renderer_client_;
   std::vector<std::unique_ptr<StrictMock<MockDemuxerStream>>> streams_;
-  NiceMock<MockSbPlayerInterface> mock_sbplayer_interface_;
+  StrictMock<MockSbPlayerInterface> mock_sbplayer_interface_;
   ScopedSbPlayerInterfaceForTesting scoped_sbplayer_interface_{
       &mock_sbplayer_interface_};
   SbPlayerDecoderStatusFunc decoder_status_cb_ = nullptr;


### PR DESCRIPTION
media: Extract shared MockSbPlayerInterface and add ScopedSbPlayerInterfaceForTesting

Extracts `MockSbPlayerInterface` into `//media/starboard:test_support` for
reuse across test targets (unit tests, Mojo service tests, and browser tests).

### Key Changes:
- **Shared Test Support Target**:
  - `media/starboard/mock_sbplayer_interface.{h,cc}`: Extracted `MockSbPlayerInterface` using modern `MOCK_METHOD(...)` syntax.
  - Defined `struct MockSbPlayer` in `namespace media` to back opaque `SbPlayer` handles in tests without ODR conflicts.
  - Added `source_set("test_support")` in `media/starboard/BUILD.gn` and exposed it via `//media:test_support` in `media/BUILD.gn`.
- **Testing Interface Override Hooks**:
  - Added `media::SetSbPlayerInterfaceForTesting()` / `media::GetSbPlayerInterfaceForTesting()` in `media/starboard/sbplayer_interface.{h,cc}`.
  - Added `media::ScopedSbPlayerInterfaceForTesting` RAII helper to automatically register the mock when a test starts and restore state upon test exit or failure.
  - This moves mock injection from `StarboardRenderer` instance methods to `sbplayer_interface.h` (mirroring the `media::SetSbMediaInterfaceForTesting` pattern in `sbmedia_interface.h`), enabling browser and service-level tests where `StarboardRenderer` is constructed internally by the pipeline.
- **StarboardRenderer Integration**:
  - Updated `StarboardRenderer::GetSbPlayerInterface()` to check for the testing mock first, falling back to each renderer instance's own `sbplayer_interface_` member in production to prevent shared mutable state across renderers.
- **Unit Test Coverage**:
  - Updated `StarboardRendererTest` in `media/starboard/starboard_renderer_unittest.cc` to use `ScopedSbPlayerInterfaceForTesting` and `MockSbPlayerInterface`.
  - Added a test verifying custom MIME parameter propagation to `SbPlayerCreate` and `SbPlayerWriteSamples`.

Bug: 531137547
BUG=531137547
TAG=agy
CONV=3d16d398-cb5e-4e32-8c60-6a317e27597b