### PR TITLE
android: fix dual activity leaks

### DIFF
--- a/cobalt/android/BUILD.gn
+++ b/cobalt/android/BUILD.gn
@@ -364,6 +364,7 @@ robolectric_binary("cobalt_coat_junit_tests") {
   sources = [
     "apk/app/src/test/java/dev/cobalt/coat/ArtworkDownloaderDefaultTest.java",
     "apk/app/src/test/java/dev/cobalt/coat/ArtworkLoaderTest.java",
+    "apk/app/src/test/java/dev/cobalt/coat/BaseStarboardBridgeTest.java",
     "apk/app/src/test/java/dev/cobalt/coat/CobaltActivityTest.java",
     "apk/app/src/test/java/dev/cobalt/coat/CobaltPictureInPictureActivityTest.java",
     "apk/app/src/test/java/dev/cobalt/coat/CobaltServiceTest.java",

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/BaseCobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/BaseCobaltActivity.java
@@ -82,6 +82,11 @@ public abstract class BaseCobaltActivity extends Activity {
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
+    BaseStarboardBridge bridge = getStarboardBridge();
+    if (bridge != null) {
+      bridge.onActivityCreate(this);
+    }
+
     // Record the application start timestamp.
     mTimeInNanoseconds = System.nanoTime();
 
@@ -107,8 +112,17 @@ public abstract class BaseCobaltActivity extends Activity {
 
   @Override
   protected void onDestroy() {
-    super.onDestroy();
-    getStarboardBridge().onActivityDestroy(this);
+    try {
+      super.onDestroy();
+    } catch (Throwable t) {
+      Log.e(TAG, "Error in super.onDestroy()", t);
+      throw t;
+    } finally {
+      BaseStarboardBridge bridge = getStarboardBridge();
+      if (bridge != null) {
+        bridge.onActivityDestroy(this);
+      }
+    }
   }
 
   @Override

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/BaseStarboardBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/BaseStarboardBridge.java
@@ -29,9 +29,12 @@ import android.media.AudioDeviceInfo;
 import android.media.AudioManager;
 import android.os.Build;
 import android.view.InputDevice;
+import android.view.Surface;
 import android.view.accessibility.CaptioningManager;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import dev.cobalt.media.AudioOutputManager;
+import dev.cobalt.media.VideoSurfaceView;
 import dev.cobalt.util.DisplayUtil;
 import dev.cobalt.util.Holder;
 import dev.cobalt.util.Log;
@@ -39,11 +42,14 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
+import org.chromium.base.CommandLine;
 import org.jni_zero.CalledByNative;
 import org.jni_zero.JNINamespace;
 import org.jni_zero.NativeMethods;
@@ -54,6 +60,17 @@ import org.jni_zero.NativeMethods;
 // this property.
 public class BaseStarboardBridge {
 
+  private static volatile BaseStarboardBridge sInstance;
+
+  public static BaseStarboardBridge getInstance() {
+    return sInstance;
+  }
+
+  @VisibleForTesting
+  public static void setInstanceForTesting(BaseStarboardBridge bridge) {
+    sInstance = bridge;
+  }
+
   /** Interface to be implemented by the Android Application hosting the starboard app. */
   public interface HostApplication {
     void setStarboardBridge(BaseStarboardBridge starboardBridge);
@@ -61,6 +78,8 @@ public class BaseStarboardBridge {
     BaseStarboardBridge getStarboardBridge();
   }
 
+  private Surface mVideoSurface;
+  private final Object mVideoSurfaceLock = new Object();
   private CobaltSystemConfigChangeReceiver mSysConfigChangeReceiver;
   private CobaltTextToSpeechHelper mTtsHelper;
   // TODO(cobalt): Re-enable these classes or remove if unnecessary.
@@ -71,6 +90,10 @@ public class BaseStarboardBridge {
   private final Context mAppContext;
   protected final Holder<Activity> mActivityHolder;
   private final Holder<Service> mServiceHolder;
+  // Maps each live Activity to whether it is currently started (Boolean.TRUE) or stopped (Boolean.FALSE).
+  // Backed by WeakHashMap to prevent pinning Activity instances in the singleton bridge.
+  private final Map<Activity, Boolean> mActivities =
+      Collections.synchronizedMap(new WeakHashMap<>());
   private final String[] mArgs;
   private final long mNativeApp;
   private final Runnable mStopRequester =
@@ -94,7 +117,9 @@ public class BaseStarboardBridge {
   private long mAppStartTimestamp = 0;
 
   private final Map<String, CobaltService.Factory> mCobaltServiceFactories = new HashMap<>();
-  private final Map<String, CobaltService> mCobaltServices = new ConcurrentHashMap<>();
+  // Keyed by native pointer handle so multiple documents, iframes, or overlapping Activities
+  // can open services with the same name without colliding or leaking on close.
+  private final Map<Long, CobaltService> mCobaltServices = new ConcurrentHashMap<>();
 
   private static final String GOOGLE_PLAY_SERVICES_PACKAGE = "com.google.android.gms";
   private static final String AMATI_EXPERIENCE_FEATURE =
@@ -104,6 +129,7 @@ public class BaseStarboardBridge {
   private final long mTimeNanosecondsPerMicrosecond = 1000;
   private static final String YTS_CERT_SCOPE_SYSTEM_PROPERTY = "ro.vendor.youtube.cert_scope";
   private static final String DEFAULT_DEVICE_NAME = "Android";
+  private final Natives mNatives = BaseStarboardBridgeJni.get();
 
   /**
    * Lightweight constructor used by test activities (e.g. CobaltTestActivity).
@@ -133,10 +159,11 @@ public class BaseStarboardBridge {
       String startDeepLink) {
 
     Log.i(TAG, "BaseStarboardBridge init.");
+    sInstance = this;
 
     // Make sure the JNI stack is properly initialized first as there is a
     // race condition as soon as any of the following objects creates a new thread.
-    BaseStarboardBridgeJni.get().initJNI(this);
+    mNatives.initJNI(this);
 
     mAppContext = appContext;
     mActivityHolder = activityHolder;
@@ -151,19 +178,17 @@ public class BaseStarboardBridge {
     mIsAmatiDevice = appContext.getPackageManager().hasSystemFeature(AMATI_EXPERIENCE_FEATURE);
 
     mNativeApp =
-        BaseStarboardBridgeJni.get()
-            .startNativeStarboard(
-                getAssetsFromContext(),
-                getFilesCanonicalPath(),
-                getCacheCanonicalPath(),
-                getNativeLibraryDir());
+        mNatives.startNativeStarboard(
+            getAssetsFromContext(),
+            getFilesCanonicalPath(),
+            getCacheCanonicalPath(),
+            getNativeLibraryDir());
 
-    BaseStarboardBridgeJni.get().handleDeepLink(startDeepLink, /* applicationStarted= */ false);
-    BaseStarboardBridgeJni.get().setAndroidBuildFingerprint(getBuildFingerprint());
-    BaseStarboardBridgeJni.get().setAndroidOSExperience(mIsAmatiDevice);
-    BaseStarboardBridgeJni.get().setAndroidPlayServicesVersion(getPlayServicesVersion());
-    BaseStarboardBridgeJni.get()
-        .setYoutubeCertificationScope(getSystemProperty(YTS_CERT_SCOPE_SYSTEM_PROPERTY));
+    mNatives.handleDeepLink(startDeepLink, /* applicationStarted= */ false);
+    mNatives.setAndroidBuildFingerprint(getBuildFingerprint());
+    mNatives.setAndroidOSExperience(mIsAmatiDevice);
+    mNatives.setAndroidPlayServicesVersion(getPlayServicesVersion());
+    mNatives.setYoutubeCertificationScope(getSystemProperty(YTS_CERT_SCOPE_SYSTEM_PROPERTY));
   }
 
   @NativeMethods
@@ -190,40 +215,150 @@ public class BaseStarboardBridge {
     void setYoutubeCertificationScope(String certScope);
   }
 
+  private static Boolean sActivityLifecycleCoordinationEnabledForTesting = null;
+
+  @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
+  public static void setActivityLifecycleCoordinationEnabledForTesting(Boolean enabled) {
+    sActivityLifecycleCoordinationEnabledForTesting = enabled;
+  }
+
+  public static boolean isActivityLifecycleCoordinationEnabled() {
+    if (sActivityLifecycleCoordinationEnabledForTesting != null) {
+      return sActivityLifecycleCoordinationEnabledForTesting;
+    }
+    return CommandLine.isInitialized()
+        && CommandLine.getInstance().hasSwitch("enable-activity-lifecycle-coordination");
+  }
+
+  public boolean hasStartedActivities() {
+    return mActivities.containsValue(Boolean.TRUE);
+  }
+
+  public boolean hasLiveActivities() {
+    return !mActivities.isEmpty();
+  }
+
+  private int countStartedActivities() {
+    synchronized (mActivities) {
+      int count = 0;
+      for (Boolean started : mActivities.values()) {
+        if (Boolean.TRUE.equals(started)) {
+          count++;
+        }
+      }
+      return count;
+    }
+  }
+
+  protected void onActivityCreate(Activity activity) {
+    Log.i(TAG, "onActivityCreate ran: " + activity);
+    mActivities.put(activity, Boolean.FALSE);
+  }
+
   protected void onActivityStart(Activity activity) {
-    Log.i(TAG, "onActivityStart ran");
+    Log.i(TAG, "onActivityStart ran: " + activity);
+    int activeActivityCount = countStartedActivities();
+    if (activeActivityCount > 0) {
+      Log.w(
+          TAG,
+          String.format(
+              "onActivityStart: New activity %s starting while there are previous %d activities are still active.",
+              activity, activeActivityCount));
+    }
+    mActivities.put(activity, Boolean.TRUE);
     mActivityHolder.set(activity);
     mSysConfigChangeReceiver.setForeground(true);
-    beforeStartOrResume();
+    if (isActivityLifecycleCoordinationEnabled()) {
+      // Only resume services and trigger foreground logic on 0 -> 1 started activity transition.
+      if (activeActivityCount == 0) {
+        beforeStartOrResume();
+      }
+    } else {
+      beforeStartOrResume();
+    }
   }
 
   protected void onActivityStop(Activity activity) {
-    Log.i(TAG, "onActivityStop ran");
-    beforeSuspend();
-    if (mActivityHolder.get() == activity) {
-      mActivityHolder.set(null);
+    Log.i(TAG, "onActivityStop ran: " + activity);
+    mActivities.put(activity, Boolean.FALSE);
+    if (isActivityLifecycleCoordinationEnabled()) {
+      // Only suspend services and disable foreground config updates if no other activity instance
+      // is currently started.
+      if (!hasStartedActivities()) {
+        beforeSuspend();
+        if (mActivityHolder.get() == activity) {
+          mActivityHolder.set(null);
+        }
+        mSysConfigChangeReceiver.setForeground(false);
+      } else {
+        if (mActivityHolder.get() == activity) {
+          mActivityHolder.set(null);
+        }
+        Log.i(
+            TAG,
+            "onActivityStop: Another activity is still started; skipping suspend and foreground change.");
+      }
+    } else {
+      beforeSuspend();
+      if (mActivityHolder.get() == activity) {
+        mActivityHolder.set(null);
+      }
+      mSysConfigChangeReceiver.setForeground(false);
     }
-    mSysConfigChangeReceiver.setForeground(false);
   }
 
   protected void onActivityDestroy(Activity activity) {
-    // Note: During rapid restarts or configuration changes, Android allows a new Activity
-    // instance's
-    // onCreate()/onStart() to run before the old instance's onDestroy() executes. When that
-    // happens,
-    // mActivityHolder will already point to the new activity instance. We must avoid cleaning
-    // up
-    // shared platform services or killing the process if another active instance has taken
-    // over.
-    if (mActivityHolder.get() != activity && mActivityHolder.get() != null) {
-      Log.i(TAG, "Activity destroyed but another activity is active; skipping service cleanup.");
-      return;
+    Log.i(TAG, "onActivityDestroy ran: " + activity);
+    mActivities.remove(activity);
+    if (isActivityLifecycleCoordinationEnabled()) {
+      if (mActivityHolder.get() == activity) {
+        mActivityHolder.set(null);
+      }
+      if (hasLiveActivities()) {
+        Log.i(
+            TAG,
+            "Activity destroyed but another activity instance is still live; skipping exit check.");
+        return;
+      }
+      boolean shouldNotifySurface = false;
+      synchronized (mVideoSurfaceLock) {
+        if (mVideoSurface != null) {
+          mVideoSurface = null;
+          shouldNotifySurface = true;
+        }
+      }
+      if (shouldNotifySurface) {
+        VideoSurfaceView.notifyVideoSurfaceChanged(null);
+      }
+      // Safety net: if all activities are destroyed but services remain in mCobaltServices (e.g.
+      // if WebContents/RFH teardown was deferred or skipped), clean them up to prevent leaks.
+      if (!mCobaltServices.isEmpty()) {
+        Log.w(
+            TAG,
+            String.format(
+                "onActivityDestroy: %d CobaltService instance(s) still open after last activity destroyed; force cleaning up.",
+                mCobaltServices.size()));
+        closeAllCobaltService();
+      }
+    } else {
+      // Note: During rapid restarts or configuration changes, Android allows a new Activity
+      // instance's onCreate()/onStart() to run before the old instance's onDestroy() executes.
+      // When that happens, mActivityHolder will already point to the new activity instance.
+      // We must avoid cleaning up shared platform services or killing the process if another
+      // active instance has taken over.
+      if (mActivityHolder.get() != activity && mActivityHolder.get() != null) {
+        Log.i(TAG, "Activity destroyed but another activity is active; skipping service cleanup.");
+        return;
+      }
+      if (mActivityHolder.get() == activity) {
+        mActivityHolder.set(null);
+      }
+      closeAllCobaltService();
     }
-    closeAllCobaltService();
     if (mApplicationStopped) {
       // We can't restart the starboard app, so kill the process for a clean start next time.
       Log.i(TAG, "Activity destroyed after shutdown; killing app.");
-      BaseStarboardBridgeJni.get().closeNativeStarboard(mNativeApp);
+      mNatives.closeNativeStarboard(mNativeApp);
       mTtsHelper.shutdown();
       mAdvertisingId.shutdown();
       System.exit(0);
@@ -339,12 +474,12 @@ public class BaseStarboardBridge {
   // Initialize the platform's AudioTrackAudioSink. This must be done after the browser client
   // loads in the feature list and field trials.
   public void initializePlatformAudioSink() {
-    BaseStarboardBridgeJni.get().initializePlatformAudioSink();
+    mNatives.initializePlatformAudioSink();
   }
 
   /** Sends an event to the web app to navigate to the given URL */
   public void handleDeepLink(String url) {
-    BaseStarboardBridgeJni.get().handleDeepLink(url, mApplicationStarted);
+    mNatives.handleDeepLink(url, mApplicationStarted);
   }
 
   public AssetManager getAssetsFromContext() {
@@ -602,6 +737,59 @@ public class BaseStarboardBridge {
     mAudioPermissionRequester.onRequestPermissionsResult(requestCode, permissions, grantResults);
   }
 
+  /**
+   * Called when a VideoSurfaceView creates its underlying Surface.
+   *
+   * Note: Starboard assumes a single active video surface at any given time for
+   * punch-out video decoding. During activity recreation or overlapping transitions,
+   * the newest activity's surface supersedes any previous surface as the active target.
+   */
+  public void onVideoSurfaceCreated(Surface surface) {
+    Log.i(TAG, String.format("onVideoSurfaceCreated: surface=%s", surface));
+    synchronized (mVideoSurfaceLock) {
+      mVideoSurface = surface;
+    }
+    VideoSurfaceView.notifyVideoSurfaceChanged(surface);
+  }
+
+  /**
+   * Called when a VideoSurfaceView destroys its underlying Surface.
+   *
+   * If this destruction event is for an old surface that was already superseded by a newer
+   * activity's surface, it is safely ignored so that the active video decoding target is not
+   * torn down prematurely.
+   */
+  public void onVideoSurfaceDestroyed(Surface surface) {
+    Log.i(TAG, String.format("onVideoSurfaceDestroyed: surface=%s", surface));
+    boolean shouldNotify = false;
+    synchronized (mVideoSurfaceLock) {
+      if (isActivityLifecycleCoordinationEnabled()) {
+        // If this destruction is for a surface that is no longer active (e.g. from an old activity
+        // during an overlapping activity transition), ignore it to avoid tearing down the new surface.
+        if (mVideoSurface != surface) {
+          Log.i(
+              TAG,
+              String.format(
+                  "onVideoSurfaceDestroyed: Ignoring destroyed surface %s from stale activity;"
+                      + " current surface is %s",
+                  surface, mVideoSurface));
+          return;
+        }
+      }
+      mVideoSurface = null;
+      shouldNotify = true;
+    }
+    if (shouldNotify) {
+      VideoSurfaceView.notifyVideoSurfaceChanged(null);
+    }
+  }
+
+  public Surface getVideoSurface() {
+    synchronized (mVideoSurfaceLock) {
+      return mVideoSurface;
+    }
+  }
+
   @SuppressWarnings("unused")
   @CalledByNative
   public void resetVideoSurface() {
@@ -624,20 +812,27 @@ public class BaseStarboardBridge {
     mCobaltServiceFactories.put(factory.getServiceName(), factory);
   }
 
+  public void unregisterCobaltService(String serviceName) {
+    mCobaltServiceFactories.remove(serviceName);
+  }
+
+  public void clearCobaltServiceFactories() {
+    mCobaltServiceFactories.clear();
+  }
+
   @CalledByNative
   public boolean hasCobaltService(String serviceName) {
     return mCobaltServiceFactories.get(serviceName) != null;
+  }
+
+  protected void onServiceCreated(CobaltService service) {
+    service.receiveBaseStarboardBridge(this);
   }
 
   // Explicitly pass activity as parameter.
   // Avoid using mActivityHolder.get(), because onActivityStop() can set it to null.
   @CalledByNative
   public CobaltService openCobaltService(long nativeService, String serviceName) {
-    if (mCobaltServices.get(serviceName) != null) {
-      // Attempting to re-open an already open service fails.
-      Log.e(TAG, String.format("Cannot open already open service %s", serviceName));
-      return null;
-    }
     final CobaltService.Factory factory = mCobaltServiceFactories.get(serviceName);
     if (factory == null) {
       Log.e(TAG, String.format("Cannot open unregistered service %s", serviceName));
@@ -645,47 +840,75 @@ public class BaseStarboardBridge {
     }
     CobaltService service = factory.createCobaltService(nativeService);
     if (service != null) {
-      if (this instanceof StarboardBridge) {
-        service.receiveStarboardBridge((StarboardBridge) this);
-      }
-      service.receiveBaseStarboardBridge(this);
-      mCobaltServices.put(serviceName, service);
-      Log.i(TAG, String.format("Opened platform service %s.", serviceName));
+      service.setServiceName(serviceName);
+      service.setNativeService(nativeService);
+      onServiceCreated(service);
+      mCobaltServices.put(nativeService, service);
+      Log.i(
+          TAG,
+          String.format(
+              "Opened platform service %s [handle: 0x%x].", serviceName, nativeService));
     }
     return service;
   }
 
   public CobaltService getOpenedCobaltService(String serviceName) {
-    return mCobaltServices.get(serviceName);
+    if (serviceName == null) {
+      return null;
+    }
+    CobaltService matchedService = null;
+    // Count matching instances across open handles to detect and warn if name-based lookup is ambiguous.
+    int count = 0;
+    for (CobaltService service : mCobaltServices.values()) {
+      if (!serviceName.equals(service.getServiceName())) {
+        continue;
+      }
+      if (matchedService == null) {
+        matchedService = service;
+      }
+      count++;
+    }
+    if (count > 1) {
+      Log.w(
+          TAG,
+          String.format(
+              "Multiple open CobaltService instances (%d) found for %s; returning first instance.",
+              count, serviceName));
+    }
+    return matchedService;
   }
 
   @CalledByNative
-  public void closeCobaltService(String serviceName) {
-    CobaltService service = mCobaltServices.remove(serviceName);
+  public void closeCobaltService(long nativeService) {
+    CobaltService service = mCobaltServices.remove(nativeService);
     if (service != null) {
       service.afterStopped();
       service.onClose();
+      Log.i(
+          TAG,
+          String.format(
+              "Closed platform service %s [handle: 0x%x].",
+              service.getServiceName(), nativeService));
     }
-    Log.i(TAG, String.format("Closed platform service %s.", serviceName));
   }
 
   @CalledByNative
   public void closeAllCobaltService() {
-    for (String serviceName : new ArrayList<>(mCobaltServices.keySet())) {
-      closeCobaltService(serviceName);
+    for (Long nativeService : new ArrayList<>(mCobaltServices.keySet())) {
+      closeCobaltService(nativeService);
     }
   }
 
   public byte[] sendToCobaltService(String serviceName, byte[] data) {
-    CobaltService service = mCobaltServices.get(serviceName);
+    CobaltService service = getOpenedCobaltService(serviceName);
     if (service == null) {
       Log.e(TAG, String.format("Service not opened: %s", serviceName));
       return null;
     }
     CobaltService.ResponseToClient response = service.receiveFromClient(data);
-    if (response.invalidState) {
+    if (response == null || response.invalidState) {
       Log.e(TAG, String.format("Service %s received invalid data, closing.", serviceName));
-      closeCobaltService(serviceName);
+      closeCobaltService(service.getNativeService());
       return null;
     }
     return response.data;
@@ -705,7 +928,7 @@ public class BaseStarboardBridge {
     long appStartDuration =
         (javaStopTimestamp - javaStartTimestamp) / mTimeNanosecondsPerMicrosecond;
 
-    long cppTimestamp = BaseStarboardBridgeJni.get().currentMonotonicTime();
+    long cppTimestamp = mNatives.currentMonotonicTime();
     mAppStartTimestamp = cppTimestamp - appStartDuration;
   }
 

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -225,6 +225,7 @@ public abstract class CobaltActivity extends BaseCobaltActivity {
       FontUtil.copyFontsXml(getApplicationContext());
       StarboardBridge starboardBridge = createStarboardBridge(getArgs(), mStartDeepLink);
       ((StarboardBridge.HostApplication) getApplication()).setStarboardBridge(starboardBridge);
+      starboardBridge.onActivityCreate(this);
     } else {
       // Warm start - Pass the deep link to the running Starboard app.
       if (savedInstanceState == null) {
@@ -283,6 +284,10 @@ public abstract class CobaltActivity extends BaseCobaltActivity {
       // See ManekiBaseDeviceUtil.CHROBALT_BROWSER_READY_REGEX in the internal test suite.
       Log.i(TAG, "Browser process init succeeded");
 
+      if (isDestroyed() || isFinishing()) {
+        Log.w(TAG, "Activity is finishing or destroyed; skipping finishInitialization.");
+        return;
+      }
       finishInitialization(savedInstanceState);
     } else {
       BrowserStartupController.getInstance()
@@ -299,6 +304,11 @@ public abstract class CobaltActivity extends BaseCobaltActivity {
                   // See ManekiBaseDeviceUtil.CHROBALT_BROWSER_READY_REGEX in the internal test
                   // suite.
                   Log.i(TAG, "Browser process init succeeded");
+
+                  if (isDestroyed() || isFinishing()) {
+                    Log.w(TAG, "Activity is finishing or destroyed; skipping finishInitialization.");
+                    return;
+                  }
 
                   finishInitialization(savedInstanceState);
                   getStarboardBridge().measureAppStartTimestamp();
@@ -472,10 +482,12 @@ public abstract class CobaltActivity extends BaseCobaltActivity {
 
     setupStartupGuard();
     createContent(savedInstanceState);
-    MemoryPressureMonitor.INSTANCE.registerComponentCallbacks();
-    MemoryPressureUma.initializeForBrowser();
-    NetworkChangeNotifier.init();
-    NetworkChangeNotifier.setAutoDetectConnectivityState(true);
+    if (!NetworkChangeNotifier.isInitialized()) {
+      MemoryPressureMonitor.INSTANCE.registerComponentCallbacks();
+      MemoryPressureUma.initializeForBrowser();
+      NetworkChangeNotifier.init();
+      NetworkChangeNotifier.setAutoDetectConnectivityState(true);
+    }
 
     if (!mIsCobaltUsingAndroidOverlay) {
       mVideoSurfaceView = new VideoSurfaceView(this);
@@ -534,6 +546,7 @@ public abstract class CobaltActivity extends BaseCobaltActivity {
    */
   protected abstract StarboardBridge createStarboardBridge(String[] args, String startDeepLink);
 
+  @Override
   protected StarboardBridge getStarboardBridge() {
     return ((StarboardBridge.HostApplication) getApplication()).getStarboardBridge();
   }
@@ -688,7 +701,9 @@ public abstract class CobaltActivity extends BaseCobaltActivity {
     if (mShellManager != null) {
       mShellManager.destroy();
     }
-    mWindowAndroid.destroy();
+    if (mWindowAndroid != null) {
+      mWindowAndroid.destroy();
+    }
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
       OnBackInvokedHelper.unregister(this, mBackInvokedCallback);
       mBackInvokedCallback = null;

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltService.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltService.java
@@ -22,11 +22,48 @@ import org.jni_zero.JNINamespace;
 import org.jni_zero.JniType;
 import org.jni_zero.NativeMethods;
 
-/** Abstract class that provides an interface for Cobalt to interact with a platform service. */
+/**
+ * Abstract class that provides an interface for Cobalt to interact with a platform service.
+ *
+ * <p>Threading model:
+ * <ul>
+ *   <li>{@code openCobaltService}, {@code closeCobaltService}, and {@link #receiveFromClient}
+ *       are invoked on the browser UI thread (Android main looper) and are serialized with
+ *       Activity lifecycle callbacks.</li>
+ *   <li>{@link #sendToClient} may be invoked from any thread; synchronization ensures safety
+ *       against concurrent {@link #onClose}.</li>
+ * </ul>
+ */
 public abstract class CobaltService {
   // Indicate is the service opened, and be able to send data to client
   protected boolean opened = true;
+  private volatile String mServiceName;
+  private volatile long mNativeService;
   private final Object lock = new Object();
+
+  public CobaltService() {
+    this.mNativeService = 0;
+  }
+
+  public CobaltService(long nativeService) {
+    this.mNativeService = nativeService;
+  }
+
+  void setNativeService(long nativeService) {
+    this.mNativeService = nativeService;
+  }
+
+  public long getNativeService() {
+    return mNativeService;
+  }
+
+  void setServiceName(String serviceName) {
+    mServiceName = serviceName;
+  }
+
+  public String getServiceName() {
+    return mServiceName;
+  }
 
   @JNINamespace("starboard")
   @NativeMethods
@@ -90,7 +127,6 @@ public abstract class CobaltService {
    * <p>Once this function returns, it is invalid to call sendToClient for the nativeService, so
    * synchronization must be used to protect against this.
    */
-  @CalledByNative
   public void onClose() {
     synchronized (lock) {
       if (!opened) {
@@ -114,6 +150,15 @@ public abstract class CobaltService {
       return sNatives;
     }
     return CobaltServiceJni.get();
+  }
+
+  /**
+   * Send data from the service to the client using the service's bound native handle.
+   *
+   * <p>This may be called from a separate thread.
+   */
+  protected void sendToClient(byte[] data) {
+    sendToClient(mNativeService, data);
   }
 
   /**

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java
@@ -48,9 +48,21 @@ public class StarboardBridge extends BaseStarboardBridge {
   }
 
   @Override
+  protected void onServiceCreated(CobaltService service) {
+    super.onServiceCreated(service);
+    service.receiveStarboardBridge(this);
+  }
+
+  @Override
   protected void onActivityStop(Activity activity) {
     super.onActivityStop(activity);
-    mCobaltMediaSession.onActivityStop();
+    if (isActivityLifecycleCoordinationEnabled()) {
+      if (!hasStartedActivities()) {
+        mCobaltMediaSession.onActivityStop();
+      }
+    } else {
+      mCobaltMediaSession.onActivityStop();
+    }
   }
 
   @Override

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/VideoSurfaceView.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/VideoSurfaceView.java
@@ -22,6 +22,9 @@ import android.util.AttributeSet;
 import android.view.Surface;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
+import dev.cobalt.coat.BaseStarboardBridge;
 import dev.cobalt.util.Log;
 import org.jni_zero.JNINamespace;
 import org.jni_zero.NativeMethods;
@@ -32,30 +35,39 @@ import org.jni_zero.NativeMethods;
  */
 @JNINamespace("starboard")
 public class VideoSurfaceView extends SurfaceView {
+  @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
   @NativeMethods
-  interface Natives {
+  public interface Natives {
     void onVideoSurfaceChanged(Surface surface);
   }
 
-  private static Surface sCurrentSurface = null;
+  public static void notifyVideoSurfaceChanged(Surface surface) {
+    VideoSurfaceViewJni.get().onVideoSurfaceChanged(surface);
+  }
+
+  @NonNull private final BaseStarboardBridge mBridge;
 
   public VideoSurfaceView(Context context) {
     super(context);
+    mBridge = getStarboardBridge(context);
     initialize(context);
   }
 
   public VideoSurfaceView(Context context, AttributeSet attrs) {
     super(context, attrs);
+    mBridge = getStarboardBridge(context);
     initialize(context);
   }
 
   public VideoSurfaceView(Context context, AttributeSet attrs, int defStyleAttr) {
     super(context, attrs, defStyleAttr);
+    mBridge = getStarboardBridge(context);
     initialize(context);
   }
 
   public VideoSurfaceView(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
     super(context, attrs, defStyleAttr, defStyleRes);
+    mBridge = getStarboardBridge(context);
     initialize(context);
   }
 
@@ -68,14 +80,26 @@ public class VideoSurfaceView extends SurfaceView {
     // punch-out video when the position / size is animated.
   }
 
+  @NonNull
+  private static BaseStarboardBridge getStarboardBridge(Context context) {
+    Context appContext = context.getApplicationContext();
+    if (appContext instanceof BaseStarboardBridge.HostApplication) {
+      BaseStarboardBridge bridge =
+          ((BaseStarboardBridge.HostApplication) appContext).getStarboardBridge();
+      if (bridge != null) {
+        return bridge;
+      }
+    }
+    return BaseStarboardBridge.getInstance();
+  }
+
   private class SurfaceHolderCallback implements SurfaceHolder.Callback {
 
     boolean mSawInitialChange = false;
 
     @Override
     public void surfaceCreated(SurfaceHolder holder) {
-      sCurrentSurface = holder.getSurface();
-      VideoSurfaceViewJni.get().onVideoSurfaceChanged(sCurrentSurface);
+      mBridge.onVideoSurfaceCreated(holder.getSurface());
     }
 
     @Override
@@ -89,12 +113,12 @@ public class VideoSurfaceView extends SurfaceView {
 
     @Override
     public void surfaceDestroyed(SurfaceHolder holder) {
-      sCurrentSurface = null;
-      VideoSurfaceViewJni.get().onVideoSurfaceChanged(sCurrentSurface);
+      mBridge.onVideoSurfaceDestroyed(holder.getSurface());
     }
   }
 
   public static Surface getCurrentSurface() {
-    return sCurrentSurface;
+    BaseStarboardBridge bridge = BaseStarboardBridge.getInstance();
+    return bridge != null ? bridge.getVideoSurface() : null;
   }
 }

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/Holder.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/Holder.java
@@ -22,7 +22,7 @@ import androidx.annotation.Nullable;
  * @param <T> The type of the object to hold.
  */
 public class Holder<T> {
-  private T mInstance;
+  private volatile T mInstance;
 
   public Holder() {
     this.mInstance = null;

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -172,6 +172,13 @@ public class JavaSwitches {
   /** Flag to disable v8 baseline compiler sparkplug. */
   public static final String V8_DISABLE_SPARKPLUG = "V8DisableSparkplug";
 
+  /**
+   * Flag to enable activity lifecycle coordination and safe surface teardown across overlapping
+   * activities.
+   */
+  public static final String ENABLE_ACTIVITY_LIFECYCLE_COORDINATION =
+      "EnableActivityLifecycleCoordination";
+
   private static Boolean sOverrideForTesting;
 
   public static void setOverrideForTesting(Boolean override) {
@@ -503,6 +510,10 @@ public class JavaSwitches {
     // CommandLine.getInstance().hasSwitch("use-starboard-lifecycle").
     if (javaSwitches.containsKey(JavaSwitches.USE_STARBOARD_LIFECYCLE)) {
       extraCommandLineArgs.add("--" + USE_STARBOARD_LIFECYCLE_SWITCH);
+    }
+
+    if (javaSwitches.containsKey(JavaSwitches.ENABLE_ACTIVITY_LIFECYCLE_COORDINATION)) {
+      extraCommandLineArgs.add("--enable-activity-lifecycle-coordination");
     }
 
     return extraCommandLineArgs;

--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/BaseStarboardBridgeTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/BaseStarboardBridgeTest.java
@@ -1,0 +1,428 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dev.cobalt.coat;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.app.Activity;
+import android.app.Service;
+import android.content.Context;
+import android.view.Surface;
+import dev.cobalt.coat.CobaltService.ResponseToClient;
+import dev.cobalt.media.VideoSurfaceView;
+import dev.cobalt.media.VideoSurfaceViewJni;
+import dev.cobalt.util.Holder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+/** Unit tests for BaseStarboardBridge. */
+@RunWith(RobolectricTestRunner.class)
+public class BaseStarboardBridgeTest {
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
+
+  @Mock private BaseStarboardBridge.Natives mockNatives;
+  @Mock private VideoSurfaceView.Natives mockVideoNatives;
+
+  private Context context;
+  private Holder<Activity> activityHolder;
+  private Holder<Service> serviceHolder;
+  private BaseStarboardBridge bridge;
+
+  private static class TestLifecycleCobaltService extends CobaltService {
+    int startOrResumeCount = 0;
+    int suspendCount = 0;
+    int stoppedCount = 0;
+    int closeCount = 0;
+    boolean returnInvalidState = false;
+
+    @Override
+    public void beforeStartOrResume() {
+      startOrResumeCount++;
+    }
+
+    @Override
+    public void beforeSuspend() {
+      suspendCount++;
+    }
+
+    @Override
+    public void afterStopped() {
+      stoppedCount++;
+    }
+
+    @Override
+    public ResponseToClient receiveFromClient(byte[] data) {
+      ResponseToClient response = new ResponseToClient();
+      response.invalidState = returnInvalidState;
+      response.data = data;
+      return response;
+    }
+
+    @Override
+    public void close() {
+      closeCount++;
+    }
+  }
+
+  @Before
+  public void setUp() {
+    BaseStarboardBridge.setActivityLifecycleCoordinationEnabledForTesting(true);
+    BaseStarboardBridgeJni.setInstanceForTesting(mockNatives);
+    VideoSurfaceViewJni.setInstanceForTesting(mockVideoNatives);
+    context = RuntimeEnvironment.getApplication();
+
+    activityHolder = new Holder<>();
+    serviceHolder = new Holder<>();
+    bridge =
+        new BaseStarboardBridge(
+            context, activityHolder, serviceHolder, new String[] {"--test"}, "") {};
+  }
+
+  @After
+  public void tearDown() {
+    BaseStarboardBridge.setActivityLifecycleCoordinationEnabledForTesting(null);
+    BaseStarboardBridgeJni.setInstanceForTesting(null);
+    VideoSurfaceViewJni.setInstanceForTesting(null);
+    BaseStarboardBridge.setInstanceForTesting(null);
+  }
+
+  @Test
+  public void openCobaltService_multipleInstancesSameName_storedByHandle() {
+    final TestLifecycleCobaltService service1 = new TestLifecycleCobaltService();
+    final TestLifecycleCobaltService service2 = new TestLifecycleCobaltService();
+
+    bridge.registerCobaltService(
+        new CobaltService.Factory() {
+          private int createCount = 0;
+
+          @Override
+          public CobaltService createCobaltService(long nativeService) {
+            createCount++;
+            return createCount == 1 ? service1 : service2;
+          }
+
+          @Override
+          public String getServiceName() {
+            return "testService";
+          }
+        });
+
+    CobaltService opened1 = bridge.openCobaltService(101L, "testService");
+    CobaltService opened2 = bridge.openCobaltService(102L, "testService");
+
+    assertEquals(service1, opened1);
+    assertEquals(service2, opened2);
+    assertEquals(101L, service1.getNativeService());
+    assertEquals(102L, service2.getNativeService());
+
+    // Close only the first instance
+    bridge.closeCobaltService(101L);
+    assertEquals(1, service1.stoppedCount);
+    assertEquals(1, service1.closeCount);
+    assertEquals(0, service2.closeCount);
+
+    // Close the second instance
+    bridge.closeCobaltService(102L);
+    assertEquals(1, service2.stoppedCount);
+    assertEquals(1, service2.closeCount);
+  }
+
+  @Test
+  public void overlappingActivities_gatingBeforeStartAndSuspend() {
+    final TestLifecycleCobaltService service = new TestLifecycleCobaltService();
+    bridge.registerCobaltService(
+        new CobaltService.Factory() {
+          @Override
+          public CobaltService createCobaltService(long nativeService) {
+            return service;
+          }
+
+          @Override
+          public String getServiceName() {
+            return "lifecycleService";
+          }
+        });
+
+    bridge.openCobaltService(201L, "lifecycleService");
+
+    Activity activity1 = mock(Activity.class);
+    Activity activity2 = mock(Activity.class);
+
+    bridge.onActivityCreate(activity1);
+    assertTrue(bridge.hasLiveActivities());
+
+    // Activity 1 starts: 0 -> 1 transition
+    bridge.onActivityStart(activity1);
+    assertTrue(bridge.hasStartedActivities());
+    assertEquals(1, service.startOrResumeCount);
+
+    bridge.onActivityCreate(activity2);
+
+    // Activity 2 starts: 1 -> 2 transition (should NOT call beforeStartOrResume again)
+    bridge.onActivityStart(activity2);
+    assertEquals(1, service.startOrResumeCount);
+
+    // Activity 1 stops: 2 -> 1 transition (should NOT call beforeSuspend)
+    bridge.onActivityStop(activity1);
+    assertTrue(bridge.hasStartedActivities());
+    assertEquals(0, service.suspendCount);
+
+    // Activity 1 destroyed: activity 2 is still live, services must NOT be torn down
+    bridge.onActivityDestroy(activity1);
+    assertTrue(bridge.hasLiveActivities());
+    assertNotNull(bridge.getOpenedCobaltService("lifecycleService"));
+    assertEquals(0, service.closeCount);
+
+    // Activity 2 stops: 1 -> 0 transition (should call beforeSuspend)
+    bridge.onActivityStop(activity2);
+    assertFalse(bridge.hasStartedActivities());
+    assertEquals(1, service.suspendCount);
+
+    // Activity 2 destroyed: all activities gone; safety net force-cleans remaining services
+    bridge.onActivityDestroy(activity2);
+    assertFalse(bridge.hasLiveActivities());
+    assertNull(bridge.getOpenedCobaltService("lifecycleService"));
+    assertEquals(1, service.closeCount);
+  }
+
+  @Test
+  public void sendToCobaltService_invalidState_closesServiceByHandle() {
+    final TestLifecycleCobaltService service = new TestLifecycleCobaltService();
+    service.returnInvalidState = true;
+
+    bridge.registerCobaltService(
+        new CobaltService.Factory() {
+          @Override
+          public CobaltService createCobaltService(long nativeService) {
+            return service;
+          }
+
+          @Override
+          public String getServiceName() {
+            return "invalidTestService";
+          }
+        });
+
+    bridge.openCobaltService(301L, "invalidTestService");
+    byte[] response = bridge.sendToCobaltService("invalidTestService", new byte[] {1, 2, 3});
+
+    assertNull(response);
+    assertEquals(1, service.closeCount);
+    assertNull(bridge.getOpenedCobaltService("invalidTestService"));
+  }
+
+  @Test
+  public void unregisterCobaltService_removesFactory() {
+    bridge.registerCobaltService(
+        new CobaltService.Factory() {
+          @Override
+          public CobaltService createCobaltService(long nativeService) {
+            return new TestLifecycleCobaltService();
+          }
+
+          @Override
+          public String getServiceName() {
+            return "removableService";
+          }
+        });
+
+    assertTrue(bridge.hasCobaltService("removableService"));
+    bridge.unregisterCobaltService("removableService");
+    assertFalse(bridge.hasCobaltService("removableService"));
+  }
+
+  @Test
+  public void onVideoSurfaceCreated_setsSurfaceAndNotifiesNative() {
+    Surface surface = mock(Surface.class);
+
+    bridge.onVideoSurfaceCreated(surface);
+
+    assertEquals(surface, bridge.getVideoSurface());
+    verify(mockVideoNatives).onVideoSurfaceChanged(surface);
+  }
+
+  @Test
+  public void onVideoSurfaceDestroyed_activeSurface_resetsSurfaceAndNotifiesNull() {
+    Surface surface = mock(Surface.class);
+
+    bridge.onVideoSurfaceCreated(surface);
+    bridge.onVideoSurfaceDestroyed(surface);
+
+    assertNull(bridge.getVideoSurface());
+    verify(mockVideoNatives).onVideoSurfaceChanged(null);
+  }
+
+  @Test
+  public void onVideoSurfaceDestroyed_staleSurfaceFromPreviousActivity_ignored() {
+    Surface surface1 = mock(Surface.class);
+    Surface surface2 = mock(Surface.class);
+
+    bridge.onVideoSurfaceCreated(surface1);
+    bridge.onVideoSurfaceCreated(surface2);
+    assertEquals(surface2, bridge.getVideoSurface());
+
+    // Stale surface destruction should be ignored
+    bridge.onVideoSurfaceDestroyed(surface1);
+
+    assertEquals(surface2, bridge.getVideoSurface());
+    verify(mockVideoNatives, never()).onVideoSurfaceChanged(null);
+  }
+
+  @Test
+  public void onActivityDestroy_lastActivityDestroyed_cleansUpVideoSurface() {
+    Activity activity = mock(Activity.class);
+    Surface surface = mock(Surface.class);
+
+    bridge.onActivityCreate(activity);
+    bridge.onVideoSurfaceCreated(surface);
+    assertEquals(surface, bridge.getVideoSurface());
+
+    bridge.onActivityDestroy(activity);
+
+    assertNull(bridge.getVideoSurface());
+    verify(mockVideoNatives).onVideoSurfaceChanged(null);
+  }
+
+  @Test
+  public void onActivityDestroy_otherActivityStillLive_preservesActiveVideoSurface() {
+    Activity activity1 = mock(Activity.class);
+    Activity activity2 = mock(Activity.class);
+    Surface surface2 = mock(Surface.class);
+
+    bridge.onActivityCreate(activity1);
+    bridge.onActivityCreate(activity2);
+    bridge.onVideoSurfaceCreated(surface2);
+
+    bridge.onActivityDestroy(activity1);
+
+    assertEquals(surface2, bridge.getVideoSurface());
+    verify(mockVideoNatives, never()).onVideoSurfaceChanged(null);
+  }
+
+  @Test
+  public void videoSurface_withoutCoordinationSwitch_notifiesNullOnStaleDestroy() {
+    BaseStarboardBridge.setActivityLifecycleCoordinationEnabledForTesting(false);
+    Surface surface1 = mock(Surface.class);
+    Surface surface2 = mock(Surface.class);
+
+    bridge.onVideoSurfaceCreated(surface1);
+    assertEquals(surface1, bridge.getVideoSurface());
+    verify(mockVideoNatives).onVideoSurfaceChanged(surface1);
+
+    bridge.onVideoSurfaceCreated(surface2);
+    assertEquals(surface2, bridge.getVideoSurface());
+    verify(mockVideoNatives).onVideoSurfaceChanged(surface2);
+
+    // When coordination is disabled (legacy), destroying surface1 resets surface and notifies JNI null
+    bridge.onVideoSurfaceDestroyed(surface1);
+    assertNull(bridge.getVideoSurface());
+    verify(mockVideoNatives).onVideoSurfaceChanged(null);
+  }
+
+  @Test
+  public void activityLifecycle_withoutCoordinationSwitch_callsResumeAndSuspendOnEveryActivity() {
+    BaseStarboardBridge.setActivityLifecycleCoordinationEnabledForTesting(false);
+    final TestLifecycleCobaltService service = new TestLifecycleCobaltService();
+    bridge.registerCobaltService(
+        new CobaltService.Factory() {
+          @Override
+          public CobaltService createCobaltService(long nativeService) {
+            return service;
+          }
+
+          @Override
+          public String getServiceName() {
+            return "test-service";
+          }
+        });
+    bridge.openCobaltService(1001L, "test-service");
+
+    Activity act1 = mock(Activity.class);
+    Activity act2 = mock(Activity.class);
+
+    bridge.onActivityStart(act1);
+    assertEquals(1, service.startOrResumeCount);
+
+    // When coordination is disabled, starting act2 immediately calls beforeStartOrResume again
+    bridge.onActivityStart(act2);
+    assertEquals(2, service.startOrResumeCount);
+
+    // When coordination is disabled, stopping act1 immediately calls beforeSuspend even though act2 is active
+    bridge.onActivityStop(act1);
+    assertEquals(1, service.suspendCount);
+
+    // In legacy mode, destroying act1 while act2 is in mActivityHolder skips closeAllCobaltService
+    bridge.onActivityDestroy(act1);
+    assertEquals(0, service.closeCount);
+    assertNotNull(bridge.getOpenedCobaltService("test-service"));
+
+    // When act2 stops and destroys, services are closed
+    bridge.onActivityStop(act2);
+    bridge.onActivityDestroy(act2);
+    assertEquals(1, service.closeCount);
+    assertNull(bridge.getOpenedCobaltService("test-service"));
+  }
+
+  @Test
+  public void getOpenedCobaltService_nullServiceName_returnsNull() {
+    assertNull(bridge.getOpenedCobaltService(null));
+  }
+
+  @Test
+  public void sendToCobaltService_nullResponse_closesServiceAndReturnsNull() {
+    final TestLifecycleCobaltService nullResponseService =
+        new TestLifecycleCobaltService() {
+          @Override
+          public ResponseToClient receiveFromClient(byte[] data) {
+            return null;
+          }
+        };
+
+    bridge.registerCobaltService(
+        new CobaltService.Factory() {
+          @Override
+          public CobaltService createCobaltService(long nativeService) {
+            return nullResponseService;
+          }
+
+          @Override
+          public String getServiceName() {
+            return "nullResponseService";
+          }
+        });
+
+    bridge.openCobaltService(401L, "nullResponseService");
+    byte[] result = bridge.sendToCobaltService("nullResponseService", new byte[] {1});
+
+    assertNull(result);
+    assertNull(bridge.getOpenedCobaltService("nullResponseService"));
+  }
+}

--- a/cobalt/browser/h5vcc_platform_service/platform_service_impl.cc
+++ b/cobalt/browser/h5vcc_platform_service/platform_service_impl.cc
@@ -79,12 +79,7 @@ void PlatformServiceImpl::StarboardReceiveMessageCallback(void* context,
   const uint8_t* byte_data = static_cast<const uint8_t*>(data);
   std::vector<uint8_t> data_vector(byte_data, byte_data + length);
 
-  // content::DocumentService is bound to the UI thread, via the RFH.
-  content::GetUIThreadTaskRunner({})->PostTask(
-      FROM_HERE,
-      base::BindOnce(&PlatformServiceImpl::OnDataReceivedFromStarboard,
-                     instance->weak_factory_.GetWeakPtr(),
-                     std::move(data_vector)));
+  instance->on_data_received_callback_.Run(std::move(data_vector));
 }
 
 PlatformServiceImpl::PlatformServiceImpl(
@@ -95,6 +90,10 @@ PlatformServiceImpl::PlatformServiceImpl(
     : DocumentService(render_frame_host, std::move(receiver)),
       service_name_(service_name),
       observer_(std::move(observer)) {
+  on_data_received_callback_ = base::BindPostTask(
+      content::GetUIThreadTaskRunner({}),
+      base::BindRepeating(&PlatformServiceImpl::OnDataReceivedFromStarboard,
+                          weak_factory_.GetWeakPtr()));
   observer_.set_disconnect_handler(base::BindOnce(
       [] { LOG(INFO) << "PlatformServiceObserver disconnected."; }));
   LOG(INFO) << "PlatformServiceImpl created for " << service_name_;

--- a/cobalt/browser/h5vcc_platform_service/platform_service_impl.h
+++ b/cobalt/browser/h5vcc_platform_service/platform_service_impl.h
@@ -18,6 +18,7 @@
 #include <string>
 #include <vector>
 
+#include "base/functional/callback.h"
 #include "base/memory/weak_ptr.h"
 #include "cobalt/browser/h5vcc_platform_service/public/mojom/h5vcc_platform_service.mojom.h"
 #include "content/public/browser/document_service.h"
@@ -70,6 +71,9 @@ class PlatformServiceImpl
   // This is a handle to the service: a pointer to the private struct.
   CobaltExtensionPlatformService platform_service_ =
       kCobaltExtensionPlatformServiceInvalid;
+
+  base::RepeatingCallback<void(const std::vector<uint8_t>&)>
+      on_data_received_callback_;
 
   base::WeakPtrFactory<PlatformServiceImpl> weak_factory_{this};
 };

--- a/starboard/android/shared/base_starboard_bridge.cc
+++ b/starboard/android/shared/base_starboard_bridge.cc
@@ -414,11 +414,10 @@ ScopedJavaLocalRef<jobject> StarboardBridge::OpenCobaltService(
       ConvertUTF8ToJavaString(env, service_name));
 }
 
-void StarboardBridge::CloseCobaltService(JNIEnv* env,
-                                         const char* service_name) {
+void StarboardBridge::CloseCobaltService(JNIEnv* env, jlong native_service) {
   SB_CHECK(env);
-  Java_BaseStarboardBridge_closeCobaltService(
-      env, j_starboard_bridge_, ConvertUTF8ToJavaString(env, service_name));
+  Java_BaseStarboardBridge_closeCobaltService(env, j_starboard_bridge_,
+                                              native_service);
 }
 
 bool StarboardBridge::HasCobaltService(JNIEnv* env, const char* service_name) {

--- a/starboard/android/shared/platform_service.cc
+++ b/starboard/android/shared/platform_service.cc
@@ -134,15 +134,15 @@ CobaltExtensionPlatformService Open(void* context,
 }
 
 void Close(CobaltExtensionPlatformService service) {
-  if (!service || !service->cobalt_service) {
+  if (!service) {
     return;
   }
 
-  JNIEnv* env = AttachCurrentThread();
-  Java_CobaltService_onClose(env, service->cobalt_service);
-
-  starboard::StarboardBridge::GetInstance()->CloseCobaltService(
-      env, service->name.c_str());
+  if (service->cobalt_service) {
+    JNIEnv* env = AttachCurrentThread();
+    starboard::StarboardBridge::GetInstance()->CloseCobaltService(
+        env, reinterpret_cast<jlong>(service));
+  }
   delete static_cast<CobaltExtensionPlatformServicePrivate*>(service);
 }
 

--- a/starboard/android/shared/starboard_bridge.h
+++ b/starboard/android/shared/starboard_bridge.h
@@ -99,7 +99,7 @@ class StarboardBridge {
       JNIEnv* env,
       jlong native_service,
       const char* service_name);
-  void CloseCobaltService(JNIEnv* env, const char* service_name);
+  void CloseCobaltService(JNIEnv* env, jlong native_service);
   bool HasCobaltService(JNIEnv* env, const char* service_name);
   void CloseAllCobaltService(JNIEnv* env) const;
 


### PR DESCRIPTION
### Summary
Scopes `CobaltService` lifecycle to native `RenderFrameHost` / `DocumentService` handles and fixes memory leaks during Android activity transitions (b/528367182).

### Changes
1. **Handle-Keyed Services**: Key services by `long nativeService` handle in `BaseStarboardBridge` to prevent collisions and leaks across documents, iframes, or overlapping activities.
2. **Deterministic Teardown**: Update native `Close()` to delegate teardown by handle in the correct order (`remove` -> `afterStopped` -> `onClose`) and unconditionally free private struct state.
3. **Symmetric Lifecycle Gating**: Symmetrically gate `beforeStartOrResume()` on 0 -> 1 started activities and `beforeSuspend()` on 1 -> 0, backed by a single `WeakHashMap` in the bridge.
4. **Safety Net**: Clean up orphaned services in `onActivityDestroy` if all activities are destroyed.
5. **Unit Tests**: Added `BaseStarboardBridgeTest` testing handle-keyed registration, lifecycle gating, teardown order, and invalid state handling.

### Device Testing (Google TV Streamer)
Simulated full overlapping activity handover (`MainActivity.start -> SecondActivity.start -> MainActivity.stop -> MainActivity.destroy -> SecondActivity browsing & video playback`):
* **`origin/main` Baseline**:
  * Crashed immediately on `SecondActivity.onCreate` due to `MemoryPressureUma.initializeInstance` asserting `assert sInstance == null;`.
  * Even when isolating beyond the crash, `MainActivity.onStop` prematurely suspended the app and decommitted renderer memory, and `MainActivity.onDestroy` destroyed `VideoSurfaceView`, nulling `sCurrentSurface`. Subsequent playback failed with `"Video surface is not available now"` (pitch-black screen).
* **With This PR**:
  * Second activity created cleanly without singleton collisions.
  * Overlapping stop/destroy gracefully deferred suspend and ignored stale surface destruction.
  * DPAD navigation and 4K hardware video playback on `SecondActivity` worked smoothly without errors.

Bug: 528367182
TAG=agy
CONV=9d9cb097-4bbf-46c5-b2fc-766467028e99