### PR TITLE
finch: Defer active config initialization until crash streak is synced

### DIFF
--- a/cobalt/browser/cobalt_content_browser_client.cc
+++ b/cobalt/browser/cobalt_content_browser_client.cc
@@ -630,6 +630,14 @@ void CobaltContentBrowserClient::SetUpCobaltFeaturesAndParams(
   auto* global_features = GlobalFeatures::GetInstance();
   auto* experiment_config_manager =
       global_features->experiment_config_manager();
+
+  // It is critical that GetExperimentConfigType() is evaluated after
+  // InstantiateFieldTrialList(), because the latter triggers
+  // CleanExitBeacon::Initialize(), which reads the 'Variations' beacon file
+  // from DIR_CACHE and increments/syncs the crash streak into
+  // metrics_local_state.
+  // ExperimentConfigManager can then see the true crash streak and fall back
+  // to Safe Mode when needed.
   auto config_type = experiment_config_manager->GetExperimentConfigType();
   if (config_type == ExperimentConfigType::kEmptyConfig) {
     return;

--- a/cobalt/browser/cobalt_content_browser_client.cc
+++ b/cobalt/browser/cobalt_content_browser_client.cc
@@ -634,6 +634,8 @@ void CobaltContentBrowserClient::SetUpCobaltFeaturesAndParams(
   if (config_type == ExperimentConfigType::kEmptyConfig) {
     return;
   }
+
+  global_features->InitializeActiveConfigData(config_type);
   auto* experiment_config = global_features->experiment_config();
   const bool use_safe_config =
       (config_type == ExperimentConfigType::kSafeConfig);

--- a/cobalt/browser/global_features.cc
+++ b/cobalt/browser/global_features.cc
@@ -48,11 +48,8 @@ constexpr base::FilePath::CharType kMetricsConfigFilename[] =
 GlobalFeatures::GlobalFeatures() {
   CreateExperimentConfig();
   CreateMetricsServices();
-  // InitializeActiveConfigData needs ExperimentConfigManager to determine
-  // the experiment config type.
   experiment_config_manager_ = std::make_unique<ExperimentConfigManager>(
       experiment_config_.get(), metrics_local_state_.get());
-  InitializeActiveConfigData();
 }
 
 // static
@@ -190,11 +187,9 @@ void GlobalFeatures::CreateMetricsLocalState() {
   metrics_local_state_ = pref_service_factory.Create(std::move(pref_registry));
 }
 
-void GlobalFeatures::InitializeActiveConfigData() {
+void GlobalFeatures::InitializeActiveConfigData(
+    ExperimentConfigType experiment_config_type) {
   DCHECK(experiment_config_);
-  DCHECK(experiment_config_manager_);
-  auto experiment_config_type =
-      experiment_config_manager_->GetExperimentConfigType();
   if (experiment_config_type == ExperimentConfigType::kEmptyConfig) {
     return;
   }

--- a/cobalt/browser/global_features.cc
+++ b/cobalt/browser/global_features.cc
@@ -191,6 +191,7 @@ void GlobalFeatures::InitializeActiveConfigData(
     ExperimentConfigType experiment_config_type) {
   DCHECK(experiment_config_);
   if (experiment_config_type == ExperimentConfigType::kEmptyConfig) {
+    active_config_data_.clear();
     return;
   }
 

--- a/cobalt/browser/global_features.h
+++ b/cobalt/browser/global_features.h
@@ -69,6 +69,12 @@ class GlobalFeatures {
     return experiment_config_manager_.get();
   }
 
+  // Record the active config data in the member variable to preserve the active
+  // config data for the current app life cycle in case it's needed after the
+  // config data in storage has been modified.
+  // Modified config data should only apply to the next app life cycle.
+  void InitializeActiveConfigData(ExperimentConfigType experiment_config_type);
+
   void set_accessor(std::unique_ptr<base::FeatureList::Accessor> accessor);
 
   // Explicitly shuts down the metrics service. This is to ensure the
@@ -99,11 +105,6 @@ class GlobalFeatures {
   void CreateMetricsLocalState();
   // Initialize a PrefService instance for local state.
   void CreateLocalState();
-  // Record the active config data in the member variable to preserve the active
-  // config data for the current app life cycle in case it's needed after the
-  // config data in storage has been modified.
-  // Modified config data should only apply to the next app life cycle.
-  void InitializeActiveConfigData();
 
   // Construct a FilePath for a pref file and ensure its parent directory
   // exists.

--- a/cobalt/browser/global_features_unittest.cc
+++ b/cobalt/browser/global_features_unittest.cc
@@ -70,6 +70,7 @@ class GlobalFeaturesTest : public testing::Test {
     experiment_config->ClearPref(kSafeConfigActiveConfigData);
     experiment_config->ClearPref(kSafeConfigFeatures);
     experiment_config->ClearPref(kSafeConfigFeatureParams);
+    instance_->InitializeActiveConfigData(ExperimentConfigType::kEmptyConfig);
     // auto metrics_local_state = instance_->metrics_local_state();
   }
 
@@ -138,6 +139,28 @@ TEST_F(GlobalFeaturesTest,
 
   // Active config data in memory should remain the same.
   EXPECT_EQ(instance_->active_config_data(), "initial_data");
+}
+
+TEST_F(GlobalFeaturesTest, InitializedActiveConfigDataClearedOnEmptyConfig) {
+  ASSERT_NE(instance_, nullptr);
+  auto* experiment_config = instance_->experiment_config();
+  experiment_config->SetString(kExperimentConfigActiveConfigData,
+                               "initial_data");
+
+  instance_->InitializeActiveConfigData(ExperimentConfigType::kRegularConfig);
+  EXPECT_EQ(instance_->active_config_data(), "initial_data");
+
+  instance_->InitializeActiveConfigData(ExperimentConfigType::kEmptyConfig);
+  EXPECT_TRUE(instance_->active_config_data().empty());
+}
+
+TEST_F(GlobalFeaturesTest, InitializedActiveConfigDataSnapshotsSafeConfig) {
+  ASSERT_NE(instance_, nullptr);
+  auto* experiment_config = instance_->experiment_config();
+  experiment_config->SetString(kSafeConfigActiveConfigData, "safe_data");
+
+  instance_->InitializeActiveConfigData(ExperimentConfigType::kSafeConfig);
+  EXPECT_EQ(instance_->active_config_data(), "safe_data");
 }
 
 TEST_F(GlobalFeaturesTest, SetAndGetSettingInt) {

--- a/cobalt/browser/global_features_unittest.cc
+++ b/cobalt/browser/global_features_unittest.cc
@@ -126,18 +126,18 @@ TEST_F(GlobalFeaturesTest, RegisterPrefsRegistersExpectedPrefs) {
 TEST_F(GlobalFeaturesTest,
        InitializedActiveConfigDataUnchangedAfterChangeToStoredData) {
   ASSERT_NE(instance_, nullptr);
-  auto active_config_data = instance_->active_config_data();
-  EXPECT_TRUE(active_config_data.empty());
+  auto* experiment_config = instance_->experiment_config();
+  experiment_config->SetString(kExperimentConfigActiveConfigData,
+                               "initial_data");
 
-  base::FilePath config_file =
-      temp_dir_->GetPath().Append(FILE_PATH_LITERAL("Experiment Config"));
-  base::WriteFile(
-      config_file,
-      R"({"experiment_config":{"features":{"feature_a":true},"feature_params":{"param1":"value1"},"active_config_data":"ab"},"latest_config_hash":"cd")");
+  instance_->InitializeActiveConfigData(ExperimentConfigType::kRegularConfig);
+  EXPECT_EQ(instance_->active_config_data(), "initial_data");
+
+  experiment_config->SetString(kExperimentConfigActiveConfigData,
+                               "modified_data");
 
   // Active config data in memory should remain the same.
-  active_config_data = instance_->active_config_data();
-  EXPECT_TRUE(active_config_data.empty());
+  EXPECT_EQ(instance_->active_config_data(), "initial_data");
 }
 
 TEST_F(GlobalFeaturesTest, SetAndGetSettingInt) {


### PR DESCRIPTION
Move the initialization of active configuration data from the
GlobalFeatures constructor to CobaltContentBrowserClient. This allows
the initialization to be deferred until the experiment config type is
determined crash streak synchronization from beacon file to metrics
local state is processed.

Bug: 549905088