### PR TITLE
evergreen: Port forward ELF load memory histogram

### DIFF
--- a/cobalt/browser/loader_app_metrics.cc
+++ b/cobalt/browser/loader_app_metrics.cc
@@ -28,50 +28,27 @@ namespace browser {
 namespace {
 
 const StarboardExtensionLoaderAppMetricsApi* GetLoaderAppMetricsExtension() {
-  const auto* loader_app_metrics =
+  const auto* metrics_extension =
       static_cast<const StarboardExtensionLoaderAppMetricsApi*>(
           SbSystemGetExtension(kStarboardExtensionLoaderAppMetricsName));
 
-  if (!loader_app_metrics) {
+  if (!metrics_extension) {
     LOG(WARNING) << "LoaderAppMetrics: Extension not found.";
     return nullptr;
   }
 
-  if (strcmp(loader_app_metrics->name,
+  if (strcmp(metrics_extension->name,
              kStarboardExtensionLoaderAppMetricsName) != 0) {
     LOG(ERROR) << "LoaderAppMetrics: Extension name mismatch.";
     return nullptr;
   }
-  return loader_app_metrics;
+  return metrics_extension;
 }
 
-}  // namespace
-
-void RecordLoaderAppMetrics() {
-  const auto* loader_app_metrics = GetLoaderAppMetricsExtension();
-  if (!loader_app_metrics) {
-    return;
-  }
-
-  if (loader_app_metrics->version < 2) {
-    LOG(WARNING) << "LoaderAppMetrics: Extension version too low ("
-                 << loader_app_metrics->version << "). Need at least 2.";
-    return;
-  }
-
-  if (loader_app_metrics->version >= 3) {
-    base::UmaHistogramEnumeration("Cobalt.LoaderApp.SlotSelectionStatus",
-                                  loader_app_metrics->GetSlotSelectionStatus());
-  }
-
-  if (!loader_app_metrics->GetElfLibraryStoredCompressed()) {
-    LOG(INFO) << "LoaderAppMetrics: ELF was not stored compressed. Skipping "
-                 "decompression metric.";
-    return;
-  }
-
+void RecordLoaderAppTimeMetrics(
+    const StarboardExtensionLoaderAppMetricsApi* metrics_extension) {
   int64_t elf_decompression_duration_us =
-      loader_app_metrics->GetElfDecompressionDurationMicroseconds();
+      metrics_extension->GetElfDecompressionDurationMicroseconds();
 
   if (elf_decompression_duration_us < 0) {
     LOG(ERROR) << "LoaderAppMetrics: Decompression duration is negative, "
@@ -83,6 +60,55 @@ void RecordLoaderAppMetrics() {
                           base::Microseconds(elf_decompression_duration_us));
   LOG(INFO) << "LoaderAppMetrics: Logging ELF Decompression Duration: "
             << elf_decompression_duration_us << " us";
+}
+
+void RecordLoaderAppSpaceMetrics(
+    const StarboardExtensionLoaderAppMetricsApi* metrics_extension) {
+  int64_t max_sampled_used_cpu_bytes =
+      metrics_extension->GetMaxSampledUsedCpuBytesDuringElfLoad();
+
+  if (max_sampled_used_cpu_bytes < 0) {
+    LOG(ERROR) << "LoaderAppMetrics: Max sampled used CPU bytes is negative, "
+                  "not logging.";
+    return;
+  }
+
+  base::UmaHistogramMemoryMB(
+      "Cobalt.LoaderApp.MaxSampledUsedCPUMemoryDuringELFLoad",
+      static_cast<int>(max_sampled_used_cpu_bytes / 1000000));
+  LOG(INFO) << "LoaderAppMetrics: Logging Max Sampled Used CPU Memory During "
+               "ELF Load: "
+            << max_sampled_used_cpu_bytes << " bytes ("
+            << (max_sampled_used_cpu_bytes / 1000000) << " MB)";
+}
+
+}  // namespace
+
+void RecordLoaderAppMetrics() {
+  const auto* metrics_extension = GetLoaderAppMetricsExtension();
+  if (!metrics_extension) {
+    return;
+  }
+
+  if (metrics_extension->version < 2) {
+    LOG(WARNING) << "LoaderAppMetrics: Extension version too low ("
+                 << metrics_extension->version << "). Need at least 2.";
+    return;
+  }
+
+  if (metrics_extension->version >= 3) {
+    base::UmaHistogramEnumeration("Cobalt.LoaderApp.SlotSelectionStatus",
+                                  metrics_extension->GetSlotSelectionStatus());
+  }
+
+  if (!metrics_extension->GetElfLibraryStoredCompressed()) {
+    LOG(INFO) << "LoaderAppMetrics: ELF was not stored compressed. Skipping "
+                 "decompression metric.";
+    return;
+  }
+
+  RecordLoaderAppTimeMetrics(metrics_extension);
+  RecordLoaderAppSpaceMetrics(metrics_extension);
 }
 
 }  // namespace browser

--- a/tools/metrics/histograms/metadata/cobalt/histograms.xml
+++ b/tools/metrics/histograms/metadata/cobalt/histograms.xml
@@ -209,6 +209,21 @@ Always run the pretty print utility on this file after editing:
   </summary>
 </histogram>
 
+<histogram name="Cobalt.LoaderApp.MaxSampledUsedCPUMemoryDuringELFLoad"
+    units="MB" expires_after="never">
+<!-- expires-never: Needed for long-term tracking of ELF load performance. -->
+
+  <owner>hwarriner@google.com</owner>
+  <owner>cobalt-team@google.com</owner>
+  <summary>
+    The maximum sampled value of CPU memory used by the Loader App while the ELF
+    dynamic shared library is being loaded. Note that this maximum sampled value
+    is not guaranteed to be the true maximum value, which could be greater. This
+    metric is only recorded when the shared library is stored as a compressed
+    file.
+  </summary>
+</histogram>
+
 <histogram name="Cobalt.LoaderApp.SlotSelectionStatus"
     enum="SlotSelectionStatus" expires_after="never">
 <!-- expires-never: Needed for Evergreen updates health metrics. -->


### PR DESCRIPTION
This MaxSampledUsedCPUMemoryDuringELFLoad histogram was originally added in b/329445690 but so far left behind in the chrobalt migration. I think we want to keep this histogram anyway, for continued monitoring of our binary decompression performance (for example, in light of changes to binary size). But it's also a key metric that we've identified for go/zstd-test-experiment-design.

Other loader app histograms will be added in separate PRs.

The unit tests for this module were also left behind when this module was (partially) ported forward in #7216. I've manually tested these changes e2e for now but will add back relevant unit test cases in a quick follow up PR.

Issue: 537769651