### PR TITLE
cobalt: Add memory metrics to Performance API

### DIFF
--- a/base/process/process_metrics.h
+++ b/base/process/process_metrics.h
@@ -95,6 +95,7 @@ struct ProcessMemoryInfo {
 
 #if BUILDFLAG(IS_COBALT)
   uint64_t vm_size_bytes = 0;
+  uint64_t vm_hwm_bytes = 0;
 #endif  // BUILDFLAG(IS_COBALT)
 
 #if BUILDFLAG(IS_WIN)

--- a/base/process/process_metrics_linux.cc
+++ b/base/process/process_metrics_linux.cc
@@ -156,12 +156,16 @@ ProcessMetrics::GetMemoryInfo() const {
   }
   ProcessMemoryInfo dump;
   for (const auto& [key, value_str] : *pairs) {
-    if (key == "VmSize") {
 #if BUILDFLAG(IS_COBALT)
+    if (key == "VmSize") {
       dump.vm_size_bytes =
           static_cast<uint64_t>(GetKbFieldAsSizeT(value_str)) * 1024;
-#endif    // BUILDFLAG(IS_COBALT)
-    } else if (key == "VmSwap") {
+    } else if (key == "VmHWM") {
+      dump.vm_hwm_bytes =
+          static_cast<uint64_t>(GetKbFieldAsSizeT(value_str)) * 1024;
+    } else
+#endif  // BUILDFLAG(IS_COBALT)
+    if (key == "VmSwap") {
       dump.vm_swap_bytes =
           static_cast<uint64_t>(GetKbFieldAsSizeT(value_str)) * 1024;
     } else if (key == "VmRSS") {

--- a/base/process/process_metrics_unittest.cc
+++ b/base/process/process_metrics_unittest.cc
@@ -759,6 +759,12 @@ TEST_F(SystemMetricsTest, TestValidMemoryInfo) {
 #if BUILDFLAG(IS_WIN)
   EXPECT_GT(memory_info->private_bytes, 0U);
 #endif  // BUILDFLAG(IS_WIN)
+
+#if BUILDFLAG(IS_COBALT) && \
+    (BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID))
+  EXPECT_GT(memory_info->vm_size_bytes, 0U);
+  EXPECT_GT(memory_info->vm_hwm_bytes, 0U);
+#endif  // BUILDFLAG(IS_COBALT) && ...
 }
 
 #if BUILDFLAG(IS_CHROMEOS)

--- a/cobalt/browser/performance/performance_impl.cc
+++ b/cobalt/browser/performance/performance_impl.cc
@@ -21,12 +21,24 @@
 #include "base/task/thread_pool.h"
 #include "build/build_config.h"
 
+#if BUILDFLAG(IS_POSIX)
+#include <unistd.h>
+#endif
+
+#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID)
+#include "base/debug/proc_maps_linux.h"
+#endif
+
 #if BUILDFLAG(IS_ANDROIDTV)
 #include "starboard/android/shared/starboard_bridge.h"
 
 using ::starboard::StarboardBridge;
 #elif BUILDFLAG(IS_STARBOARD)
 #include "starboard/common/time.h"
+#endif
+
+#if BUILDFLAG(IS_STARBOARD)
+#include "starboard/system.h"
 #endif
 
 namespace performance {
@@ -59,7 +71,7 @@ void PerformanceImpl::MeasureAvailableCpuMemory(
 }
 
 void PerformanceImpl::MeasureUsedCpuMemory(
-    MeasureAvailableCpuMemoryCallback callback) {
+    MeasureUsedCpuMemoryCallback callback) {
   base::ThreadPool::PostTaskAndReplyWithResult(
       FROM_HERE, {base::MayBlock(), base::TaskPriority::USER_VISIBLE},
       base::BindOnce([]() -> uint64_t {
@@ -109,6 +121,100 @@ void PerformanceImpl::MeasureReservedVirtualMemory(
         return info.has_value() ? info->vm_size_bytes : 0;
       }),
       std::move(callback));
+}
+
+void PerformanceImpl::MeasureRssHighWaterMarkMemory(
+    MeasureRssHighWaterMarkMemoryCallback callback) {
+#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID)
+  base::ThreadPool::PostTaskAndReplyWithResult(
+      FROM_HERE, {base::MayBlock(), base::TaskPriority::USER_VISIBLE},
+      base::BindOnce([]() -> uint64_t {
+        auto process_metrics = base::ProcessMetrics::CreateProcessMetrics(
+            base::GetCurrentProcessHandle());
+        if (!process_metrics) {
+          return 0;
+        }
+        auto info = process_metrics->GetMemoryInfo();
+        return info.has_value() ? info->vm_hwm_bytes : 0;
+      }),
+      std::move(callback));
+#else
+  std::move(callback).Run(0);
+#endif
+}
+
+void PerformanceImpl::MeasureUsedRssAnonMemory(
+    MeasureUsedRssAnonMemoryCallback callback) {
+#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID)
+  base::ThreadPool::PostTaskAndReplyWithResult(
+      FROM_HERE, {base::MayBlock(), base::TaskPriority::USER_VISIBLE},
+      base::BindOnce([]() -> uint64_t {
+        auto process_metrics = base::ProcessMetrics::CreateProcessMetrics(
+            base::GetCurrentProcessHandle());
+        if (!process_metrics) {
+          return 0;
+        }
+        auto info = process_metrics->GetMemoryInfo();
+        return info.has_value() ? info->rss_anon_bytes : 0;
+      }),
+      std::move(callback));
+#else
+  std::move(callback).Run(0);
+#endif
+}
+
+void PerformanceImpl::MeasureTotalCpuMemory(
+    MeasureTotalCpuMemoryCallback callback) {
+  base::ThreadPool::PostTaskAndReplyWithResult(
+      FROM_HERE, {base::MayBlock(), base::TaskPriority::USER_VISIBLE},
+      base::BindOnce([]() -> uint64_t {
+#if BUILDFLAG(IS_POSIX) && defined(_SC_PHYS_PAGES)
+        long pages = sysconf(_SC_PHYS_PAGES);
+#if defined(_SC_PAGESIZE)
+        long page_size = sysconf(_SC_PAGESIZE);
+#elif defined(_SC_PAGE_SIZE)
+        long page_size = sysconf(_SC_PAGE_SIZE);
+#else
+        long page_size = -1;
+#endif
+        if (pages > 0 && page_size > 0) {
+          return static_cast<uint64_t>(pages) *
+                 static_cast<uint64_t>(page_size);
+        }
+#endif
+        return 0;
+      }),
+      std::move(callback));
+}
+
+void PerformanceImpl::MeasureUsedPssMemory(
+    MeasureUsedPssMemoryCallback callback) {
+#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID)
+  base::ThreadPool::PostTaskAndReplyWithResult(
+      FROM_HERE, {base::MayBlock(), base::TaskPriority::USER_VISIBLE},
+      base::BindOnce([]() -> uint64_t {
+        auto smaps_rollup = base::debug::ReadAndParseSmapsRollup();
+        return smaps_rollup.has_value() ? smaps_rollup->pss : 0;
+      }),
+      std::move(callback));
+#else
+  std::move(callback).Run(0);
+#endif
+}
+
+void PerformanceImpl::MeasureApplicationLimitMemory(
+    MeasureApplicationLimitMemoryCallback callback) {
+#if BUILDFLAG(IS_STARBOARD)
+  base::ThreadPool::PostTaskAndReplyWithResult(
+      FROM_HERE, {base::MayBlock(), base::TaskPriority::USER_VISIBLE},
+      base::BindOnce([]() -> uint64_t {
+        int64_t limit = SbSystemGetTotalCPUMemory();
+        return limit > 0 ? static_cast<uint64_t>(limit) : 0;
+      }),
+      std::move(callback));
+#else
+  std::move(callback).Run(0);
+#endif
 }
 
 void PerformanceImpl::GetAppStartupTimeStamp(

--- a/cobalt/browser/performance/performance_impl.h
+++ b/cobalt/browser/performance/performance_impl.h
@@ -43,10 +43,17 @@ class PerformanceImpl
   PerformanceImpl& operator=(const PerformanceImpl&) = delete;
 
   void MeasureAvailableCpuMemory(MeasureAvailableCpuMemoryCallback) override;
-  void MeasureUsedCpuMemory(MeasureAvailableCpuMemoryCallback) override;
+  void MeasureUsedCpuMemory(MeasureUsedCpuMemoryCallback) override;
   void MeasureUsedSwapMemory(MeasureUsedSwapMemoryCallback) override;
   void MeasureReservedVirtualMemory(
       MeasureReservedVirtualMemoryCallback) override;
+  void MeasureRssHighWaterMarkMemory(
+      MeasureRssHighWaterMarkMemoryCallback) override;
+  void MeasureUsedRssAnonMemory(MeasureUsedRssAnonMemoryCallback) override;
+  void MeasureTotalCpuMemory(MeasureTotalCpuMemoryCallback) override;
+  void MeasureUsedPssMemory(MeasureUsedPssMemoryCallback) override;
+  void MeasureApplicationLimitMemory(
+      MeasureApplicationLimitMemoryCallback) override;
   void GetAppStartupTimeStamp(GetAppStartupTimeStampCallback callback) override;
 
  private:

--- a/cobalt/browser/performance/public/mojom/performance.mojom
+++ b/cobalt/browser/performance/public/mojom/performance.mojom
@@ -32,6 +32,26 @@ interface CobaltPerformance {
   [Sync]
   MeasureReservedVirtualMemory() => (uint64 bytes);
 
+  // Get the peak resident set size (high water mark) used by the process in bytes.
+  [Sync]
+  MeasureRssHighWaterMarkMemory() => (uint64 bytes);
+
+  // Get the resident anonymous memory used by the process in bytes.
+  [Sync]
+  MeasureUsedRssAnonMemory() => (uint64 bytes);
+
+  // Get the total physical CPU memory on the device in bytes.
+  [Sync]
+  MeasureTotalCpuMemory() => (uint64 bytes);
+
+  // Get the proportional set size (PSS) memory used by the process in bytes.
+  [Sync]
+  MeasureUsedPssMemory() => (uint64 bytes);
+
+  // Get the application CPU memory limit in bytes.
+  [Sync]
+  MeasureApplicationLimitMemory() => (uint64 bytes);
+
   // Get the application startup timestamp in microseconds (us).
   [Sync]
   GetAppStartupTimeStamp() => (int64 timestamp);

--- a/third_party/blink/renderer/core/cobalt/performance/performance_extensions.cc
+++ b/third_party/blink/renderer/core/cobalt/performance/performance_extensions.cc
@@ -72,6 +72,47 @@ uint64_t PerformanceExtensions::measureReservedVirtualMemory(
   return virtual_memory_size;
 }
 
+uint64_t PerformanceExtensions::measureRssHighWaterMarkMemory(
+    ScriptState* script_state,
+    const Performance&) {
+  uint64_t rss_hwm_memory = 0;
+  BindRemotePerformance(script_state)
+      ->MeasureRssHighWaterMarkMemory(&rss_hwm_memory);
+  return rss_hwm_memory;
+}
+
+uint64_t PerformanceExtensions::measureUsedRssAnonMemory(
+    ScriptState* script_state,
+    const Performance&) {
+  uint64_t rss_anon_memory = 0;
+  BindRemotePerformance(script_state)
+      ->MeasureUsedRssAnonMemory(&rss_anon_memory);
+  return rss_anon_memory;
+}
+
+uint64_t PerformanceExtensions::measureTotalCpuMemory(ScriptState* script_state,
+                                                      const Performance&) {
+  uint64_t total_cpu_memory = 0;
+  BindRemotePerformance(script_state)->MeasureTotalCpuMemory(&total_cpu_memory);
+  return total_cpu_memory;
+}
+
+uint64_t PerformanceExtensions::measureUsedPssMemory(ScriptState* script_state,
+                                                     const Performance&) {
+  uint64_t pss_memory = 0;
+  BindRemotePerformance(script_state)->MeasureUsedPssMemory(&pss_memory);
+  return pss_memory;
+}
+
+uint64_t PerformanceExtensions::measureApplicationLimitMemory(
+    ScriptState* script_state,
+    const Performance&) {
+  uint64_t app_limit_memory = 0;
+  BindRemotePerformance(script_state)
+      ->MeasureApplicationLimitMemory(&app_limit_memory);
+  return app_limit_memory;
+}
+
 ScriptPromise<IDLDouble> PerformanceExtensions::getAppStartupTimeStamp(
     ScriptState* script_state,
     const Performance& performance_obj,

--- a/third_party/blink/renderer/core/cobalt/performance/performance_extensions.h
+++ b/third_party/blink/renderer/core/cobalt/performance/performance_extensions.h
@@ -36,6 +36,13 @@ class CORE_EXPORT PerformanceExtensions final {
   static uint64_t measureUsedSwapMemory(ScriptState*, const Performance&);
   static uint64_t measureReservedVirtualMemory(ScriptState*,
                                                const Performance&);
+  static uint64_t measureRssHighWaterMarkMemory(ScriptState*,
+                                                const Performance&);
+  static uint64_t measureUsedRssAnonMemory(ScriptState*, const Performance&);
+  static uint64_t measureTotalCpuMemory(ScriptState*, const Performance&);
+  static uint64_t measureUsedPssMemory(ScriptState*, const Performance&);
+  static uint64_t measureApplicationLimitMemory(ScriptState*,
+                                                const Performance&);
   static ScriptPromise<IDLDouble> getAppStartupTimeStamp(ScriptState*,
                                                          const Performance&,
                                                          ExceptionState&);

--- a/third_party/blink/renderer/core/cobalt/performance/performance_extensions.idl
+++ b/third_party/blink/renderer/core/cobalt/performance/performance_extensions.idl
@@ -16,6 +16,21 @@
     // Returns the amount of virtual memory currently reserved in bytes.
     [CallWith=ScriptState] unsigned long long measureReservedVirtualMemory();
 
+    // Returns the peak resident set size (high water mark) used by the process in bytes.
+    [CallWith=ScriptState] unsigned long long measureRssHighWaterMarkMemory();
+
+    // Returns the resident anonymous memory used by the process in bytes.
+    [CallWith=ScriptState] unsigned long long measureUsedRssAnonMemory();
+
+    // Returns the total physical CPU memory on the device in bytes.
+    [CallWith=ScriptState] unsigned long long measureTotalCpuMemory();
+
+    // Returns the proportional set size (PSS) memory used by the process in bytes.
+    [CallWith=ScriptState] unsigned long long measureUsedPssMemory();
+
+    // Returns the application CPU memory limit in bytes.
+    [CallWith=ScriptState] unsigned long long measureApplicationLimitMemory();
+
     // Returns the application startup timestamp in millisecs (ms).
     [CallWith=ScriptState, RaisesException] Promise<DOMHighResTimeStamp> getAppStartupTimeStamp();
 };


### PR DESCRIPTION
Add new methods to the Performance web API to provide more granular
memory usage information, such as RSS high water mark, total physical
memory, and PSS. These metrics enable web applications to better
monitor their memory footprint and limits on constrained devices.

The base::ProcessMetrics class is also updated to include VmHWM
support on Linux-based platforms to source these metrics.

Bug: 548530403