### PR TITLE
cobalt: Remove redundant debugging logs

### DIFF
--- a/cobalt/browser/memory_ablation.cc
+++ b/cobalt/browser/memory_ablation.cc
@@ -21,7 +21,6 @@
 
 #include "base/feature_list.h"
 #include "base/functional/bind.h"
-#include "base/logging.h"
 #include "base/metrics/histogram_functions.h"
 #include "base/no_destructor.h"
 #include "base/task/sequenced_task_runner.h"
@@ -58,8 +57,6 @@ void DoMemoryAblationInBackground(
   if (!buffer) {
     base::UmaHistogramEnumeration("Cobalt.Features.NativeMemoryAblation.Result",
                                   NativeMemoryAblationResult::kOomFailure);
-    LOG(ERROR) << "Failed to allocate " << size_mb
-               << " MB for native memory ablation (OOM).";
     return;
   }
 
@@ -108,9 +105,6 @@ void MaybeApplyMemoryAblation() {
   if (size_mb > kMaxAblationSizeMB) {
     base::UmaHistogramEnumeration("Cobalt.Features.NativeMemoryAblation.Result",
                                   NativeMemoryAblationResult::kExceedsMaxLimit);
-    LOG(ERROR) << "Requested ablation size " << size_mb
-               << " MB exceeds maximum allowable limit (" << kMaxAblationSizeMB
-               << " MB). Ablation skipped.";
     return;
   }
 

--- a/cobalt/site/docs/development/index.md
+++ b/cobalt/site/docs/development/index.md
@@ -86,7 +86,7 @@ For step-by-step instructions on deploying prebuilt `.crx` packages on Linux wor
 
 > [!CAUTION]
 > **Mandatory CRX Requirement for SoC Partners:**
-> SoC and OEM partners are strictly required to use official Google-built Prebuilt CRX packages for testing, QA, and certification. 
+> SoC and OEM partners are strictly required to use official Google-built Prebuilt CRX packages for testing, QA, and certification.
 > Compiling Cobalt Core (`libcobalt.so`) from source is reserved for internal engine development and core debugging.
 
 When developing or debugging custom Cobalt Core engine modifications:


### PR DESCRIPTION
Remove error logs from the memory ablation implementation in the
browser logic. These events, such as allocation failures or size
limit violations, are already captured by UMA histograms. Removing
these logs reduces unnecessary console noise.

Bug: 543418301