### PR TITLE
Loader App Loading Priority for mmap

### DIFF
--- a/starboard/loader_app/loader_app.cc
+++ b/starboard/loader_app/loader_app.cc
@@ -150,7 +150,10 @@ void LoadLibraryAndInitialize(const std::string& alternative_content_path,
   elf_loader::CompressionType compression_type =
       elf_loader::CompressionType::kNone;
   struct stat info;
-  if (stat(lz4_compressed_library_path.c_str(), &info) == 0) {
+  if (use_memory_mapped_file &&
+      stat(uncompressed_library_path.c_str(), &info) == 0) {
+    library_path = uncompressed_library_path;
+  } else if (stat(lz4_compressed_library_path.c_str(), &info) == 0) {
     library_path = lz4_compressed_library_path;
     compression_type = elf_loader::CompressionType::kLz4;
   } else if (stat(zstd_compressed_library_path.c_str(), &info) == 0) {


### PR DESCRIPTION
Change the fixed priority order of loading libcobalt. If --loader_use_mmap_file is passed, let loader_app natively prioritize the uncompressed libcobalt.so.

Bug: 537318952