### PR TITLE
cobalt: Bypass BufferingBytesConsumer by default

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -97,10 +97,6 @@ public class JavaSwitches {
   /** Avoid reuse resource. */
   public static final String AVOID_CC_REUSE_RESOURCE = "AvoidCCReuseResource";
 
-  /** flag to bypass BufferingBytesConsumer Oilpan heap buffering. */
-  public static final String COBALT_BYPASS_BUFFERING_BYTES_CONSUMER =
-      "CobaltBypassBufferingBytesConsumer";
-
   /** flag to bypass ResourceLoadScheduler subresource queueing and throttling. */
   public static final String COBALT_BYPASS_RESOURCE_LOAD_SCHEDULER =
       "CobaltBypassResourceLoadScheduler";
@@ -291,11 +287,6 @@ public class JavaSwitches {
 
     if (javaSwitches.containsKey(JavaSwitches.AVOID_CC_REUSE_RESOURCE)) {
       extraCommandLineArgs.add("--avoid-cc-reuse-resource");
-    }
-
-    if (javaSwitches.containsKey(JavaSwitches.COBALT_BYPASS_BUFFERING_BYTES_CONSUMER)) {
-      extraCommandLineArgs.add(
-          "--enable-features=" + JavaSwitches.COBALT_BYPASS_BUFFERING_BYTES_CONSUMER);
     }
 
     if (javaSwitches.containsKey(JavaSwitches.COBALT_BYPASS_RESOURCE_LOAD_SCHEDULER)) {

--- a/third_party/blink/common/features.cc
+++ b/third_party/blink/common/features.cc
@@ -450,7 +450,7 @@ BASE_FEATURE(kClientHintsXRFormFactor,
 // bypassing BufferingBytesConsumer Oilpan heap buffering.
 BASE_FEATURE(kCobaltBypassBufferingBytesConsumer,
              "CobaltBypassBufferingBytesConsumer",
-             base::FEATURE_DISABLED_BY_DEFAULT);
+             base::FEATURE_ENABLED_BY_DEFAULT);
 
 // Bypasses Blink HTMLPreloadScanner and HTMLResourcePreloader in Cobalt
 // since Cobalt UI is a single-page app with dynamically generated DOM.


### PR DESCRIPTION
Enable the CobaltBypassBufferingBytesConsumer feature by default and
remove the command-line switch logic from Android.

This optimization reduces memory usage by approximately 1.5MB (RSS and
PMF). The change has been approved as part of a global initiative to
reduce the browser memory footprint (go/bonsai-memory).

Issue: 532673378