### PR TITLE
Flag Simplification for mmap Users

### DIFF
--- a/cobalt/updater/configurator.cc
+++ b/cobalt/updater/configurator.cc
@@ -54,6 +54,7 @@ const char kUpdaterJSONDefaultUrl[] =
 // Whether to request, download, and install uncompressed (rather than
 // compressed) Evergreen binaries.
 constexpr char kUseUncompressedUpdates[] = "use_uncompressed_updates";
+constexpr char kLoaderUseMemoryMappedFile[] = "loader_use_mmap_file";
 
 // Uses the QA update server to test the changes to the configuration of the
 // PROD update server.
@@ -102,6 +103,8 @@ Configurator::Configurator(
     SetChannel(persisted_channel);
   }
   if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+          kLoaderUseMemoryMappedFile) ||
+      base::CommandLine::ForCurrentProcess()->HasSwitch(
           kUseUncompressedUpdates)) {
     use_compressed_updates_.store(false);
   } else {

--- a/starboard/loader_app/loader_app.cc
+++ b/starboard/loader_app/loader_app.cc
@@ -279,21 +279,9 @@ void SbEventHandle(const SbEvent* event) {
         command_line.GetSwitchValue(loader_app::kContent);
     SB_LOG(INFO) << "alternative_content=" << alternative_content;
 
-    bool use_compressed_updates =
-        !is_evergreen_lite &&
-        !command_line.HasSwitch(loader_app::kUseUncompressedUpdates);
-
     bool use_memory_mapped_file =
         command_line.HasSwitch(loader_app::kLoaderUseMemoryMappedFile);
     SB_LOG(INFO) << "use_memory_mapped_file=" << use_memory_mapped_file;
-
-    if (use_compressed_updates && use_memory_mapped_file) {
-      SB_LOG(ERROR) << "Compression and memory mapping are incompatible."
-                    << " Compressed updates should not be installed because"
-                    << " the loader app is configured to use memory mapping"
-                    << " and would not be able to load them.";
-      return;
-    }
 
     if (command_line.HasSwitch(loader_app::kLoaderTrackMemory)) {
       std::string period =


### PR DESCRIPTION
Simplify mmap execution flags natively. If --loader_use_mmap_file is passed, let it default to natively requesting uncompressed updates from the updater, with not need to pass --use_uncompressed_updates, preventing users from needing to pass redundant parameters.

Bug: 537318952