### PR TITLE
[m139] media: Adapt Android audio capture fast-path to upstream changes

### DIFF
--- a/media/audio/android/audio_manager_android.cc
+++ b/media/audio/android/audio_manager_android.cc
@@ -484,7 +484,7 @@ void AudioManagerAndroid::GetDeviceNames(AudioDeviceNames* device_names,
   AddDefaultDevice(device_names);
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-  // simplfified flow - just return, device_names is set to default.
+  // simplified flow - just return, device_names is set to default.
   return;
 #else
   std::vector<JniAudioDevice> j_devices =

--- a/media/audio/android/audio_manager_android.cc
+++ b/media/audio/android/audio_manager_android.cc
@@ -551,7 +551,7 @@ void AudioManagerAndroid::GetCommunicationDeviceNames(
   AddDefaultDevice(device_names);
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-  // simplfified flow - just return, device_names is set to default. 
+  // simplified flow - just return, device_names is set to default.
   return;
 #else
   std::optional<std::vector<JniAudioDevice>> j_devices =

--- a/media/audio/android/audio_manager_android.cc
+++ b/media/audio/android/audio_manager_android.cc
@@ -86,7 +86,9 @@ class JniDelegateImpl : public AudioManagerAndroid::JniDelegate {
       : j_audio_manager_(Java_AudioManagerAndroid_createAudioManagerAndroid(
             AttachCurrentThread(),
             reinterpret_cast<jlong>(audio_manager))) {
+#if !BUILDFLAG(USE_STARBOARD_MEDIA)
     Java_AudioManagerAndroid_init(AttachCurrentThread(), j_audio_manager_);
+#endif  // !BUILDFLAG(USE_STARBOARD_MEDIA)
   }
 
   ~JniDelegateImpl() override {
@@ -548,6 +550,10 @@ void AudioManagerAndroid::GetCommunicationDeviceNames(
   DCHECK(device_names->empty());
   AddDefaultDevice(device_names);
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  // simplfified flow - just return, device_names is set to default. 
+  return;
+#else
   std::optional<std::vector<JniAudioDevice>> j_devices =
       GetJniDelegate().GetCommunicationDevices();
   if (!j_devices) {
@@ -565,6 +571,7 @@ void AudioManagerAndroid::GetCommunicationDeviceNames(
     device_names->emplace_back(std::move(j_device.name).value(),
                                std::move(device_id_string));
   }
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 }
 
 const AudioManagerAndroid::DeviceCache& AudioManagerAndroid::GetDeviceCache(


### PR DESCRIPTION
Upstream CL 6586528 refactored device enumeration in AudioManagerAndroid
by introducing JniDelegate and GetCommunicationDeviceNames().

This change adapts Cobalt's audio capture fast-path to those changes:
- Guard Java_AudioManagerAndroid_init with BUILDFLAG(USE_STARBOARD_MEDIA)
  in JniDelegateImpl to avoid registering unnecessary audio listeners.
- Short-circuit GetCommunicationDeviceNames() when BUILDFLAG(USE_STARBOARD_MEDIA)
  is enabled so it returns only the default device without querying JNI.

Bug: 543784629
TAG=agy
CONV=3bc3dc39-bbcb-489f-b335-3b032071e01a