### PR TITLE
player: apply volume directly on the audio sink

### DIFF
--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/player/player_internal.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/player/player_internal.cc
@@ -1655,6 +1655,8 @@ class PlayerImpl : public Player {
   std::mutex source_setup_mutex_;
   std::condition_variable source_setup_condition_;
   std::mutex seek_mutex_;
+  GstElement* audio_sink_{nullptr};
+  double volume_{1.0};
   double rate_{1.0};
   int ticket_{SB_PLAYER_INITIAL_TICKET};
   mutable GstClockTime seek_position_{GST_CLOCK_TIME_NONE};
@@ -1937,6 +1939,9 @@ PlayerImpl::~PlayerImpl() {
     DispatchOnWorkerThread(new PlayerDestroyedTask(
       player_status_func_, player_, ticket_, context_, main_loop_));
     playback_thread_.join();
+  }
+  if (audio_sink_) {
+    gst_object_unref(audio_sink_);
   }
   if (audio_caps_) {
     gst_caps_unref(audio_caps_);
@@ -2450,6 +2455,20 @@ void PlayerImpl::SetupElement(GstElement* pipeline,
       }
     }
 
+    // playsink only routes volume to GstStreamVolume sinks; set the property directly.
+    if (strstr(klass_str, "Audio") &&
+        !GST_IS_STREAM_VOLUME(element) &&
+        g_object_class_find_property(oclass, "volume")) {
+      std::lock_guard lock(self->mutex_);
+      if (self->audio_sink_ != element) {
+        gst_object_ref(element);
+        if (self->audio_sink_)
+          gst_object_unref(self->audio_sink_);
+        self->audio_sink_ = element;
+      }
+      g_object_set(G_OBJECT(element), "volume", self->volume_, nullptr);
+    }
+
     if (g_object_class_find_property(oclass, "has-drm")) {
       g_object_set(G_OBJECT(element), "has-drm", self->drm_system_ != nullptr, nullptr);
     }
@@ -2698,6 +2717,11 @@ void PlayerImpl::SetVolume(double volume) {
   GST_DEBUG_OBJECT(pipeline_, "volume %lf", volume);
   gst_stream_volume_set_volume(GST_STREAM_VOLUME(pipeline_),
                                GST_STREAM_VOLUME_FORMAT_LINEAR, volume);
+
+  std::lock_guard lock(mutex_);
+  volume_ = volume;
+  if (audio_sink_)
+    g_object_set(G_OBJECT(audio_sink_), "volume", volume, nullptr);
 }
 
 void PlayerImpl::HandleInititialSeek() {


### PR DESCRIPTION
When a video is cast from a phone and the user changes the volume, Cobalt shows the volume overlay but the audio level does not change. `SbPlayerSetVolume` only set the volume on the playbin, which forwards it to the audio sink only when that sink implements the GstStreamVolume interface.  The sink in use exposes a 'volume' property **without implementing the interface**, so the requested value was applied to nothing while `SbPlayerGetInfo` read it back and reported it as effective.

Implement the volume control in the GStreamer pipeline, tracking such a sink when it is set up and writing the level to its 'volume' property. 

Bug: 534354811