### PR TITLE
[tvos] Fix compiler error in oemcrypto_engine_device_properties_uikit.mm

### DIFF
--- a/starboard/tvos/shared/BUILD.gn
+++ b/starboard/tvos/shared/BUILD.gn
@@ -249,6 +249,6 @@ static_library("starboard_platform") {
   }
 
   if (use_starboard_media) {
-    defines += [ "USE_STARBOARD_MEDIA" ]
+    defines = [ "USE_STARBOARD_MEDIA" ]
   }
 }

--- a/starboard/tvos/shared/BUILD.gn
+++ b/starboard/tvos/shared/BUILD.gn
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import("//starboard/build/buildflags.gni")
 import("//starboard/shared/starboard/player/buildfiles.gni")
 
 if (is_internal_build) {
@@ -245,5 +246,9 @@ static_library("starboard_platform") {
       "//starboard/shared/stub/drm_update_session.cc",
       "media/drm_system_platform.mm",
     ]
+  }
+
+  if (use_starboard_media) {
+    defines += [ "USE_STARBOARD_MEDIA" ]
   }
 }

--- a/starboard/tvos/shared/media/oemcrypto_engine_device_properties_uikit.mm
+++ b/starboard/tvos/shared/media/oemcrypto_engine_device_properties_uikit.mm
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#define USE_STARBOARD_MEDIA
+
 #include "starboard/tvos/shared/media/oemcrypto_engine_device_properties_uikit.h"
 
 #include <atomic>

--- a/starboard/tvos/shared/media/oemcrypto_engine_device_properties_uikit.mm
+++ b/starboard/tvos/shared/media/oemcrypto_engine_device_properties_uikit.mm
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#define USE_STARBOARD_MEDIA
+
 #include "starboard/tvos/shared/media/oemcrypto_engine_device_properties_uikit.h"
 
 #include <atomic>
@@ -88,7 +90,7 @@ void OEMCrypto_AlwaysEnforceOutputProtection() {
 
 class CryptoEngineUikit : public CryptoEngine {
  public:
-  explicit CryptoEngineUikit(scoped_ptr<FileSystem> file_system)
+  explicit CryptoEngineUikit(scoped_ptr<wvcdm::FileSystem> file_system)
       : CryptoEngine(file_system) {}
 
   OEMCrypto_HDCP_Capability config_current_hdcp_capability() override {
@@ -110,7 +112,7 @@ class CryptoEngineUikit : public CryptoEngine {
 };
 
 CryptoEngine* CryptoEngine::MakeCryptoEngine(
-    scoped_ptr<FileSystem> file_system) {
+    scoped_ptr<wvcdm::FileSystem> file_system) {
   return new CryptoEngineUikit(file_system);
 }
 

--- a/starboard/tvos/shared/media/oemcrypto_engine_device_properties_uikit.mm
+++ b/starboard/tvos/shared/media/oemcrypto_engine_device_properties_uikit.mm
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#define USE_STARBOARD_MEDIA
-
 #include "starboard/tvos/shared/media/oemcrypto_engine_device_properties_uikit.h"
 
 #include <atomic>


### PR DESCRIPTION
wvcdm::FileSystem needs the qualifier or else it leads to undefined symbol error due to the wvoec_mock namespace. Also needs starboard media flag to include wvcdm:: Errors below:

```
ld64.lld: error: undefined symbol: wvoec_mock::CryptoEngine::CryptoEngine(wvoec_mock::scoped_ptr<wvoec_mock::FileSystem>)
>>> referenced by third_party/cobalt/app/tvos/cotvos/branch_27_lts/lib/release/arm64/cobalt.a(oemcrypto_engine_device_properties_uikit.o):(symbol wvoec_mock::CryptoEngine::MakeCryptoEngine(wvoec_mock::scoped_ptr<wvoec_mock::FileSystem>)+0x30)
```
```
../../starboard/tvos/shared/media/oemcrypto_engine_device_properties_uikit.mm:91:41: error: use of undeclared identifier 'wvcdm'
   91 |   explicit CryptoEngineUikit(scoped_ptr<wvcdm::FileSystem> file_system)
```

Bug: 546727215