### PR TITLE
feat: Implement hang recovery storage for 3P

### DIFF
--- a/cobalt/browser/BUILD.gn
+++ b/cobalt/browser/BUILD.gn
@@ -238,6 +238,7 @@ if (is_starboard || is_androidtv) {
       ":global_features",
       "//base",
       "//cobalt/browser/h5vcc_native_stability:h5vcc_native_stability",
+      "//cobalt/build/configs:buildflags",
     ]
   }
 }

--- a/cobalt/browser/h5vcc_native_stability/native_stability_manager.cc
+++ b/cobalt/browser/h5vcc_native_stability/native_stability_manager.cc
@@ -110,6 +110,10 @@ std::unordered_set<std::string> ReadAckedUuidsFromDisk(
     return acked_uuids;
   }
 
+  if (file_content.empty()) {
+    return acked_uuids;
+  }
+
   std::optional<base::Value::List> parsed_list =
       base::JSONReader::ReadList(file_content);
   if (!parsed_list) {
@@ -185,6 +189,10 @@ std::unordered_map<std::string, HangAttributes> ReadHangAttributesFromDisk(
   if (!base::ReadFileToString(file_path, &file_content)) {
     LOG(WARNING) << "Failed to read hang attributes file: "
                  << file_path.value();
+    return hang_attributes;
+  }
+
+  if (file_content.empty()) {
     return hang_attributes;
   }
 

--- a/cobalt/browser/h5vcc_native_stability/native_stability_manager.cc
+++ b/cobalt/browser/h5vcc_native_stability/native_stability_manager.cc
@@ -17,6 +17,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -29,6 +30,7 @@
 #include "base/json/json_reader.h"
 #include "base/json/json_writer.h"
 #include "base/logging.h"
+#include "base/synchronization/lock.h"
 #include "base/task/bind_post_task.h"
 #include "base/task/thread_pool.h"
 #include "base/uuid.h"
@@ -42,13 +44,41 @@ namespace h5vcc_native_stability {
 
 namespace {
 
+// Schema for |acked_event_uuids.json|:
+// A JSON list of UUID strings representing stability reports that have already
+// been acknowledged by the web application:
+// [
+//   "<uuid_1>",
+//   "<uuid_2>",
+//   ...
+// ]
+//
+// Schema for |hang_attributes.json|:
+// A JSON dictionary mapping hang UUIDs to dictionary objects containing
+// hang-specific attributes (such as whether the hang recovered):
+// {
+//   "<hang_uuid_1>": {
+//     "is_recovered": <bool>
+//   },
+//   "<hang_uuid_2>": {
+//     "is_recovered": <bool>
+//   },
+//   ...
+// }
+
 constexpr char kNativeStabilityDirName[] = "native_stability";
 constexpr char kAckedEventUuidsFileName[] = "acked_event_uuids.json";
+constexpr char kHangAttributesFileName[] = "hang_attributes.json";
+constexpr char kIsRecoveredKey[] = "is_recovered";
 
 // We want a number large enough that we avoid missing any reports in all but
 // the most extreme cases, but not so large that we waste significant memory
 // when allocating the buffer.
 constexpr int kMaxNumReports = 128;
+
+struct HangAttributes {
+  bool is_recovered = false;
+};
 
 // Safely extracts the UUID string from an SbNativeStabilityReport, clamping to
 // the canonical 36-character UUID length and guarding against missing null
@@ -100,6 +130,20 @@ std::unordered_set<std::string> ReadAckedUuidsFromDisk(
   return acked_uuids;
 }
 
+// We typically expect this directory to already exist but it may not, for
+// example if this code path has never executed on a particular device or the
+// system removed the directory.
+bool EnsureNativeStabilityDirectoryExists(const base::FilePath& dir_path) {
+  base::File::Error error = base::File::FILE_OK;
+  if (!base::CreateDirectoryAndGetError(dir_path, &error)) {
+    LOG(ERROR) << "Failed to create " << kNativeStabilityDirName
+               << " directory: " << dir_path.value()
+               << ", error: " << base::File::ErrorToString(error);
+    return false;
+  }
+  return true;
+}
+
 void WriteAckedUuidsToDisk(const base::FilePath& file_path,
                            const std::unordered_set<std::string>& acked_uuids) {
   if (file_path.empty()) {
@@ -107,15 +151,7 @@ void WriteAckedUuidsToDisk(const base::FilePath& file_path,
     return;
   }
 
-  // We typically expect this directory to already exist but it may not, for
-  // example if this code path has never executed on a particular device or the
-  // system removed the directory.
-  base::FilePath dir_path = file_path.DirName();
-  base::File::Error error = base::File::FILE_OK;
-  if (!base::CreateDirectoryAndGetError(dir_path, &error)) {
-    LOG(ERROR) << "Failed to create " << kNativeStabilityDirName
-               << " directory: " << dir_path.value()
-               << ", error: " << base::File::ErrorToString(error);
+  if (!EnsureNativeStabilityDirectoryExists(file_path.DirName())) {
     return;
   }
 
@@ -133,6 +169,79 @@ void WriteAckedUuidsToDisk(const base::FilePath& file_path,
 
   if (!base::ImportantFileWriter::WriteFileAtomically(file_path, *json)) {
     LOG(ERROR) << "Failed to write acked UUIDs atomically to: "
+               << file_path.value();
+    return;
+  }
+}
+
+std::unordered_map<std::string, HangAttributes> ReadHangAttributesFromDisk(
+    const base::FilePath& file_path) {
+  std::unordered_map<std::string, HangAttributes> hang_attributes;
+  if (file_path.empty() || !base::PathExists(file_path)) {
+    return hang_attributes;
+  }
+
+  std::string file_content;
+  if (!base::ReadFileToString(file_path, &file_content)) {
+    LOG(WARNING) << "Failed to read hang attributes file: "
+                 << file_path.value();
+    return hang_attributes;
+  }
+
+  std::optional<base::Value::Dict> parsed_dict =
+      base::JSONReader::ReadDict(file_content);
+  if (!parsed_dict) {
+    LOG(WARNING) << "Failed to parse hang attributes JSON dict in: "
+                 << file_path.value();
+    return hang_attributes;
+  }
+
+  for (const auto [uuid, value] : *parsed_dict) {
+    if (!value.is_dict()) {
+      LOG(WARNING) << "Skipping non-dict item for UUID in hang attributes: "
+                   << uuid;
+      continue;
+    }
+    const base::Value::Dict& entry_dict = value.GetDict();
+    std::optional<bool> is_recovered = entry_dict.FindBool(kIsRecoveredKey);
+    if (!is_recovered.has_value()) {
+      LOG(WARNING) << "Missing or invalid '" << kIsRecoveredKey
+                   << "' field for UUID: " << uuid;
+      continue;
+    }
+    hang_attributes[uuid] = HangAttributes{*is_recovered};
+  }
+
+  return hang_attributes;
+}
+
+void WriteHangAttributesToDisk(
+    const base::FilePath& file_path,
+    const std::unordered_map<std::string, HangAttributes>& hang_attributes) {
+  if (file_path.empty()) {
+    LOG(ERROR) << "Failed to write hang attributes: file path is empty.";
+    return;
+  }
+
+  if (!EnsureNativeStabilityDirectoryExists(file_path.DirName())) {
+    return;
+  }
+
+  base::Value::Dict uuid_to_attributes;
+  for (const auto& [uuid, attributes] : hang_attributes) {
+    base::Value::Dict entry_dict;
+    entry_dict.Set(kIsRecoveredKey, attributes.is_recovered);
+    uuid_to_attributes.Set(uuid, std::move(entry_dict));
+  }
+
+  std::optional<std::string> json = base::WriteJson(uuid_to_attributes);
+  if (!json) {
+    LOG(ERROR) << "Failed to serialize hang attributes dict to JSON.";
+    return;
+  }
+
+  if (!base::ImportantFileWriter::WriteFileAtomically(file_path, *json)) {
+    LOG(ERROR) << "Failed to write hang attributes atomically to: "
                << file_path.value();
     return;
   }
@@ -158,10 +267,28 @@ void NativeStabilityManager::SetAckedUuidsFilePathForTesting(
   acked_uuids_file_path_for_testing_ = std::move(file_path);
 }
 
+void NativeStabilityManager::SetHangAttributesFilePathForTesting(
+    base::FilePath file_path) {
+  hang_attributes_file_path_for_testing_ = std::move(file_path);
+}
+
 void NativeStabilityManager::ResetForTesting() {
+  base::AutoLock auto_lock(task_runner_lock_);
   task_runner_ = nullptr;
   get_extension_callback_for_testing_.Reset();
   acked_uuids_file_path_for_testing_.clear();
+  hang_attributes_file_path_for_testing_.clear();
+}
+
+scoped_refptr<base::SequencedTaskRunner>
+NativeStabilityManager::GetOrCreateTaskRunner() {
+  base::AutoLock auto_lock(task_runner_lock_);
+  if (!task_runner_) {
+    task_runner_ = base::ThreadPool::CreateSequencedTaskRunner(
+        {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
+         base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN});
+  }
+  return task_runner_;
 }
 
 base::FilePath NativeStabilityManager::GetAckedUuidsFilePath() {
@@ -180,6 +307,22 @@ base::FilePath NativeStabilityManager::GetAckedUuidsFilePath() {
   return base::FilePath(cache_dir.data())
       .Append(kNativeStabilityDirName)
       .Append(kAckedEventUuidsFileName);
+}
+
+base::FilePath NativeStabilityManager::GetHangAttributesFilePath() {
+  if (!hang_attributes_file_path_for_testing_.empty()) {
+    return hang_attributes_file_path_for_testing_;
+  }
+
+  std::vector<char> cache_dir(kSbFileMaxPath);
+  if (!SbSystemGetPath(kSbSystemPathCacheDirectory, cache_dir.data(),
+                       cache_dir.size())) {
+    LOG(ERROR) << "Failed to get kSbSystemPathCacheDirectory";
+    return base::FilePath();
+  }
+  return base::FilePath(cache_dir.data())
+      .Append(kNativeStabilityDirName)
+      .Append(kHangAttributesFileName);
 }
 
 const void* NativeStabilityManager::GetExtension(const char* name) {
@@ -206,15 +349,11 @@ void NativeStabilityManager::GetPendingReports(
     base::OnceCallback<void(std::vector<mojom::NativeStabilityReportPtr>)>
         callback) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  if (!task_runner_) {
-    task_runner_ = base::ThreadPool::CreateSequencedTaskRunner(
-        {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
-         base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN});
-  }
+  auto task_runner = GetOrCreateTaskRunner();
   auto* native_stability_extension =
       static_cast<const StarboardExtensionNativeStabilityApi*>(
           GetExtension(kStarboardExtensionNativeStabilityName));
-  task_runner_->PostTask(
+  task_runner->PostTask(
       FROM_HERE,
       base::BindOnce(&NativeStabilityManager::GetPendingReportsOnTaskRunner,
                      base::Unretained(this), native_stability_extension,
@@ -234,9 +373,13 @@ void NativeStabilityManager::GetPendingReportsOnTaskRunner(
     return;
   }
 
-  base::FilePath file_path = GetAckedUuidsFilePath();
+  base::FilePath acked_uuids_file_path = GetAckedUuidsFilePath();
   std::unordered_set<std::string> acked_uuids =
-      ReadAckedUuidsFromDisk(file_path);
+      ReadAckedUuidsFromDisk(acked_uuids_file_path);
+
+  base::FilePath hang_attributes_file_path = GetHangAttributesFilePath();
+  std::unordered_map<std::string, HangAttributes> hang_attributes =
+      ReadHangAttributesFromDisk(hang_attributes_file_path);
 
   std::vector<SbNativeStabilityReport> sb_reports(kMaxNumReports);
   int count = native_stability_extension->ReadReports(sb_reports.data(),
@@ -270,6 +413,14 @@ void NativeStabilityManager::GetPendingReportsOnTaskRunner(
     } else if (sb_report.report_type == kSbNativeStabilityReportHang) {
       auto hang_report = mojom::HangReport::New();
       hang_report->base = CreateBaseReportData(sb_report);
+      auto it = hang_attributes.find(uuid);
+      if (it != hang_attributes.end()) {
+        hang_report->is_recovered = it->second.is_recovered;
+      } else {
+        LOG(WARNING) << "Missing hang attributes for UUID: " << uuid
+                     << ". Defaulting is_recovered to false.";
+        hang_report->is_recovered = false;
+      }
       results.push_back(
           mojom::NativeStabilityReport::NewHangReport(std::move(hang_report)));
     } else {
@@ -285,12 +436,8 @@ void NativeStabilityManager::AcknowledgeReports(
     std::vector<std::string> native_stability_event_uuids,
     base::OnceClosure callback) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  if (!task_runner_) {
-    task_runner_ = base::ThreadPool::CreateSequencedTaskRunner(
-        {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
-         base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN});
-  }
-  task_runner_->PostTask(
+  auto task_runner = GetOrCreateTaskRunner();
+  task_runner->PostTask(
       FROM_HERE,
       base::BindOnce(&NativeStabilityManager::AcknowledgeReportsOnTaskRunner,
                      base::Unretained(this),
@@ -322,45 +469,82 @@ void NativeStabilityManager::AcknowledgeReportsOnTaskRunner(
 }
 
 void NativeStabilityManager::RecordHangStarted(const std::string& hang_uuid) {
-  // TODO(b/528362453): Implement persistent storage layer.
-  LOG(INFO) << "Mock NativeStabilityManager::RecordHangStarted for UUID: "
-            << hang_uuid;
+  if (hang_uuid.empty()) {
+    return;
+  }
+  auto task_runner = GetOrCreateTaskRunner();
+  task_runner->PostTask(
+      FROM_HERE,
+      base::BindOnce(&NativeStabilityManager::RecordHangStartedOnTaskRunner,
+                     base::Unretained(this), hang_uuid));
+}
+
+void NativeStabilityManager::RecordHangStartedOnTaskRunner(
+    std::string hang_uuid) {
+  base::FilePath file_path = GetHangAttributesFilePath();
+  std::unordered_map<std::string, HangAttributes> hang_attributes =
+      ReadHangAttributesFromDisk(file_path);
+
+  if (hang_attributes.contains(hang_uuid)) {
+    LOG(WARNING) << "Hang UUID " << hang_uuid
+                 << " is unexpectedly already recorded.";
+    return;
+  }
+
+  hang_attributes[hang_uuid] = HangAttributes{/*is_recovered=*/false};
+  WriteHangAttributesToDisk(file_path, hang_attributes);
 }
 
 void NativeStabilityManager::RecordHangRecovered(const std::string& hang_uuid) {
-  // TODO(b/528362453): Implement persistent storage layer.
-  LOG(INFO) << "Mock NativeStabilityManager::RecordHangRecovered for UUID: "
-            << hang_uuid;
+  if (hang_uuid.empty()) {
+    return;
+  }
+  auto task_runner = GetOrCreateTaskRunner();
+  task_runner->PostTask(
+      FROM_HERE,
+      base::BindOnce(&NativeStabilityManager::RecordHangRecoveredOnTaskRunner,
+                     base::Unretained(this), hang_uuid));
 }
 
-void NativeStabilityManager::PruneStorage(base::OnceClosure callback) {
-  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  if (!task_runner_) {
-    task_runner_ = base::ThreadPool::CreateSequencedTaskRunner(
-        {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
-         base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN});
+void NativeStabilityManager::RecordHangRecoveredOnTaskRunner(
+    std::string hang_uuid) {
+  base::FilePath file_path = GetHangAttributesFilePath();
+  std::unordered_map<std::string, HangAttributes> hang_attributes =
+      ReadHangAttributesFromDisk(file_path);
+
+  auto it = hang_attributes.find(hang_uuid);
+  if (it == hang_attributes.end()) {
+    LOG(WARNING) << "Hang UUID " << hang_uuid
+                 << " was unexpectedly not found. The update is skipped.";
+    return;
   }
+
+  if (it->second.is_recovered) {
+    LOG(WARNING) << "Hang UUID " << hang_uuid
+                 << " is unexpectedly already recorded as recovered.";
+    return;
+  }
+
+  it->second.is_recovered = true;
+  WriteHangAttributesToDisk(file_path, hang_attributes);
+}
+
+void NativeStabilityManager::PruneStorage() {
+  auto task_runner = GetOrCreateTaskRunner();
   auto* native_stability_extension =
       static_cast<const StarboardExtensionNativeStabilityApi*>(
           GetExtension(kStarboardExtensionNativeStabilityName));
-  task_runner_->PostTask(
+  task_runner->PostTask(
       FROM_HERE,
-      base::BindOnce(
-          &NativeStabilityManager::PruneStorageOnTaskRunner,
-          base::Unretained(this), native_stability_extension,
-          callback ? base::BindPostTaskToCurrentDefault(std::move(callback))
-                   : base::OnceClosure()));
+      base::BindOnce(&NativeStabilityManager::PruneStorageOnTaskRunner,
+                     base::Unretained(this), native_stability_extension));
 }
 
 void NativeStabilityManager::PruneStorageOnTaskRunner(
-    const StarboardExtensionNativeStabilityApi* native_stability_extension,
-    base::OnceClosure callback) {
+    const StarboardExtensionNativeStabilityApi* native_stability_extension) {
   if (!native_stability_extension || native_stability_extension->version < 1 ||
       !native_stability_extension->ReadReports) {
     VLOG(1) << "NativeStability extension is not supported on this platform.";
-    if (callback) {
-      std::move(callback).Run();
-    }
     return;
   }
 
@@ -370,9 +554,6 @@ void NativeStabilityManager::PruneStorageOnTaskRunner(
   if (count < 0) {
     LOG(WARNING) << "NativeStability extension ReadReports returned error ("
                  << count << "). Aborting storage pruning.";
-    if (callback) {
-      std::move(callback).Run();
-    }
     return;
   }
   if (count > kMaxNumReports) {
@@ -391,23 +572,34 @@ void NativeStabilityManager::PruneStorageOnTaskRunner(
     }
   }
 
-  base::FilePath file_path = GetAckedUuidsFilePath();
+  base::FilePath acked_uuids_file_path = GetAckedUuidsFilePath();
   std::unordered_set<std::string> acked_uuids =
-      ReadAckedUuidsFromDisk(file_path);
+      ReadAckedUuidsFromDisk(acked_uuids_file_path);
 
-  size_t removed = std::erase_if(
+  size_t acked_event_uuids_removed = std::erase_if(
       acked_uuids, [&starboard_report_ids](const std::string& uuid) {
         return !starboard_report_ids.contains(uuid);
       });
 
-  if (removed > 0) {
-    VLOG(1) << "Removed " << removed
-            << " obsolete native stability report UUID(s) from disk.";
-    WriteAckedUuidsToDisk(file_path, acked_uuids);
+  if (acked_event_uuids_removed > 0) {
+    VLOG(1) << "Removed " << acked_event_uuids_removed
+            << " obsolete acknowledged report UUID(s) from disk.";
+    WriteAckedUuidsToDisk(acked_uuids_file_path, acked_uuids);
   }
 
-  if (callback) {
-    std::move(callback).Run();
+  base::FilePath hang_attributes_file_path = GetHangAttributesFilePath();
+  std::unordered_map<std::string, HangAttributes> hang_attributes =
+      ReadHangAttributesFromDisk(hang_attributes_file_path);
+
+  size_t hang_attributes_records_removed =
+      std::erase_if(hang_attributes, [&starboard_report_ids](const auto& item) {
+        return !starboard_report_ids.contains(item.first);
+      });
+
+  if (hang_attributes_records_removed > 0) {
+    VLOG(1) << "Removed " << hang_attributes_records_removed
+            << " obsolete hang attributes report UUID(s) from disk.";
+    WriteHangAttributesToDisk(hang_attributes_file_path, hang_attributes);
   }
 }
 

--- a/cobalt/browser/h5vcc_native_stability/native_stability_manager.h
+++ b/cobalt/browser/h5vcc_native_stability/native_stability_manager.h
@@ -15,12 +15,15 @@
 #ifndef COBALT_BROWSER_H5VCC_NATIVE_STABILITY_NATIVE_STABILITY_MANAGER_H_
 #define COBALT_BROWSER_H5VCC_NATIVE_STABILITY_NATIVE_STABILITY_MANAGER_H_
 
+#include <string>
 #include <vector>
 
+#include "base/files/file_path.h"
 #include "base/functional/callback.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/no_destructor.h"
 #include "base/sequence_checker.h"
+#include "base/synchronization/lock.h"
 #include "base/task/sequenced_task_runner.h"
 #include "cobalt/browser/h5vcc_native_stability/public/mojom/h5vcc_native_stability.mojom.h"
 #include "starboard/extension/native_stability.h"
@@ -33,10 +36,16 @@ namespace h5vcc_native_stability {
 // lifetime is scoped to the application.
 //
 // Threading Model:
-// Calls must originate on the UI sequence. Offloads blocking disk I/O to a
-// background SequencedTaskRunner and posts response callbacks back to the UI
-// sequence. Using a SequencedTaskRunner guarantees that disk operations execute
-// sequentially, preventing concurrent reads and writes.
+// - Calls from Mojo (GetPendingReports, AcknowledgeReports) must originate on
+//   the UI sequence, and their response callbacks are posted back to the UI
+//   sequence.
+// - All other public methods (GetInstance, ArmCrashUuidAnnotation,
+//   RecordHangStarted, RecordHangRecovered, PruneStorage) are thread-safe and
+//   may be called from any thread.
+//
+// Blocking disk I/O is offloaded to a background SequencedTaskRunner. Using a
+// SequencedTaskRunner guarantees that disk operations execute sequentially,
+// preventing concurrent reads and writes.
 class NativeStabilityManager {
  public:
   static NativeStabilityManager* GetInstance();
@@ -49,7 +58,15 @@ class NativeStabilityManager {
   // with it.
   void ArmCrashUuidAnnotation();
 
+  // Asynchronously records that a hang with the given UUID has started,
+  // persisting an unrecovered status for the hang to disk. Expected to be
+  // called exactly once for a given hang, before any call to
+  // RecordHangRecovered.
   void RecordHangStarted(const std::string& hang_uuid);
+
+  // Asynchronously updates the status of a hang with the given UUID to
+  // recovered on disk. Expected to be called at most once for a given hang,
+  // sometime after a call to RecordHangStarted.
   void RecordHangRecovered(const std::string& hang_uuid);
 
   // Asynchronously reads and summarizes stability reports stored on disk that
@@ -81,18 +98,16 @@ class NativeStabilityManager {
   void AcknowledgeReports(std::vector<std::string> native_stability_event_uuids,
                           base::OnceClosure callback);
 
-  // Asynchronously removes acknowledged report UUIDs from disk if their
-  // corresponding stability reports are no longer stored on disk.
+  // Asynchronously removes acknowledged report UUIDs and hang attributes from
+  // disk if their corresponding stability reports are no longer stored on disk.
   //
   // Note that stability report storage is managed by the platform's crash
   // reporting system, which is expected to implement its own pruning strategy.
   // We prune by reflecting that system's state.
   //
-  // As with GetPendingReports(), disk I/O is offloaded to a background
-  // ThreadPool task runner and |callback| is posted back to the UI sequence.
-  // The |callback| parameter is optional to accommodate fire-and-forget callers
-  // that do not require completion notification.
-  void PruneStorage(base::OnceClosure callback = base::OnceClosure());
+  // As with other disk operations, disk I/O is offloaded to a background
+  // ThreadPool task runner.
+  void PruneStorage();
 
   using GetExtensionCallback =
       base::RepeatingCallback<const void*(const char*)>;
@@ -103,6 +118,9 @@ class NativeStabilityManager {
   // Injects a custom path for acked_event_uuids.json for testing.
   void SetAckedUuidsFilePathForTesting(base::FilePath file_path);
 
+  // Injects a custom path for hang_attributes.json for testing.
+  void SetHangAttributesFilePathForTesting(base::FilePath file_path);
+
   // Resets internal state for unit testing between test cases.
   void ResetForTesting();
 
@@ -111,6 +129,13 @@ class NativeStabilityManager {
 
   NativeStabilityManager();
   ~NativeStabilityManager() = default;
+
+  // Thread-safe helper that lazily creates and returns the background
+  // SequencedTaskRunner used for sequential disk I/O.
+  scoped_refptr<base::SequencedTaskRunner> GetOrCreateTaskRunner();
+
+  void RecordHangStartedOnTaskRunner(std::string hang_uuid);
+  void RecordHangRecoveredOnTaskRunner(std::string hang_uuid);
 
   void GetPendingReportsOnTaskRunner(
       const StarboardExtensionNativeStabilityApi* native_stability_extension,
@@ -122,17 +147,20 @@ class NativeStabilityManager {
       base::OnceClosure callback);
 
   void PruneStorageOnTaskRunner(
-      const StarboardExtensionNativeStabilityApi* native_stability_extension,
-      base::OnceClosure callback);
+      const StarboardExtensionNativeStabilityApi* native_stability_extension);
 
   base::FilePath GetAckedUuidsFilePath();
+  base::FilePath GetHangAttributesFilePath();
 
   const void* GetExtension(const char* name);
 
-  scoped_refptr<base::SequencedTaskRunner> task_runner_;
+  base::Lock task_runner_lock_;
+  scoped_refptr<base::SequencedTaskRunner> task_runner_
+      GUARDED_BY(task_runner_lock_);
 
   GetExtensionCallback get_extension_callback_for_testing_;
   base::FilePath acked_uuids_file_path_for_testing_;
+  base::FilePath hang_attributes_file_path_for_testing_;
 
   SEQUENCE_CHECKER(sequence_checker_);
 };

--- a/cobalt/browser/h5vcc_native_stability/native_stability_manager_unittest.cc
+++ b/cobalt/browser/h5vcc_native_stability/native_stability_manager_unittest.cc
@@ -80,17 +80,44 @@ std::unordered_set<std::string> ReadAckedUuidsFromDiskForTesting(
   return acked_uuids;
 }
 
+std::unordered_map<std::string, bool> ReadHangAttributesFromDiskForTesting(
+    const base::FilePath& file_path) {
+  std::unordered_map<std::string, bool> hang_attributes;
+  std::string file_content;
+  if (!base::ReadFileToString(file_path, &file_content)) {
+    return hang_attributes;
+  }
+  std::optional<base::Value::Dict> parsed_dict =
+      base::JSONReader::ReadDict(file_content);
+  if (!parsed_dict) {
+    return hang_attributes;
+  }
+  for (const auto [uuid, value] : *parsed_dict) {
+    if (value.is_dict()) {
+      std::optional<bool> is_recovered =
+          value.GetDict().FindBool("is_recovered");
+      if (is_recovered.has_value()) {
+        hang_attributes[uuid] = *is_recovered;
+      }
+    }
+  }
+  return hang_attributes;
+}
+
 }  // namespace
 
 class NativeStabilityManagerTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    // Overriding the acked UUIDs file path with a unique temporary directory
-    // for every test 1) isolates test storage and 2) ensures actual platform
-    // directories (e.g. kSbSystemPathCacheDirectory) are not used.
+    // Overriding the acked UUIDs and hang attributes file paths with a unique
+    // temporary directory for every test 1) isolates test storage and 2)
+    // ensures actual platform directories (e.g. kSbSystemPathCacheDirectory)
+    // are not used.
     ASSERT_TRUE(temp_dir_.CreateUniqueTempDir());
     NativeStabilityManager::GetInstance()->SetAckedUuidsFilePathForTesting(
         temp_dir_.GetPath().Append("acked_event_uuids.json"));
+    NativeStabilityManager::GetInstance()->SetHangAttributesFilePathForTesting(
+        temp_dir_.GetPath().Append("hang_attributes.json"));
   }
 
   void TearDown() override {
@@ -475,11 +502,8 @@ TEST_F(NativeStabilityManagerTest, PruneStorageRemovesObsoleteAckedUuids) {
   SetupStubExtension(manager, {report1});
 
   // Prune storage against the updated crash storage state.
-  {
-    base::RunLoop run_loop;
-    manager->PruneStorage(run_loop.QuitClosure());
-    run_loop.Run();
-  }
+  manager->PruneStorage();
+  task_environment_.RunUntilIdle();
 
   // Verify directly on disk that obsolete UUIDs ("uuid-2", "uuid-3") were
   // removed, leaving only "uuid-1".
@@ -507,11 +531,8 @@ TEST_F(NativeStabilityManagerTest,
   manager->SetGetExtensionForTesting(base::BindRepeating(
       [](const char* name) -> const void* { return nullptr; }));
 
-  {
-    base::RunLoop run_loop;
-    manager->PruneStorage(run_loop.QuitClosure());
-    run_loop.Run();
-  }
+  manager->PruneStorage();
+  task_environment_.RunUntilIdle();
 
   // Verify acked_event_uuids.json still contains exactly uuid-1.
   EXPECT_EQ(ReadAckedUuidsFromDiskForTesting(file_path),
@@ -546,11 +567,8 @@ TEST_F(NativeStabilityManagerTest,
   EXPECT_EQ(ReadAckedUuidsFromDiskForTesting(file_path),
             (std::unordered_set<std::string>{"uuid-1"}));
 
-  {
-    base::RunLoop run_loop;
-    manager->PruneStorage(run_loop.QuitClosure());
-    run_loop.Run();
-  }
+  manager->PruneStorage();
+  task_environment_.RunUntilIdle();
 
   // Verify acked_event_uuids.json still contains exactly uuid-1.
   EXPECT_EQ(ReadAckedUuidsFromDiskForTesting(file_path),
@@ -589,11 +607,8 @@ TEST_F(NativeStabilityManagerTest,
         return nullptr;
       }));
 
-  {
-    base::RunLoop run_loop;
-    manager->PruneStorage(run_loop.QuitClosure());
-    run_loop.Run();
-  }
+  manager->PruneStorage();
+  task_environment_.RunUntilIdle();
 
   // Verify acked_event_uuids.json still contains exactly uuid-1.
   EXPECT_EQ(ReadAckedUuidsFromDiskForTesting(file_path),
@@ -615,11 +630,8 @@ TEST_F(NativeStabilityManagerTest,
   ASSERT_FALSE(base::PathExists(file_path));
 
   // Prune storage when acked_event_uuids.json does not exist.
-  {
-    base::RunLoop run_loop;
-    manager->PruneStorage(run_loop.QuitClosure());
-    run_loop.Run();
-  }
+  manager->PruneStorage();
+  task_environment_.RunUntilIdle();
 
   // Verify file was not created on disk.
   EXPECT_FALSE(base::PathExists(file_path));
@@ -637,8 +649,10 @@ TEST_F(NativeStabilityManagerTest,
   SetupStubExtension(manager, {report});
 
   std::string clamped_uuid(sizeof(report.native_stability_event_uuid) - 1, 'a');
-  base::FilePath file_path =
+  base::FilePath acked_file_path =
       temp_dir_.GetPath().Append("acked_event_uuids.json");
+  base::FilePath hang_attributes_file_path =
+      temp_dir_.GetPath().Append("hang_attributes.json");
 
   {
     base::RunLoop run_loop;
@@ -646,20 +660,283 @@ TEST_F(NativeStabilityManagerTest,
     run_loop.Run();
   }
 
-  EXPECT_EQ(ReadAckedUuidsFromDiskForTesting(file_path),
-            (std::unordered_set<std::string>{clamped_uuid}));
+  manager->RecordHangStarted(clamped_uuid);
+  task_environment_.RunUntilIdle();
 
-  {
-    base::RunLoop run_loop;
-    manager->PruneStorage(run_loop.QuitClosure());
-    run_loop.Run();
-  }
-
-  // Verify acked_event_uuids.json still contains the 36-character UUID. This
-  // proves that PruneStorage() clamped the UUID it found in the starboard
-  // stability report persisted on disk.
-  EXPECT_EQ(ReadAckedUuidsFromDiskForTesting(file_path),
+  EXPECT_EQ(ReadAckedUuidsFromDiskForTesting(acked_file_path),
             (std::unordered_set<std::string>{clamped_uuid}));
+  EXPECT_EQ(ReadHangAttributesFromDiskForTesting(hang_attributes_file_path),
+            (std::unordered_map<std::string, bool>{{clamped_uuid, false}}));
+
+  manager->PruneStorage();
+  task_environment_.RunUntilIdle();
+
+  // Verify acked_event_uuids.json and hang_attributes.json still contain the
+  // 36-character UUID. This proves that PruneStorage() clamped the UUID it
+  // found in the starboard stability report persisted on disk.
+  EXPECT_EQ(ReadAckedUuidsFromDiskForTesting(acked_file_path),
+            (std::unordered_set<std::string>{clamped_uuid}));
+  EXPECT_EQ(ReadHangAttributesFromDiskForTesting(hang_attributes_file_path),
+            (std::unordered_map<std::string, bool>{{clamped_uuid, false}}));
+}
+
+TEST_F(NativeStabilityManagerTest,
+       RecordedStartedHangIsUnrecoveredInGetPendingReports) {
+  auto* manager = NativeStabilityManager::GetInstance();
+
+  manager->RecordHangStarted("hang-uuid-1");
+  task_environment_.RunUntilIdle();
+
+  SbNativeStabilityReport report = {};
+  report.report_type = kSbNativeStabilityReportHang;
+  std::strncpy(report.native_stability_event_uuid, "hang-uuid-1",
+               sizeof(report.native_stability_event_uuid) - 1);
+  SetupStubExtension(manager, {report});
+
+  base::RunLoop run_loop;
+  manager->GetPendingReports(base::BindOnce(
+      [](base::OnceClosure quit_closure,
+         std::vector<mojom::NativeStabilityReportPtr> reports) {
+        ASSERT_EQ(reports.size(), 1u);
+        ASSERT_TRUE(reports[0]->is_hang_report());
+        EXPECT_EQ(
+            reports[0]->get_hang_report()->base->native_stability_event_uuid,
+            "hang-uuid-1");
+        EXPECT_FALSE(reports[0]->get_hang_report()->is_recovered);
+        std::move(quit_closure).Run();
+      },
+      run_loop.QuitClosure()));
+  run_loop.Run();
+}
+
+TEST_F(NativeStabilityManagerTest,
+       RecordedStartedThenRecoveredHangIsRecoveredInGetPendingReports) {
+  auto* manager = NativeStabilityManager::GetInstance();
+
+  manager->RecordHangStarted("hang-uuid-1");
+  task_environment_.RunUntilIdle();
+  manager->RecordHangRecovered("hang-uuid-1");
+  task_environment_.RunUntilIdle();
+
+  SbNativeStabilityReport report = {};
+  report.report_type = kSbNativeStabilityReportHang;
+  std::strncpy(report.native_stability_event_uuid, "hang-uuid-1",
+               sizeof(report.native_stability_event_uuid) - 1);
+  SetupStubExtension(manager, {report});
+
+  base::RunLoop run_loop;
+  manager->GetPendingReports(base::BindOnce(
+      [](base::OnceClosure quit_closure,
+         std::vector<mojom::NativeStabilityReportPtr> reports) {
+        ASSERT_EQ(reports.size(), 1u);
+        ASSERT_TRUE(reports[0]->is_hang_report());
+        EXPECT_EQ(
+            reports[0]->get_hang_report()->base->native_stability_event_uuid,
+            "hang-uuid-1");
+        EXPECT_TRUE(reports[0]->get_hang_report()->is_recovered);
+        std::move(quit_closure).Run();
+      },
+      run_loop.QuitClosure()));
+  run_loop.Run();
+}
+
+TEST_F(NativeStabilityManagerTest,
+       PruneStorageRemovesObsoleteHangAttributesRecords) {
+  auto* manager = NativeStabilityManager::GetInstance();
+  base::FilePath file_path = temp_dir_.GetPath().Append("hang_attributes.json");
+
+  manager->RecordHangStarted("hang-uuid-1");
+  manager->RecordHangStarted("hang-uuid-2");
+  manager->RecordHangStarted("hang-uuid-3");
+  task_environment_.RunUntilIdle();
+
+  EXPECT_EQ(ReadHangAttributesFromDiskForTesting(file_path).size(), 3u);
+
+  // Configure extension to only return hang-uuid-1.
+  SbNativeStabilityReport report1 = {};
+  report1.report_type = kSbNativeStabilityReportHang;
+  std::strncpy(report1.native_stability_event_uuid, "hang-uuid-1",
+               sizeof(report1.native_stability_event_uuid) - 1);
+  SetupStubExtension(manager, {report1});
+
+  manager->PruneStorage();
+  task_environment_.RunUntilIdle();
+
+  EXPECT_EQ(ReadHangAttributesFromDiskForTesting(file_path),
+            (std::unordered_map<std::string, bool>{{"hang-uuid-1", false}}));
+}
+
+TEST_F(NativeStabilityManagerTest,
+       PruneStorageDoesNotRemoveHangAttributesWhenReportsStillPersisted) {
+  auto* manager = NativeStabilityManager::GetInstance();
+  SbNativeStabilityReport report1 = {};
+  report1.report_type = kSbNativeStabilityReportHang;
+  std::strncpy(report1.native_stability_event_uuid, "hang-uuid-1",
+               sizeof(report1.native_stability_event_uuid) - 1);
+
+  SbNativeStabilityReport report2 = {};
+  report2.report_type = kSbNativeStabilityReportHang;
+  std::strncpy(report2.native_stability_event_uuid, "hang-uuid-2",
+               sizeof(report2.native_stability_event_uuid) - 1);
+
+  SetupStubExtension(manager, {report1, report2});
+
+  base::FilePath file_path = temp_dir_.GetPath().Append("hang_attributes.json");
+
+  manager->RecordHangStarted("hang-uuid-1");
+  manager->RecordHangStarted("hang-uuid-2");
+  task_environment_.RunUntilIdle();
+
+  EXPECT_EQ(ReadHangAttributesFromDiskForTesting(file_path),
+            (std::unordered_map<std::string, bool>{{"hang-uuid-1", false},
+                                                   {"hang-uuid-2", false}}));
+
+  manager->PruneStorage();
+  task_environment_.RunUntilIdle();
+
+  EXPECT_EQ(ReadHangAttributesFromDiskForTesting(file_path),
+            (std::unordered_map<std::string, bool>{{"hang-uuid-1", false},
+                                                   {"hang-uuid-2", false}}));
+}
+
+TEST_F(NativeStabilityManagerTest,
+       NonRecordedHangIsUnrecoveredInGetPendingReports) {
+  auto* manager = NativeStabilityManager::GetInstance();
+
+  SbNativeStabilityReport report = {};
+  report.report_type = kSbNativeStabilityReportHang;
+  std::strncpy(report.native_stability_event_uuid, "hang-uuid-1",
+               sizeof(report.native_stability_event_uuid) - 1);
+  SetupStubExtension(manager, {report});
+
+  base::RunLoop run_loop;
+  manager->GetPendingReports(base::BindOnce(
+      [](base::OnceClosure quit_closure,
+         std::vector<mojom::NativeStabilityReportPtr> reports) {
+        ASSERT_EQ(reports.size(), 1u);
+        ASSERT_TRUE(reports[0]->is_hang_report());
+        EXPECT_EQ(
+            reports[0]->get_hang_report()->base->native_stability_event_uuid,
+            "hang-uuid-1");
+        EXPECT_FALSE(reports[0]->get_hang_report()->is_recovered);
+        std::move(quit_closure).Run();
+      },
+      run_loop.QuitClosure()));
+  run_loop.Run();
+}
+
+TEST_F(NativeStabilityManagerTest,
+       RecordedStartedHangWithRecoveredStatusIsRecoveredInGetPendingReports) {
+  auto* manager = NativeStabilityManager::GetInstance();
+
+  manager->RecordHangStarted("hang-uuid-1");
+  task_environment_.RunUntilIdle();
+  manager->RecordHangRecovered("hang-uuid-1");
+  task_environment_.RunUntilIdle();
+
+  // Subsequent RecordHangStarted on an already recovered hang should not
+  // overwrite the status to unrecovered.
+  manager->RecordHangStarted("hang-uuid-1");
+  task_environment_.RunUntilIdle();
+
+  SbNativeStabilityReport report = {};
+  report.report_type = kSbNativeStabilityReportHang;
+  std::strncpy(report.native_stability_event_uuid, "hang-uuid-1",
+               sizeof(report.native_stability_event_uuid) - 1);
+  SetupStubExtension(manager, {report});
+
+  base::RunLoop run_loop;
+  manager->GetPendingReports(base::BindOnce(
+      [](base::OnceClosure quit_closure,
+         std::vector<mojom::NativeStabilityReportPtr> reports) {
+        ASSERT_EQ(reports.size(), 1u);
+        ASSERT_TRUE(reports[0]->is_hang_report());
+        EXPECT_EQ(
+            reports[0]->get_hang_report()->base->native_stability_event_uuid,
+            "hang-uuid-1");
+        EXPECT_TRUE(reports[0]->get_hang_report()->is_recovered);
+        std::move(quit_closure).Run();
+      },
+      run_loop.QuitClosure()));
+  run_loop.Run();
+}
+
+TEST_F(NativeStabilityManagerTest,
+       GetPendingReportsReturnsUnrecoveredWhenHangAttributesFileCorrupted) {
+  auto* manager = NativeStabilityManager::GetInstance();
+  base::FilePath file_path = temp_dir_.GetPath().Append("hang_attributes.json");
+  ASSERT_TRUE(base::WriteFile(file_path, "not a valid json"));
+
+  SbNativeStabilityReport report1 = {};
+  report1.report_type = kSbNativeStabilityReportHang;
+  std::strncpy(report1.native_stability_event_uuid, "hang-uuid-1",
+               sizeof(report1.native_stability_event_uuid) - 1);
+  report1.event_time_s = 1000;
+
+  SetupStubExtension(manager, {report1});
+
+  base::RunLoop run_loop;
+  manager->GetPendingReports(base::BindOnce(
+      [](base::OnceClosure quit_closure,
+         std::vector<mojom::NativeStabilityReportPtr> reports) {
+        ASSERT_EQ(reports.size(), 1u);
+        ASSERT_TRUE(reports[0]->is_hang_report());
+        EXPECT_EQ(
+            reports[0]->get_hang_report()->base->native_stability_event_uuid,
+            "hang-uuid-1");
+        EXPECT_FALSE(reports[0]->get_hang_report()->is_recovered);
+        std::move(quit_closure).Run();
+      },
+      run_loop.QuitClosure()));
+  run_loop.Run();
+}
+
+TEST_F(NativeStabilityManagerTest,
+       RecordedRecoveredButNeverStartedHangIsUnrecoveredInGetPendingReports) {
+  auto* manager = NativeStabilityManager::GetInstance();
+
+  // RecordHangRecovered without prior start should be ignored.
+  manager->RecordHangRecovered("hang-uuid-1");
+  task_environment_.RunUntilIdle();
+
+  SbNativeStabilityReport report = {};
+  report.report_type = kSbNativeStabilityReportHang;
+  std::strncpy(report.native_stability_event_uuid, "hang-uuid-1",
+               sizeof(report.native_stability_event_uuid) - 1);
+  SetupStubExtension(manager, {report});
+
+  base::RunLoop run_loop;
+  manager->GetPendingReports(base::BindOnce(
+      [](base::OnceClosure quit_closure,
+         std::vector<mojom::NativeStabilityReportPtr> reports) {
+        ASSERT_EQ(reports.size(), 1u);
+        ASSERT_TRUE(reports[0]->is_hang_report());
+        EXPECT_EQ(
+            reports[0]->get_hang_report()->base->native_stability_event_uuid,
+            "hang-uuid-1");
+        EXPECT_FALSE(reports[0]->get_hang_report()->is_recovered);
+        std::move(quit_closure).Run();
+      },
+      run_loop.QuitClosure()));
+  run_loop.Run();
+}
+
+TEST_F(NativeStabilityManagerTest,
+       PruneStorageDoesNothingWhenHangAttributesFileDoesNotExist) {
+  auto* manager = NativeStabilityManager::GetInstance();
+  base::FilePath file_path = temp_dir_.GetPath().Append("hang_attributes.json");
+  ASSERT_FALSE(base::PathExists(file_path));
+
+  SbNativeStabilityReport report1 = {};
+  report1.report_type = kSbNativeStabilityReportHang;
+  std::strncpy(report1.native_stability_event_uuid, "hang-uuid-1",
+               sizeof(report1.native_stability_event_uuid) - 1);
+  SetupStubExtension(manager, {report1});
+
+  manager->PruneStorage();
+  task_environment_.RunUntilIdle();
+
+  EXPECT_FALSE(base::PathExists(file_path));
 }
 
 }  // namespace h5vcc_native_stability

--- a/cobalt/browser/h5vcc_native_stability/native_stability_manager_unittest.cc
+++ b/cobalt/browser/h5vcc_native_stability/native_stability_manager_unittest.cc
@@ -230,6 +230,71 @@ TEST_F(NativeStabilityManagerTest, GetPendingReportsParsesHangReport) {
 }
 
 TEST_F(NativeStabilityManagerTest,
+       GetPendingReportsParsesBothCrashAndHangReports) {
+  const std::string kCrashUuid = "crash-uuid-12345";
+  const int64_t kCrashTime = 1700000000;
+  const std::string kHangUuid = "hang-uuid-67890";
+  const int64_t kHangTime = 1700005000;
+
+  auto* manager = NativeStabilityManager::GetInstance();
+
+  manager->RecordHangStarted(kHangUuid);
+  manager->RecordHangRecovered(kHangUuid);
+  task_environment_.RunUntilIdle();
+
+  SbNativeStabilityReport crash_report = {};
+  crash_report.report_type = kSbNativeStabilityReportCrash;
+  std::strncpy(crash_report.native_stability_event_uuid, kCrashUuid.c_str(),
+               sizeof(crash_report.native_stability_event_uuid) - 1);
+  crash_report.event_time_s = kCrashTime;
+
+  SbNativeStabilityReport hang_report = {};
+  hang_report.report_type = kSbNativeStabilityReportHang;
+  std::strncpy(hang_report.native_stability_event_uuid, kHangUuid.c_str(),
+               sizeof(hang_report.native_stability_event_uuid) - 1);
+  hang_report.event_time_s = kHangTime;
+
+  SetupStubExtension(manager, {crash_report, hang_report});
+
+  base::RunLoop run_loop;
+  manager->GetPendingReports(base::BindOnce(
+      [](const std::string& crash_uuid, int64_t crash_time,
+         const std::string& hang_uuid, int64_t hang_time,
+         base::OnceClosure quit_closure,
+         std::vector<mojom::NativeStabilityReportPtr> reports) {
+        ASSERT_EQ(reports.size(), 2u);
+
+        // We avoid assuming any particular ordering of reports returned by
+        // GetPendingReports(), since the order isn't specified by the API.
+        const mojom::NativeCrashReport* crash = nullptr;
+        const mojom::HangReport* hang = nullptr;
+
+        for (const auto& report : reports) {
+          if (report->is_crash_report()) {
+            crash = report->get_crash_report().get();
+          } else if (report->is_hang_report()) {
+            hang = report->get_hang_report().get();
+          }
+        }
+
+        ASSERT_TRUE(crash);
+        ASSERT_TRUE(crash->base);
+        EXPECT_EQ(crash->base->native_stability_event_uuid, crash_uuid);
+        EXPECT_EQ(crash->base->event_time_sec, crash_time);
+
+        ASSERT_TRUE(hang);
+        ASSERT_TRUE(hang->base);
+        EXPECT_EQ(hang->base->native_stability_event_uuid, hang_uuid);
+        EXPECT_EQ(hang->base->event_time_sec, hang_time);
+        EXPECT_TRUE(hang->is_recovered);
+
+        std::move(quit_closure).Run();
+      },
+      kCrashUuid, kCrashTime, kHangUuid, kHangTime, run_loop.QuitClosure()));
+  run_loop.Run();
+}
+
+TEST_F(NativeStabilityManagerTest,
        GetPendingReportsClampsOutOfBoundsExtensionCount) {
   auto* manager = NativeStabilityManager::GetInstance();
 

--- a/cobalt/browser/h5vcc_native_stability/native_stability_manager_unittest.cc
+++ b/cobalt/browser/h5vcc_native_stability/native_stability_manager_unittest.cc
@@ -477,6 +477,33 @@ TEST_F(NativeStabilityManagerTest,
   run_loop.Run();
 }
 
+TEST_F(NativeStabilityManagerTest,
+       GetPendingReportsIgnoresEmptyAckedUuidsFile) {
+  auto* manager = NativeStabilityManager::GetInstance();
+  SbNativeStabilityReport report1 = {};
+  report1.report_type = kSbNativeStabilityReportCrash;
+  std::strncpy(report1.native_stability_event_uuid, "uuid-1",
+               sizeof(report1.native_stability_event_uuid) - 1);
+  SetupStubExtension(manager, {report1});
+
+  // Write an empty string (0 bytes) to the acked UUIDs file path.
+  base::FilePath file_path =
+      temp_dir_.GetPath().Append("acked_event_uuids.json");
+  ASSERT_TRUE(base::WriteFile(file_path, ""));
+
+  // Verify GetPendingReports handles an empty file gracefully and returns the
+  // pending report.
+  base::RunLoop run_loop;
+  manager->GetPendingReports(base::BindOnce(
+      [](base::OnceClosure quit_closure,
+         std::vector<mojom::NativeStabilityReportPtr> reports) {
+        EXPECT_EQ(reports.size(), 1u);
+        std::move(quit_closure).Run();
+      },
+      run_loop.QuitClosure()));
+  run_loop.Run();
+}
+
 TEST_F(NativeStabilityManagerTest, PruneStorageRemovesObsoleteAckedUuids) {
   auto* manager = NativeStabilityManager::GetInstance();
 
@@ -866,6 +893,36 @@ TEST_F(NativeStabilityManagerTest,
   auto* manager = NativeStabilityManager::GetInstance();
   base::FilePath file_path = temp_dir_.GetPath().Append("hang_attributes.json");
   ASSERT_TRUE(base::WriteFile(file_path, "not a valid json"));
+
+  SbNativeStabilityReport report1 = {};
+  report1.report_type = kSbNativeStabilityReportHang;
+  std::strncpy(report1.native_stability_event_uuid, "hang-uuid-1",
+               sizeof(report1.native_stability_event_uuid) - 1);
+  report1.event_time_s = 1000;
+
+  SetupStubExtension(manager, {report1});
+
+  base::RunLoop run_loop;
+  manager->GetPendingReports(base::BindOnce(
+      [](base::OnceClosure quit_closure,
+         std::vector<mojom::NativeStabilityReportPtr> reports) {
+        ASSERT_EQ(reports.size(), 1u);
+        ASSERT_TRUE(reports[0]->is_hang_report());
+        EXPECT_EQ(
+            reports[0]->get_hang_report()->base->native_stability_event_uuid,
+            "hang-uuid-1");
+        EXPECT_FALSE(reports[0]->get_hang_report()->is_recovered);
+        std::move(quit_closure).Run();
+      },
+      run_loop.QuitClosure()));
+  run_loop.Run();
+}
+
+TEST_F(NativeStabilityManagerTest,
+       GetPendingReportsReturnsUnrecoveredWhenHangAttributesFileEmpty) {
+  auto* manager = NativeStabilityManager::GetInstance();
+  base::FilePath file_path = temp_dir_.GetPath().Append("hang_attributes.json");
+  ASSERT_TRUE(base::WriteFile(file_path, ""));
 
   SbNativeStabilityReport report1 = {};
   report1.report_type = kSbNativeStabilityReportHang;

--- a/cobalt/browser/hang_watcher_delegate_impl.cc
+++ b/cobalt/browser/hang_watcher_delegate_impl.cc
@@ -25,6 +25,7 @@
 #include "cobalt/browser/features.h"
 #include "cobalt/browser/global_features.h"
 #include "cobalt/browser/h5vcc_native_stability/native_stability_manager.h"
+#include "cobalt/build/configs/buildflags.h"
 
 namespace cobalt {
 namespace browser {
@@ -176,18 +177,22 @@ std::optional<base::TimeDelta> CobaltHangWatcherDelegate::GetLongHangTimeout() {
 
 void CobaltHangWatcherDelegate::RecordHangStarted(
     const std::string& hang_uuid) {
+#if BUILDFLAG(USE_EVERGREEN)
   auto* nsm = h5vcc_native_stability::NativeStabilityManager::GetInstance();
   if (nsm) {
     nsm->RecordHangStarted(hang_uuid);
   }
+#endif
 }
 
 void CobaltHangWatcherDelegate::RecordHangRecovered(
     const std::string& hang_uuid) {
+#if BUILDFLAG(USE_EVERGREEN)
   auto* nsm = h5vcc_native_stability::NativeStabilityManager::GetInstance();
   if (nsm) {
     nsm->RecordHangRecovered(hang_uuid);
   }
+#endif
 }
 
 }  // namespace browser


### PR DESCRIPTION
This change implements |RecordHangStarted| and |RecordHangRecovered| to persist hang recovery state from HangWatcher and propagate it to the getPendingReports web API. The 3P MVP design doc has more background.

An extensible schema is used for the file to store the is_recovered boolean. This is to hopefully avoid any data migration if we later want to record any additional attributes about hangs (e.g., "long" hangs).

Issue: 528362453