### PR TITLE
tvos: Poll URL player resolution for adaptive HLS

### DIFF
--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -505,6 +505,8 @@ TimeDelta StarboardRenderer::GetMediaTime() {
   }
 #if BUILDFLAG(IS_IOS_TVOS)
   if (IsUrlPlayer()) {
+    UpdateUrlPlayerVideoResolution();
+
     if (duration_change_cb_ && duration != kNoTimestamp &&
         duration != last_duration_) {
       last_duration_ = duration;
@@ -594,24 +596,38 @@ bool StarboardRenderer::IsUrlPlayer() const {
   return !source_url_.empty();
 }
 
+void StarboardRenderer::UpdateUrlPlayerVideoResolution() {
+  DCHECK(task_runner_->RunsTasksInCurrentSequence());
+  if (!player_bridge_) {
+    return;
+  }
+
+  int width = 0, height = 0;
+  player_bridge_->GetVideoResolution(&width, &height);
+  if (width <= 0 || height <= 0) {
+    LOG(WARNING) << "Platform player reported invalid dimensions (" << width
+                 << "x" << height
+                 << ") at presenting; skipping video hole update.";
+    return;
+  }
+
+  const gfx::Size size(width, height);
+  if (size == url_player_video_size_) {
+    return;
+  }
+
+  url_player_video_size_ = size;
+  client_->OnVideoNaturalSizeChange(size);
+  paint_video_hole_frame_cb_.Run(size);
+}
+
 void StarboardRenderer::OnUrlPlayerPresenting() {
   DCHECK(task_runner_->RunsTasksInCurrentSequence());
   if (!player_bridge_) {
     return;
   }
-  int width = 0, height = 0;
-  player_bridge_->GetVideoResolution(&width, &height);
-  if (width > 0 && height > 0) {
-    gfx::Size size(width, height);
-    client_->OnVideoNaturalSizeChange(size);
-    // TODO(b/541996730): Handle resolution changes during adaptive HLS
-    // playback. Currently this is only called once at presenting state.
-    paint_video_hole_frame_cb_.Run(size);
-  } else {
-    LOG(WARNING) << "Platform player reported invalid dimensions (" << width
-                 << "x" << height
-                 << ") at presenting; skipping video hole update.";
-  }
+
+  UpdateUrlPlayerVideoResolution();
 
   // Re-apply playback rate; the platform player ignores rate changes
   // before it is ready to play.

--- a/media/starboard/starboard_renderer.h
+++ b/media/starboard/starboard_renderer.h
@@ -176,6 +176,8 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
   // Handles presenting state for URL player: propagates video resolution
   // for hole-punch rendering and re-applies playback rate.
   void OnUrlPlayerPresenting();
+  // Reads and propagates a valid URL-player resolution when it changes.
+  void UpdateUrlPlayerVideoResolution();
 #endif  // BUILDFLAG(IS_IOS_TVOS)
 
   void UpdateAudioWriteDuration();
@@ -261,6 +263,7 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
   TimeDelta last_buffer_start_;
   TimeDelta last_buffer_length_;
   TimeDelta last_duration_ = kNoTimestamp;
+  gfx::Size url_player_video_size_;
 #endif  // BUILDFLAG(IS_IOS_TVOS)
 #if BUILDFLAG(IS_ANDROID)
   RequestOverlayInfoCallBack request_overlay_info_cb_;


### PR DESCRIPTION
Extract resolution polling from OnUrlPlayerPresenting() into a new
UpdateUrlPlayerVideoResolution() method that is called on every
GetMediaTime() tick. This enables detecting resolution changes during
adaptive HLS playback, where the platform player may switch between
quality levels mid-stream.

The previous implementation only read resolution once at presenting
state and had a TODO for adaptive resolution handling. The new approach
uses a cached gfx::Size to detect changes and only propagates
OnVideoNaturalSizeChange and paint_video_hole_frame_cb_ when the
resolution actually differs.

Blocked by https://github.com/youtube/cobalt/pull/11548

Bug: 541996730
Bug: 512045535