### PR TITLE
media: Only paint video hole frame with punchout

### DIFF
--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -618,7 +618,9 @@ void StarboardRenderer::UpdateUrlPlayerVideoResolution() {
 
   url_player_video_size_ = size;
   client_->OnVideoNaturalSizeChange(size);
-  paint_video_hole_frame_cb_.Run(size);
+  if (player_bridge_->GetSbPlayerOutputMode() == kSbPlayerOutputModePunchOut) {
+    paint_video_hole_frame_cb_.Run(size);
+  }
 }
 
 void StarboardRenderer::OnUrlPlayerPresenting() {
@@ -884,8 +886,11 @@ void StarboardRenderer::UpdateDecoderConfig(DemuxerStream* stream) {
     }
 #endif  // 0
     color_space_ = decoder_config.color_space_info().ToGfxColorSpace();
-    paint_video_hole_frame_cb_.Run(
-        stream->video_decoder_config().visible_rect().size());
+    if (player_bridge_->GetSbPlayerOutputMode() ==
+        kSbPlayerOutputModePunchOut) {
+      paint_video_hole_frame_cb_.Run(
+          stream->video_decoder_config().visible_rect().size());
+    }
   }
 }
 
@@ -966,8 +971,11 @@ void StarboardRenderer::OnDemuxerStreamRead(
       // TODO(b/375275033): Refine calling to OnVideoNaturalSizeChange().
       client_->OnVideoNaturalSizeChange(
           stream->video_decoder_config().visible_rect().size());
-      paint_video_hole_frame_cb_.Run(
-          stream->video_decoder_config().visible_rect().size());
+      if (player_bridge_->GetSbPlayerOutputMode() ==
+          kSbPlayerOutputModePunchOut) {
+        paint_video_hole_frame_cb_.Run(
+            stream->video_decoder_config().visible_rect().size());
+      }
     }
     UpdateDecoderConfig(stream);
     stream->Read(


### PR DESCRIPTION
Restrict the video hole painting callback to only trigger when the
Starboard player is configured for punch-out output mode. For other
modes like decode-to-texture, painting a hole in the UI is not
required as the video is rendered directly into the graphics
pipeline. This ensures the painting logic matches the current
player output configuration.

Issue: 549780766
Issue: 548031519