### PR TITLE
android: Report negative expected written frames

### DIFF
--- a/starboard/android/shared/audio_track_audio_sink_type.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type.cc
@@ -401,6 +401,13 @@ void AudioTrackAudioSink::AudioThreadFunc() {
       expected_written_frames = frames_in_buffer - frames_in_audio_track;
     }
 
+    if (expected_written_frames < 0) {
+      // TODO(cobalt, b/549849936): resolve negative expected_written_frames
+      // issue.
+      ReportError(false, "AudioTrack expected written frames is negative.");
+      break;
+    }
+
     expected_written_frames =
         std::min(expected_written_frames, max_frames_per_request_);
 

--- a/starboard/android/shared/audio_track_audio_sink_type_test.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type_test.cc
@@ -14,11 +14,12 @@
 
 #include "starboard/android/shared/audio_track_audio_sink_type.h"
 
-#include <unistd.h>
-
 #include <atomic>
+#include <chrono>
 #include <memory>
+#include <mutex>
 #include <optional>
+#include <thread>
 #include <vector>
 
 #include "starboard/android/shared/fake_audio_track.h"
@@ -61,6 +62,15 @@ class AudioTrackAudioSinkTest : public ::testing::Test {
     fixture->total_frames_consumed_ += frames_consumed;
   }
 
+  static void ErrorCB(bool capability_changed,
+                      const std::string& error_message,
+                      void* context) {
+    auto* fixture = static_cast<AudioTrackAudioSinkTest*>(context);
+    std::lock_guard<std::mutex> lock(fixture->error_mutex_);
+    fixture->error_reported_ = true;
+    fixture->error_msg_ = error_message;
+  }
+
   std::vector<uint8_t> frame_buffer_;
   void* frame_buffers_[1];
   std::atomic<int> frames_in_buffer_ = 512;
@@ -68,6 +78,9 @@ class AudioTrackAudioSinkTest : public ::testing::Test {
   std::atomic<bool> is_playing_ = true;
   std::atomic<bool> is_eos_reached_ = false;
   std::atomic<int> total_frames_consumed_ = 0;
+  std::mutex error_mutex_;
+  std::atomic<bool> error_reported_ = false;
+  std::string error_msg_;
 };
 
 TEST_F(AudioTrackAudioSinkTest, CreateAndDestroy) {
@@ -94,7 +107,7 @@ TEST_F(AudioTrackAudioSinkTest, CreateAndDestroy) {
   // Let the sink thread run and process frames.
   int elapsed_ms = 0;
   while (track_ptr->written_frames() == 0 && elapsed_ms < 1000) {
-    usleep(10'000);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
     elapsed_ms += 10;
   }
   EXPECT_GT(track_ptr->written_frames(), 0);
@@ -124,7 +137,7 @@ TEST_F(AudioTrackAudioSinkTest, PauseAndResumePlayback) {
   int elapsed_ms = 0;
   while (track_ptr->play_state() != AudioTrack::PlayState::kPlaying &&
          elapsed_ms < 1000) {
-    usleep(10'000);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
     elapsed_ms += 10;
   }
   EXPECT_EQ(track_ptr->play_state(), AudioTrack::PlayState::kPlaying);
@@ -133,7 +146,7 @@ TEST_F(AudioTrackAudioSinkTest, PauseAndResumePlayback) {
   elapsed_ms = 0;
   while (track_ptr->play_state() != AudioTrack::PlayState::kPaused &&
          elapsed_ms < 1000) {
-    usleep(10'000);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
     elapsed_ms += 10;
   }
   EXPECT_EQ(track_ptr->play_state(), AudioTrack::PlayState::kPaused);
@@ -142,7 +155,7 @@ TEST_F(AudioTrackAudioSinkTest, PauseAndResumePlayback) {
   elapsed_ms = 0;
   while (track_ptr->play_state() != AudioTrack::PlayState::kPlaying &&
          elapsed_ms < 1000) {
-    usleep(10'000);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
     elapsed_ms += 10;
   }
   EXPECT_EQ(track_ptr->play_state(), AudioTrack::PlayState::kPlaying);
@@ -170,7 +183,7 @@ TEST_F(AudioTrackAudioSinkTest, FlushAndResumePlayback) {
   int elapsed_ms = 0;
   while (track_ptr->play_state() != AudioTrack::PlayState::kPlaying &&
          elapsed_ms < 1000) {
-    usleep(10'000);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
     elapsed_ms += 10;
   }
   EXPECT_EQ(track_ptr->play_state(), AudioTrack::PlayState::kPlaying);
@@ -184,7 +197,7 @@ TEST_F(AudioTrackAudioSinkTest, FlushAndResumePlayback) {
   while (track_ptr->play_state() != AudioTrack::PlayState::kStopped &&
          track_ptr->play_state() != AudioTrack::PlayState::kPaused &&
          elapsed_ms < 1000) {
-    usleep(10'000);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
     elapsed_ms += 10;
   }
   EXPECT_TRUE(track_ptr->play_state() == AudioTrack::PlayState::kStopped ||
@@ -195,10 +208,61 @@ TEST_F(AudioTrackAudioSinkTest, FlushAndResumePlayback) {
   elapsed_ms = 0;
   while (track_ptr->play_state() != AudioTrack::PlayState::kPlaying &&
          elapsed_ms < 1000) {
-    usleep(10'000);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
     elapsed_ms += 10;
   }
   EXPECT_EQ(track_ptr->play_state(), AudioTrack::PlayState::kPlaying);
+}
+
+TEST_F(AudioTrackAudioSinkTest,
+       HandlesFramesInBufferLessThanFramesInAudioTrack) {
+  AudioTrackAudioSinkType type;
+  auto fake_track = std::make_unique<FakeAudioTrack>(
+      2, 48000, kSbMediaAudioSampleTypeFloat32);
+  FakeAudioTrack* track_ptr = fake_track.get();
+
+  AudioTrackAudioSinkType::Callbacks callbacks{
+      UpdateSourceStatusCB,
+      ConsumeFramesCB,
+      ErrorCB,
+  };
+
+  // Start with 512 frames in buffer.
+  frames_in_buffer_ = 512;
+  auto sink = AudioTrackAudioSink::CreateForTesting(
+      &type, 2, 48000, kSbMediaAudioSampleTypeFloat32, frame_buffers_, 1024,
+      512, callbacks, 0,
+      /*tunnel_mode_audio_session_id=*/std::nullopt,
+      /*allow_audio_writing_on_pause=*/false, std::move(fake_track), this);
+
+  ASSERT_NE(sink, nullptr);
+
+  // Wait until the initial 512 frames are written to the audio track.
+  int elapsed_ms = 0;
+  while (track_ptr->written_frames() < 512 && elapsed_ms < 1000) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    elapsed_ms += 10;
+  }
+  EXPECT_GE(track_ptr->written_frames(), 512);
+
+  // Simulate source buffer underrun/drain where frames_in_buffer drops to 256,
+  // meaning frames_in_buffer (256) < frames_in_audio_track (512).
+  frames_in_buffer_ = 256;
+
+  // Wait for ReportError to be triggered.
+  elapsed_ms = 0;
+  while (!error_reported_ && elapsed_ms < 1000) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    elapsed_ms += 10;
+  }
+
+  EXPECT_TRUE(error_reported_);
+  {
+    std::lock_guard<std::mutex> lock(error_mutex_);
+    EXPECT_EQ(error_msg_, "AudioTrack expected written frames is negative.");
+  }
+
+  sink.reset();
 }
 
 }  // namespace


### PR DESCRIPTION
Ensure that AudioTrackAudioSink reports an error if the calculated
number of frames to write is negative. This condition can arise when
the frames available in the buffer are fewer than the frames already
in the audio track. Terminating execution on this inconsistency
prevents invalid playback behavior.

Issue: 547458037
Issue: 549849936