### PR TITLE
Narrow DevTools extension host permissions to localhost and loopback

### DIFF
--- a/cobalt/tools/devtools_extension/manifest.json
+++ b/cobalt/tools/devtools_extension/manifest.json
@@ -18,8 +18,8 @@
     "storage"
   ],
   "host_permissions": [
-    "http://*/*",
-    "https://*/*"
+    "http://localhost/*",
+    "http://127.0.0.1/*"
   ],
   "icons": {
     "16": "icons/icon16.png",


### PR DESCRIPTION
Narrow the host permissions for the Cobalt DevTools extension to
specifically target localhost and the 127.0.0.1 loopback address.

This is to meet the publish requirements of the Chrome extension.

Bug: 548067422