### PR TITLE
tvos: Add hardware AV1 capability check

### DIFF
--- a/starboard/tvos/shared/media/playback_capabilities.h
+++ b/starboard/tvos/shared/media/playback_capabilities.h
@@ -26,6 +26,8 @@ class PlaybackCapabilities {
   static void InitializeInBackground();
   // Returns true if the device has hardware vp9 decoder.
   static bool IsHwVp9Supported();
+  // Returns true if the device has hardware av1 decoder.
+  static bool IsHwAv1Supported();
   // Returns true if the device is Apple TV HD.
   static bool IsAppleTVHD();
   // Returns true if the device is Apple TV 4K.

--- a/starboard/tvos/shared/media/playback_capabilities.mm
+++ b/starboard/tvos/shared/media/playback_capabilities.mm
@@ -99,6 +99,8 @@ class PlaybackCapabilitiesImpl {
   PlaybackCapabilitiesImpl()
       : is_hw_vp9_supported_(
             VTIsHardwareDecodeSupported(kCMVideoCodecType_VP9)),
+        is_hw_av1_supported_(
+            VTIsHardwareDecodeSupported(kCMVideoCodecType_AV1)),
         is_apple_tv_hd_(IsAppleTVHDPriv()),
         is_apple_tv_4k_(IsAppleTV4KPriv()) {
     ObserverRegistry::RegisterObserver(&observer_);
@@ -137,6 +139,8 @@ class PlaybackCapabilitiesImpl {
   }
 
   bool IsHwVp9Supported() const { return is_hw_vp9_supported_; }
+
+  bool IsHwAv1Supported() const { return is_hw_av1_supported_; }
 
   bool IsAppleTVHD() const { return is_apple_tv_hd_; }
 
@@ -215,6 +219,7 @@ class PlaybackCapabilitiesImpl {
   }
 
   const bool is_hw_vp9_supported_;
+  const bool is_hw_av1_supported_;
   const bool is_apple_tv_hd_;
   const bool is_apple_tv_4k_;
 
@@ -241,6 +246,11 @@ void PlaybackCapabilities::InitializeInBackground() {
 // static
 bool PlaybackCapabilities::IsHwVp9Supported() {
   return GetInstance()->IsHwVp9Supported();
+}
+
+// static
+bool PlaybackCapabilities::IsHwAv1Supported() {
+  return GetInstance()->IsHwAv1Supported();
 }
 
 // static

--- a/starboard/tvos/shared/media_is_video_supported.mm
+++ b/starboard/tvos/shared/media_is_video_supported.mm
@@ -38,10 +38,6 @@ bool MediaIsVideoSupported(SbMediaVideoCodec video_codec,
                            int64_t bitrate,
                            int fps,
                            bool decode_to_texture_required) {
-  if (video_codec == kSbMediaVideoCodecAv1) {
-    return false;
-  }
-
   @autoreleasepool {
     if (bitrate > kSbMediaMaxVideoBitrateInBitsPerSecond) {
       return false;
@@ -66,20 +62,21 @@ bool MediaIsVideoSupported(SbMediaVideoCodec video_codec,
     if (video_codec == kSbMediaVideoCodecH264) {
       return !is_hdr && frame_height <= 1080 && frame_width <= 1920;
     }
-    if (video_codec == kSbMediaVideoCodecVp9) {
-#if defined(COBALT_INTERNAL_BUILD)
-      if (is_hdr) {
-        if (transfer_id == kSbMediaTransferIdSmpteSt2084 ||
-            transfer_id == kSbMediaTransferIdAribStdB67) {
-          NSInteger available_hdr_modes = AVPlayer.availableHDRModes;
-          if (!(available_hdr_modes & AVPlayerHDRModeHDR10)) {
-            return false;
-          }
-        } else {
+
+    if (is_hdr) {
+      if (transfer_id == kSbMediaTransferIdSmpteSt2084 ||
+          transfer_id == kSbMediaTransferIdAribStdB67) {
+        NSInteger available_hdr_modes = AVPlayer.availableHDRModes;
+        if (!(available_hdr_modes & AVPlayerHDRModeHDR10)) {
           return false;
         }
+      } else {
+        return false;
       }
+    }
 
+    if (video_codec == kSbMediaVideoCodecVp9) {
+#if defined(COBALT_INTERNAL_BUILD)
       if (PlaybackCapabilities::IsHwVp9Supported()) {
         return frame_height <= 2160 && frame_width <= 3840;
       }
@@ -127,6 +124,15 @@ bool MediaIsVideoSupported(SbMediaVideoCodec video_codec,
 #else
       SB_LOG(INFO) << "Non-internal build, accepting all VP9";
       return true;
+#endif  // defined(COBALT_INTERNAL_BUILD)
+    }
+
+    if (video_codec == kSbMediaVideoCodecAv1) {
+#if defined(COBALT_INTERNAL_BUILD)
+      if (PlaybackCapabilities::IsHwAv1Supported()) {
+        // Cap resolution to 4k for AV1 implementation verification.
+        return frame_height <= 2160 && frame_width <= 3840;
+      }
 #endif  // defined(COBALT_INTERNAL_BUILD)
     }
   }  // @autoreleasepool


### PR DESCRIPTION
Implement PlaybackCapabilities::IsHwAv1Supported to query hardware AV1
decoding support via VideoToolbox. Update MediaIsVideoSupported to
utilize this check instead of unconditionally returning false for AV1.

Bug: 538663615