### PR TITLE
andriod: Support audio focus for Android N

### DIFF
--- a/content/public/android/java/src/org/chromium/content/browser/AudioFocusDelegate.java
+++ b/content/public/android/java/src/org/chromium/content/browser/AudioFocusDelegate.java
@@ -8,6 +8,7 @@ import android.content.Context;
 import android.media.AudioAttributes;
 import android.media.AudioFocusRequest;
 import android.media.AudioManager;
+import android.os.Build;
 import android.os.Handler;
 
 import org.jni_zero.CalledByNative;
@@ -81,9 +82,14 @@ public class AudioFocusDelegate implements AudioManager.OnAudioFocusChangeListen
                 (AudioManager)
                         ContextUtils.getApplicationContext()
                                 .getSystemService(Context.AUDIO_SERVICE);
-        if (mFocusRequest != null) {
-            am.abandonAudioFocusRequest(mFocusRequest);
-            mFocusRequest = null;
+        // Cobalt modification to support Android N devices.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            if (mFocusRequest != null) {
+                am.abandonAudioFocusRequest(mFocusRequest);
+                mFocusRequest = null;
+            }
+        } else {
+            am.abandonAudioFocus(this);
         }
     }
 
@@ -99,26 +105,31 @@ public class AudioFocusDelegate implements AudioManager.OnAudioFocusChangeListen
                                 .getSystemService(Context.AUDIO_SERVICE);
 
         int result;
-        AudioAttributes playbackAttributes =
-                new AudioAttributes.Builder()
-                        .setUsage(AudioAttributes.USAGE_MEDIA)
-                        .setContentType(AudioAttributes.CONTENT_TYPE_UNKNOWN)
-                        .build();
-        mFocusRequest =
-                new AudioFocusRequest.Builder(mFocusType)
-                        .setAudioAttributes(playbackAttributes)
-                        .setAcceptsDelayedFocusGain(false)
-                        .setWillPauseWhenDucked(false)
-                        .setOnAudioFocusChangeListener(this, mHandler)
-                        .build();
-        try {
-            result = am.requestAudioFocus(mFocusRequest);
-        } catch (SecurityException e) {
-            // If we get a SecurityException, the platform has a bug and requestAudioFocus is broken
-            // (at least under our current running conditions). Pretend that everything worked,
-            // because the alternative is that media such as videos may refuse to ever play.
-            Log.w(TAG, "audio focus coordination is broken", e);
-            return true;
+        // Cobalt modification to support Android N devices.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            AudioAttributes playbackAttributes =
+                    new AudioAttributes.Builder()
+                            .setUsage(AudioAttributes.USAGE_MEDIA)
+                            .setContentType(AudioAttributes.CONTENT_TYPE_UNKNOWN)
+                            .build();
+            mFocusRequest =
+                    new AudioFocusRequest.Builder(mFocusType)
+                            .setAudioAttributes(playbackAttributes)
+                            .setAcceptsDelayedFocusGain(false)
+                            .setWillPauseWhenDucked(false)
+                            .setOnAudioFocusChangeListener(this, mHandler)
+                            .build();
+            try {
+                result = am.requestAudioFocus(mFocusRequest);
+            } catch (SecurityException e) {
+                // If we get a SecurityException, the platform has a bug and requestAudioFocus is broken
+                // (at least under our current running conditions). Pretend that everything worked,
+                // because the alternative is that media such as videos may refuse to ever play.
+                Log.w(TAG, "audio focus coordination is broken", e);
+                return true;
+            }
+        } else {
+            result = am.requestAudioFocus(this, AudioManager.STREAM_MUSIC, mFocusType);
         }
 
         return result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED;


### PR DESCRIPTION
Chromium m138 dropped support for Android N, causing the removal of
legacy audio focus API calls. Since Cobalt continues to support
Android N, this change restores the compatibility logic in
AudioFocusDelegate to ensure audio focus can be properly requested
and abandoned on older Android versions.

This change partially reverted https://chromium-review.git.corp.google.com/c/chromium/src/+/5985495.

Bug: 549235758