### PR TITLE
aosp: Use the Android system fonts

### DIFF
--- a/.gn
+++ b/.gn
@@ -175,7 +175,7 @@ exec_script_allowlist += [
   "//starboard/tools/BUILD.gn",
   "//starboard/build/config/sabi/BUILD.gn",
   "//starboard/build/platform_path.gni",
-  "//starboard/content/fonts/BUILD.gn",
+  "//starboard/content/fonts/variables.gni",
 ]
 
 # TODO(cobalt, b/377295011): figure out a better long-term solution here, or

--- a/cobalt/aosp/modular_apk.gni
+++ b/cobalt/aosp/modular_apk.gni
@@ -14,6 +14,7 @@
 
 import("//build/config/android/rules.gni")
 import("//cobalt/android/manifest.gni")
+import("//starboard/content/fonts/variables.gni")
 import("//starboard/content/ssl/certs.gni")
 
 template("modular_apk") {
@@ -31,18 +32,28 @@ template("modular_apk") {
     forward_variables_from(invoker, [ "testonly" ])
     disable_compression = true
 
-    renaming_sources = [
-      "$root_build_dir/app/${_name}/content/fonts/fonts.xml",
-      "$root_build_dir/app/${_name}/lib/${_lib_name}.lz4",
-    ]
-    renaming_destinations = [
-      "app/cobalt/content/fonts/fonts.xml",
-      "app/cobalt/lib/${_lib_name}.lz4",
-    ]
+    renaming_sources = [ "$root_build_dir/app/${_name}/lib/${_lib_name}.lz4" ]
+    renaming_destinations = [ "app/cobalt/lib/${_lib_name}.lz4" ]
+
+    # Cobalt Evergreen uses the empty font package.
+    renaming_sources +=
+        [ "$root_build_dir/app/${_name}/content/fonts/fonts.xml" ]
+    renaming_destinations += [ "app/cobalt/content/fonts/fonts.xml" ]
+
+    # The platform provides the fonts from cobalt_font_package.
+    renaming_sources += [ "$root_build_dir/fonts/fonts.xml" ]
+    renaming_destinations += [ "fonts/fonts.xml" ]
+    foreach(_font, font_files) {
+      _font_file = get_path_info(_font, "file")
+      renaming_sources += [ "$root_build_dir/fonts/$_font_file" ]
+      renaming_destinations += [ "fonts/$_font_file" ]
+    }
 
     deps = [
       ":copy_${_name}_empty_fonts($default_toolchain)",
       ":copy_${_name}_lib($default_toolchain)",
+      "//starboard/content/fonts:copy_fonts($default_toolchain)",
+      "//starboard/content/fonts:fonts_xml($default_toolchain)",
     ]
 
     foreach(_cert, network_certs) {

--- a/starboard/android/shared/asset_manager.cc
+++ b/starboard/android/shared/asset_manager.cc
@@ -34,44 +34,6 @@
 
 namespace starboard {
 
-namespace {
-
-// Returns the fallback for the given asset path, or an empty string if none.
-// NOTE: While Cobalt now provides a mechanism for loading system fonts through
-//       SbSystemGetPath(), using the fallback logic within SbFileOpen() is
-//       still preferred for Android's fonts. The reason for this is that the
-//       Android OS actually allows fonts to be loaded from two locations: one
-//       that it provides; and one that the devices running its OS, which it
-//       calls vendors, can provide. Rather than including the full Android font
-//       package, vendors have the option of using a smaller Android font
-//       package and supplementing it with their own fonts.
-//
-//       If Android were to use SbSystemGetPath() for its fonts, vendors would
-//       have no way of providing those supplemental fonts to Cobalt, which
-//       could result in a limited selection of fonts being available. By
-//       treating Android's fonts as Cobalt's fonts, Cobalt can still offer a
-//       straightforward mechanism for including vendor fonts via
-//       SbSystemGetPath().
-std::string FallbackPath(const std::string& path) {
-  // We don't package most font files in Cobalt content and fallback to the
-  // system font file of the same name.
-  const std::string fonts_xml("fonts.xml");
-  const std::string system_fonts_dir("/system/fonts/");
-  const std::string cobalt_fonts_dir("/cobalt/assets/fonts/");
-
-  // Fonts fallback to the system fonts.
-  if (path.compare(0, cobalt_fonts_dir.length(), cobalt_fonts_dir) == 0) {
-    std::string file_name = path.substr(cobalt_fonts_dir.length());
-    // fonts.xml doesn't fallback.
-    if (file_name != fonts_xml) {
-      return system_fonts_dir + file_name;
-    }
-  }
-  return std::string();
-}
-
-}  // namespace
-
 // static
 SB_ONCE_INITIALIZE_FUNCTION(AssetManager, AssetManager::GetInstance)
 

--- a/starboard/android/shared/file_internal.cc
+++ b/starboard/android/shared/file_internal.cc
@@ -27,7 +27,6 @@
 
 namespace starboard {
 
-const char* g_app_assets_dir = "/cobalt/assets";
 // Representing the absolute path to the application-specific directory
 // where persistent files should be stored
 // (Context.getFilesDir().getAbsolutePath()). This path is used

--- a/starboard/android/shared/file_internal.cc
+++ b/starboard/android/shared/file_internal.cc
@@ -16,6 +16,9 @@
 
 #include <android/asset_manager_jni.h>
 #include <android/log.h>
+#include <string.h>
+
+#include <string>
 
 #include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
@@ -137,6 +140,40 @@ AAssetDir* OpenAndroidAssetDir(const char* path) {
     AAssetDir_rewind(asset_directory);
     return asset_directory;
   }
+}
+
+// NOTE: While Cobalt now provides a mechanism for loading system fonts through
+//       SbSystemGetPath(), using the fallback logic here is still preferred for
+//       Android's fonts. The reason for this is that the Android OS actually
+//       allows fonts to be loaded from two locations: one that it provides; and
+//       one that the devices running its OS, which it calls vendors, can
+//       provide. Rather than including the full Android font package, vendors
+//       have the option of using a smaller Android font package and
+//       supplementing it with their own fonts.
+//
+//       If Android were to use SbSystemGetPath() for its fonts, vendors would
+//       have no way of providing those supplemental fonts to Cobalt, which
+//       could result in a limited selection of fonts being available. By
+//       treating Android's fonts as Cobalt's fonts, Cobalt can still offer a
+//       straightforward mechanism for including vendor fonts via
+//       SbSystemGetPath().
+std::string FallbackPath(const std::string& path) {
+  // We don't package most font files in Cobalt content and fallback to the
+  // system font file of the same name.
+  const std::string fonts_xml("fonts.xml");
+  const std::string system_fonts_dir("/system/fonts/");
+  const std::string cobalt_fonts_dir =
+      std::string(g_app_assets_dir) + "/fonts/";
+
+  // Fonts fallback to the system fonts.
+  if (path.compare(0, cobalt_fonts_dir.length(), cobalt_fonts_dir) == 0) {
+    std::string file_name = path.substr(cobalt_fonts_dir.length());
+    // fonts.xml doesn't fallback.
+    if (file_name != fonts_xml) {
+      return system_fonts_dir + file_name;
+    }
+  }
+  return std::string();
 }
 
 }  // namespace starboard

--- a/starboard/android/shared/file_internal.h
+++ b/starboard/android/shared/file_internal.h
@@ -55,6 +55,9 @@ bool IsAndroidAssetPath(const char* path);
 AAsset* OpenAndroidAsset(const char* path);
 AAssetDir* OpenAndroidAssetDir(const char* path);
 
+// Returns the fallback for the given asset path, or an empty string if none.
+std::string FallbackPath(const std::string& path);
+
 }  // namespace starboard
 
 #endif  // STARBOARD_ANDROID_SHARED_FILE_INTERNAL_H_

--- a/starboard/android/shared/file_internal.h
+++ b/starboard/android/shared/file_internal.h
@@ -39,7 +39,7 @@ struct SbFilePrivate {
 
 namespace starboard {
 
-extern const char* g_app_assets_dir;
+inline constexpr char g_app_assets_dir[] = "/cobalt/assets";
 extern const char* g_app_files_dir;
 extern const char* g_app_cache_dir;
 extern const char* g_app_lib_dir;

--- a/starboard/android/shared/posix_emu/stat.cc
+++ b/starboard/android/shared/posix_emu/stat.cc
@@ -19,8 +19,11 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <string>
+
 #include "starboard/android/shared/file_internal.h"
 
+using starboard::FallbackPath;
 using starboard::IsAndroidAssetPath;
 using starboard::OpenAndroidAsset;
 using starboard::OpenAndroidAssetDir;
@@ -83,6 +86,11 @@ int __wrap_fstatat(int dirfd, const char* path, struct stat* info, int flags) {
     info->st_size = 0;
     AAssetDir_close(asset_dir);
     return 0;
+  }
+
+  std::string fallback_path = FallbackPath(path);
+  if (!fallback_path.empty()) {
+    return __real_fstatat(dirfd, fallback_path.c_str(), info, flags);
   }
 
   errno = ENOENT;

--- a/starboard/android/shared/system_get_path.cc
+++ b/starboard/android/shared/system_get_path.cc
@@ -78,7 +78,7 @@ bool SbSystemGetPath(SbSystemPathId path_id, char* out_path, int path_size) {
     case kSbSystemPathFontConfigurationDirectory:
     case kSbSystemPathFontDirectory:
 #if BUILDFLAG(IS_STARBOARD)
-      if (starboard::strlcpy(path, GetContentPath(), kPathSize) >= kPathSize) {
+      if (starboard::strlcpy(path, g_app_assets_dir, kPathSize) >= kPathSize) {
         return false;
       }
       if (starboard::strlcat(path, "/fonts", kPathSize) >= kPathSize) {

--- a/starboard/aosp/arm/platform_configuration/configuration.gni
+++ b/starboard/aosp/arm/platform_configuration/configuration.gni
@@ -19,3 +19,5 @@ if (current_toolchain == default_toolchain) {
   import("//starboard/android/arm/platform_configuration/configuration.gni")
   sb_evergreen_compatible_use_libunwind = true
 }
+
+cobalt_font_package = "android_system"

--- a/starboard/content/fonts/BUILD.gn
+++ b/starboard/content/fonts/BUILD.gn
@@ -36,23 +36,7 @@ if (current_toolchain == default_toolchain) {
     }
 
     copy("copy_fonts") {
-      if (copy_font_files) {
-        fonts =
-            exec_script("scripts/filter_fonts.py",
-                        [
-                              "-i",
-                              rebase_path("$source_font_config_dir/fonts.xml",
-                                          root_build_dir),
-                              "-f",
-                              source_font_files_dir,
-                            ] + package_categories,
-                        "trim list lines",
-                        [ "$source_font_config_dir/fonts.xml" ])
-      } else {
-        # Copy at least the fallback Roboto Subsetted font.
-        fonts = [ "$source_font_files_dir/Roboto-Regular-Subsetted.woff2" ]
-      }
-      sources = fonts
+      sources = font_files
       outputs =
           [ "$sb_static_contents_output_data_dir/fonts/{{source_file_part}}" ]
     }

--- a/starboard/content/fonts/variables.gni
+++ b/starboard/content/fonts/variables.gni
@@ -75,7 +75,7 @@ if (cobalt_font_package == "standard") {
   }
 } else if (cobalt_font_package == "android_system") {
   # fonts.xml contains a superset of what we expect to find on Android
-  # devices. The Android SbFile implementation falls back to system font
+  # devices. The Android posix emulation layer falls back to the system font
   # files for those not in cobalt content.
   declare_args() {
     source_font_config_dir = "config/android"

--- a/starboard/content/fonts/variables.gni
+++ b/starboard/content/fonts/variables.gni
@@ -142,3 +142,22 @@ package_categories = [
   "fallback-emoji=${package_fallback_emoji}",
   "fallback-symbols=${package_fallback_symbols}",
 ]
+
+if (cobalt_font_package == "empty") {
+  font_files = []
+} else if (copy_font_files) {
+  font_files =
+      exec_script("scripts/filter_fonts.py",
+                  [
+                        "-i",
+                        rebase_path("$source_font_config_dir/fonts.xml",
+                                    root_build_dir),
+                        "-f",
+                        source_font_files_dir,
+                      ] + package_categories,
+                  "trim list lines",
+                  [ "$source_font_config_dir/fonts.xml" ])
+} else {
+  # Copy at least the fallback Roboto Subsetted font.
+  font_files = [ "$source_font_files_dir/Roboto-Regular-Subsetted.woff2" ]
+}

--- a/starboard/nplb/nplb_evergreen_compat_tests/fonts_test.cc
+++ b/starboard/nplb/nplb_evergreen_compat_tests/fonts_test.cc
@@ -26,10 +26,6 @@
 #error These tests apply only to EVERGREEN_COMPATIBLE platforms.
 #endif
 
-#if defined(ANDROID)
-#error These tests are not applicable to AOSP
-#endif
-
 namespace nplb {
 
 namespace {


### PR DESCRIPTION
Stop resolving the font directories from the Evergreen content path, added in https://github.com/youtube/cobalt/pull/11336, and implement the Evergreen font layout instead: the platform provides the fonts at kSbSystemPathContentDirectory/fonts/, while the system image content directory at kSbSystemPathContentDirectory/app/cobalt/content/fonts/ contains the "empty" font package.

Modify the system font directory to point to the platform fonts and set cobalt_font_package to "android_system".

Lastly, add font fallback path resolution for access() to the Android posix emulation layer, so that fonts are searched at /system/fonts when they aren't found at the system font directory.

This setup matches what Android at Cobalt 25 did.

Bug: 495203133