### PR TITLE
evergreen: provide CobaltExtensionMemoryMappedFileApi for RDK

### DIFF
--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_extensions.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_extensions.cc
@@ -28,21 +28,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "starboard/system.h"
-
 #include <cstring>
 
-
-#include "starboard/common/string.h"
 #include "starboard/common/log.h"
+#include "starboard/common/string.h"
 #include "starboard/extension/configuration.h"
 #include "starboard/extension/crash_handler.h"
-#include "starboard/extension/loader_app_metrics.h"
 #include "starboard/extension/graphics.h"
-#include "third_party/starboard/rdk/shared/graphics.h"
+#include "starboard/extension/loader_app_metrics.h"
+#include "starboard/extension/memory_mapped_file.h"
 #include "starboard/extension/platform_service.h"
+#include "starboard/shared/posix/memory_mapped_file.h"
+#include "starboard/system.h"
 #include "third_party/starboard/rdk/shared/accessibility_extension.h"
 #include "third_party/starboard/rdk/shared/configuration.h"
+#include "third_party/starboard/rdk/shared/graphics.h"
 #include "third_party/starboard/rdk/shared/platform_service.h"
 #if BUILDFLAG(IS_STARBOARD)
 #include "starboard/elf_loader/evergreen_config.h"
@@ -80,16 +80,16 @@ const void* SbSystemGetExtension(const char* name) {
 #endif
   if (strcmp(name, kCobaltExtensionConfigurationName) == 0) {
     return starboard::GetConfigurationApi();
-  }
-  else if (strcmp(name, kCobaltExtensionGraphicsName) == 0) {
+  } else if (strcmp(name, kCobaltExtensionGraphicsName) == 0) {
     return starboard::GetGraphicsApi();
-  }
-  else if (strcmp(name, kCobaltExtensionPlatformServiceName) == 0) {
+  } else if (strcmp(name, kCobaltExtensionPlatformServiceName) == 0) {
     return starboard::GetPlatformServiceApi();
   }
   if (strcmp(name, kStarboardExtensionAccessibilityName) == 0) {
     return starboard::GetAccessibilityApi();
   }
+  if (strcmp(name, kCobaltExtensionMemoryMappedFileName) == 0) {
+    return starboard::GetMemoryMappedFileApi();
+  }
   return NULL;
 }
-


### PR DESCRIPTION
This imports the fix to wire up CobaltExtensionMemoryMappedFileApi into SbSystemGetExtension for RDK: https://github.com/aelzeiny/cobalt-browser/commit/0ce80d6ca812cd92ddaa2a39cbed6f1f125f97d9.

Bug: 548055360
CONV=a3c62114-7eef-4e74-afbd-917ce2080ec8
TAG=agy