### PR TITLE
Update DevTools extension description to reflect cross-platform telemetry links

### DIFF
--- a/cobalt/site/docs/development/index.md
+++ b/cobalt/site/docs/development/index.md
@@ -86,7 +86,7 @@ For step-by-step instructions on deploying prebuilt `.crx` packages on Linux wor
 
 > [!CAUTION]
 > **Mandatory CRX Requirement for SoC Partners:**
-> SoC and OEM partners are strictly required to use official Google-built Prebuilt CRX packages for testing, QA, and certification. 
+> SoC and OEM partners are strictly required to use official Google-built Prebuilt CRX packages for testing, QA, and certification.
 > Compiling Cobalt Core (`libcobalt.so`) from source is reserved for internal engine development and core debugging.
 
 When developing or debugging custom Cobalt Core engine modifications:

--- a/cobalt/tools/devtools_extension/manifest.json
+++ b/cobalt/tools/devtools_extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Cobalt Memory Breakdown",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Real-time memory breakdown and session P50 telemetry inspection panel for Cobalt/Chrobalt on Android TV, RDK, and Linux.",
   "devtools_page": "devtools.html",
   "action": {

--- a/cobalt/tools/devtools_extension/panel.html
+++ b/cobalt/tools/devtools_extension/panel.html
@@ -34,9 +34,8 @@
           <div id="sampling-progress" class="sampling-badge">0 / 12 Reported</div>
         </div>
         <div class="section-instruction">
-          Aggregated median (P50) memory footprint across continuous native and managed allocators since launch,
-          mirroring production Kimono / PLX telemetry (<code>go/kimono-memory-metrics</code>).
-          Demonstrates physical memory distribution beyond the JavaScript heap.
+          Session steady-state median (P50) of total physical CPU RAM (RSS) broken down across native C++, V8, graphics, and system allocators, continuously updated in real time since app launch.
+          Mirrors production telemetry (<code>go/kimono-memory-metrics</code> and <code>go/evergreen-memory-metrics</code>).
         </div>
         <div id="sampling-hint" class="sampling-hint" style="display: none;">
           💡 <strong>Sampling Tip:</strong> P50 metrics are computed from background UMA memory dumps. To accelerate sampling to every 3 seconds during development, launch Cobalt with <code>--enable-features=CobaltMetricsInterval:memory-metrics-interval/3</code>.


### PR DESCRIPTION
Update the memory footprint description in the DevTools extension panel
to include references to cross-platform production telemetry. This
change adds a link to Evergreen memory metrics to complement the
existing Kimono metrics reference.

Bug: 549295573