### PR TITLE
starboard: Refactor DecodedAudio to plain object

### DIFF
--- a/starboard/android/shared/audio_decoder_passthrough.h
+++ b/starboard/android/shared/audio_decoder_passthrough.h
@@ -15,6 +15,7 @@
 #ifndef STARBOARD_ANDROID_SHARED_AUDIO_DECODER_PASSTHROUGH_H_
 #define STARBOARD_ANDROID_SHARED_AUDIO_DECODER_PASSTHROUGH_H_
 
+#include <optional>
 #include <queue>
 #include <utility>
 
@@ -64,11 +65,11 @@ class AudioDecoderPassthrough : public AudioDecoder {
     //       mode on more platforms.
     const int kChannels = 1;
     for (const auto& input_buffer : input_buffers) {
-      scoped_refptr<DecodedAudio> decoded_audio =
-          new DecodedAudio(kChannels, kSbMediaAudioSampleTypeInt16Deprecated,
-                           kSbMediaAudioFrameStorageTypePlanar,
-                           input_buffer->timestamp(), input_buffer->size());
-      memcpy(decoded_audio->data(), input_buffer->data(), input_buffer->size());
+      DecodedAudio decoded_audio(
+          kChannels, kSbMediaAudioSampleTypeInt16Deprecated,
+          kSbMediaAudioFrameStorageTypePlanar, input_buffer->timestamp(),
+          input_buffer->size());
+      memcpy(decoded_audio.data(), input_buffer->data(), input_buffer->size());
       decoded_audios_.push(std::move(decoded_audio));
       output_cb_();
     }
@@ -80,18 +81,19 @@ class AudioDecoderPassthrough : public AudioDecoder {
     SB_CHECK(thread_checker_.CalledOnValidThread());
     SB_DCHECK(output_cb_);
 
-    decoded_audios_.push(new DecodedAudio);
+    decoded_audios_.push(DecodedAudio());
     output_cb_();
   }
 
-  scoped_refptr<DecodedAudio> Read(int* samples_per_second) override {
+  std::optional<DecodedAudio> Read(int* samples_per_second) override {
     SB_CHECK(thread_checker_.CalledOnValidThread());
     SB_DCHECK(samples_per_second);
     SB_DCHECK(!decoded_audios_.empty());
 
     *samples_per_second = samples_per_second_;
 
-    auto decoded_audio = std::move(decoded_audios_.front());
+    std::optional<DecodedAudio> decoded_audio =
+        std::move(decoded_audios_.front());
     decoded_audios_.pop();
     return decoded_audio;
   }
@@ -99,7 +101,7 @@ class AudioDecoderPassthrough : public AudioDecoder {
   void Reset() override {
     SB_CHECK(thread_checker_.CalledOnValidThread());
 
-    decoded_audios_ = std::queue<scoped_refptr<DecodedAudio>>();  // Clear
+    decoded_audios_ = std::queue<DecodedAudio>();  // Clear
   }
 
  private:
@@ -107,7 +109,7 @@ class AudioDecoderPassthrough : public AudioDecoder {
 
   const int samples_per_second_;
   OutputCB output_cb_;
-  std::queue<scoped_refptr<DecodedAudio>> decoded_audios_;
+  std::queue<DecodedAudio> decoded_audios_;
 };
 
 }  // namespace starboard

--- a/starboard/android/shared/audio_renderer_passthrough.cc
+++ b/starboard/android/shared/audio_renderer_passthrough.cc
@@ -302,8 +302,8 @@ void AudioRendererPassthrough::Seek(int64_t seek_to_time) {
     seek_to_time_ = seek_to_time;
   }
   paused_ = true;
-  decoded_audios_ = std::queue<scoped_refptr<DecodedAudio>>();  // clear it
-  decoded_audio_writing_in_progress_ = nullptr;
+  decoded_audios_ = std::queue<DecodedAudio>();  // clear it
+  decoded_audio_writing_in_progress_ = std::nullopt;
   decoded_audio_writing_offset_ = 0;
   total_frames_written_on_audio_track_thread_ = 0;
 }
@@ -527,7 +527,7 @@ void AudioRendererPassthrough::UpdateStatusAndWriteData(
         playback_head_position_when_stopped_ =
             audio_track_bridge_->GetAudioTimestamp(&stopped_at_);
         total_frames_written_ = total_frames_written_on_audio_track_thread_;
-        decoded_audio_writing_in_progress_ = nullptr;
+        decoded_audio_writing_in_progress_ = std::nullopt;
         SB_LOG(INFO) << "Audio track stopped at " << stopped_at_
                      << ", playback head: "
                      << playback_head_position_when_stopped_;
@@ -576,7 +576,7 @@ void AudioRendererPassthrough::UpdateStatusAndWriteData(
       if (decoded_audio_writing_offset_ ==
           decoded_audio_writing_in_progress_->size_in_bytes()) {
         total_frames_written_on_audio_track_thread_ += frames_per_input_buffer_;
-        decoded_audio_writing_in_progress_ = nullptr;
+        decoded_audio_writing_in_progress_ = std::nullopt;
         decoded_audio_writing_offset_ = 0;
         fully_written = true;
       } else if (!prerolled_.exchange(true)) {
@@ -641,7 +641,7 @@ void AudioRendererPassthrough::OnDecoderOutput() {
   }
 
   std::lock_guard scoped_lock(mutex_);
-  decoded_audios_.push(std::move(decoded_audio));
+  decoded_audios_.push(std::move(*decoded_audio));
 }
 
 }  // namespace starboard

--- a/starboard/android/shared/audio_renderer_passthrough.h
+++ b/starboard/android/shared/audio_renderer_passthrough.h
@@ -131,11 +131,11 @@ class AudioRendererPassthrough : public AudioRenderer,
   double volume_ = 1.0;
   bool paused_ = true;
   double playback_rate_ = 1.0;
-  std::queue<scoped_refptr<DecodedAudio>> decoded_audios_;
+  std::queue<DecodedAudio> decoded_audios_;
 
   // The following variable group is only accessed on |audio_track_thread_|, or
   // after |audio_track_thread_| is destroyed (in Seek()).
-  scoped_refptr<DecodedAudio> decoded_audio_writing_in_progress_;
+  std::optional<DecodedAudio> decoded_audio_writing_in_progress_;
   int decoded_audio_writing_offset_ = 0;
   JobQueue::JobToken update_status_and_write_data_token_ =
       JobQueue::JobToken::kUnscheduled;

--- a/starboard/android/shared/media_codec_audio_decoder.cc
+++ b/starboard/android/shared/media_codec_audio_decoder.cc
@@ -164,12 +164,12 @@ void MediaCodecAudioDecoder::WriteEndOfStream() {
   }
 }
 
-scoped_refptr<DecodedAudio> MediaCodecAudioDecoder::Read(
+std::optional<DecodedAudio> MediaCodecAudioDecoder::Read(
     int* samples_per_second) {
   SB_CHECK(BelongsToCurrentThread());
   SB_DCHECK(output_cb_);
 
-  scoped_refptr<DecodedAudio> result;
+  std::optional<DecodedAudio> result;
   {
     std::lock_guard lock(decoded_audios_mutex_);
     SB_DCHECK(!decoded_audios_.empty());
@@ -268,12 +268,12 @@ void MediaCodecAudioDecoder::ProcessOutputBuffer(
       size /= 2;
     }
 
-    scoped_refptr<DecodedAudio> decoded_audio = new DecodedAudio(
+    DecodedAudio decoded_audio(
         audio_stream_info_.number_of_channels, sample_type_,
         kSbMediaAudioFrameStorageTypeInterleaved,
         dequeue_output_result.presentation_time_microseconds, size);
 
-    memcpy(decoded_audio->data(), data, size);
+    memcpy(decoded_audio.data(), data, size);
     audio_frame_discarder_.AdjustForDiscardedDurations(
         audio_stream_info_.samples_per_second, &decoded_audio);
 
@@ -281,7 +281,7 @@ void MediaCodecAudioDecoder::ProcessOutputBuffer(
       std::lock_guard lock(decoded_audios_mutex_);
       decoded_audios_.push(std::move(decoded_audio));
       VERBOSE_MEDIA_LOG() << "T2: timestamp "
-                          << decoded_audios_.front()->timestamp();
+                          << decoded_audios_.front().timestamp();
     }
     Schedule(output_cb_);
   }
@@ -290,7 +290,7 @@ void MediaCodecAudioDecoder::ProcessOutputBuffer(
   if (dequeue_output_result.flags & MediaCodec::kBufferFlagEndOfStream) {
     {
       std::lock_guard lock(decoded_audios_mutex_);
-      decoded_audios_.push(new DecodedAudio());
+      decoded_audios_.push(DecodedAudio());
     }
     audio_frame_discarder_.OnDecodedAudioEndOfStream();
     Schedule(output_cb_);

--- a/starboard/android/shared/media_codec_audio_decoder.h
+++ b/starboard/android/shared/media_codec_audio_decoder.h
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <queue>
 #include <string>
 
@@ -60,7 +61,7 @@ class MediaCodecAudioDecoder : public AudioDecoder,
   void Decode(const InputBuffers& input_buffers,
               const ConsumedCB& consumed_cb) override;
   void WriteEndOfStream() override;
-  scoped_refptr<DecodedAudio> Read(int* samples_per_second) override;
+  std::optional<DecodedAudio> Read(int* samples_per_second) override;
   void Reset() override;
 
  private:
@@ -97,7 +98,7 @@ class MediaCodecAudioDecoder : public AudioDecoder,
   ConsumedCB consumed_cb_;
 
   std::mutex decoded_audios_mutex_;
-  std::queue<scoped_refptr<DecodedAudio>> decoded_audios_;
+  std::queue<DecodedAudio> decoded_audios_;
 
   AudioFrameDiscarder audio_frame_discarder_;
   std::unique_ptr<MediaCodecDecoder> media_decoder_;

--- a/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.cc
@@ -237,29 +237,29 @@ void FfmpegAudioDecoderImpl<FFMPEG>::ProcessDecodedFrame(
     return;
   }
 
-  scoped_refptr<DecodedAudio> decoded_audio = new DecodedAudio(
+  DecodedAudio decoded_audio(
       channel_count, GetSampleType(), GetStorageType(),
       input_buffer.timestamp(),
       channel_count * av_frame.nb_samples * GetBytesPerSample(GetSampleType()));
   if (GetStorageType() == kSbMediaAudioFrameStorageTypeInterleaved) {
-    memcpy(decoded_audio->data(), *av_frame.extended_data,
-           decoded_audio->size_in_bytes());
+    memcpy(decoded_audio.data(), *av_frame.extended_data,
+           decoded_audio.size_in_bytes());
   } else {
     SB_DCHECK_EQ(GetStorageType(), kSbMediaAudioFrameStorageTypePlanar);
     const int per_channel_size_in_bytes =
-        decoded_audio->size_in_bytes() / decoded_audio->channels();
-    for (int i = 0; i < decoded_audio->channels(); ++i) {
-      memcpy(decoded_audio->data() + per_channel_size_in_bytes * i,
+        decoded_audio.size_in_bytes() / decoded_audio.channels();
+    for (int i = 0; i < decoded_audio.channels(); ++i) {
+      memcpy(decoded_audio.data() + per_channel_size_in_bytes * i,
              av_frame.extended_data[i], per_channel_size_in_bytes);
     }
-    decoded_audio = decoded_audio->SwitchFormatTo(
+    decoded_audio = decoded_audio.SwitchFormatTo(
         GetSampleType(), kSbMediaAudioFrameStorageTypeInterleaved);
   }
-  decoded_audio->AdjustForDiscardedDurations(
+  decoded_audio.AdjustForDiscardedDurations(
       audio_stream_info_.samples_per_second,
       input_buffer.audio_sample_info().discarded_duration_from_front,
       input_buffer.audio_sample_info().discarded_duration_from_back);
-  decoded_audios_.push(decoded_audio);
+  decoded_audios_.push(std::move(decoded_audio));
   Schedule(output_cb_);
 }
 
@@ -271,20 +271,20 @@ void FfmpegAudioDecoderImpl<FFMPEG>::WriteEndOfStream() {
   // to ensure that Decode() is not called when the stream is ended.
   stream_ended_ = true;
   // Put EOS into the queue.
-  decoded_audios_.push(new DecodedAudio);
+  decoded_audios_.push(DecodedAudio());
 
   Schedule(output_cb_);
 }
 
-scoped_refptr<DecodedAudio> FfmpegAudioDecoderImpl<FFMPEG>::Read(
+std::optional<DecodedAudio> FfmpegAudioDecoderImpl<FFMPEG>::Read(
     int* samples_per_second) {
   SB_CHECK(BelongsToCurrentThread());
   SB_DCHECK(output_cb_);
   SB_DCHECK(!decoded_audios_.empty());
 
-  scoped_refptr<DecodedAudio> result;
+  std::optional<DecodedAudio> result;
   if (!decoded_audios_.empty()) {
-    result = decoded_audios_.front();
+    result = std::move(decoded_audios_.front());
     decoded_audios_.pop();
   }
   *samples_per_second = audio_stream_info_.samples_per_second;

--- a/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.h
+++ b/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.h
@@ -16,10 +16,10 @@
 #define STARBOARD_SHARED_FFMPEG_FFMPEG_AUDIO_DECODER_IMPL_H_
 
 #include <memory>
+#include <optional>
 #include <queue>
 
 #include "starboard/common/pass_key.h"
-#include "starboard/common/ref_counted.h"
 #include "starboard/media.h"
 #include "starboard/shared/ffmpeg/ffmpeg_audio_decoder.h"
 #include "starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl_interface.h"
@@ -57,7 +57,7 @@ class FfmpegAudioDecoderImpl<FFMPEG> : public FfmpegAudioDecoder,
   void Decode(const InputBuffers& input_buffers,
               const ConsumedCB& consumed_cb) override;
   void WriteEndOfStream() override;
-  scoped_refptr<DecodedAudio> Read(int* samples_per_second) override;
+  std::optional<DecodedAudio> Read(int* samples_per_second) override;
   void Reset() override;
 
  private:
@@ -82,7 +82,7 @@ class FfmpegAudioDecoderImpl<FFMPEG> : public FfmpegAudioDecoder,
   AVFrame* av_frame_ = nullptr;
 
   bool stream_ended_ = false;
-  std::queue<scoped_refptr<DecodedAudio>> decoded_audios_;
+  std::queue<DecodedAudio> decoded_audios_;
   AudioStreamInfo audio_stream_info_;
 };
 

--- a/starboard/shared/libfdkaac/fdk_aac_audio_decoder.cc
+++ b/starboard/shared/libfdkaac/fdk_aac_audio_decoder.cc
@@ -70,14 +70,14 @@ void FdkAacAudioDecoder::Decode(const InputBuffers& input_buffers,
   ReadFromFdkDecoder(kDecodeModeDoNotFlush);
 }
 
-scoped_refptr<DecodedAudio> FdkAacAudioDecoder::Read(int* samples_per_second) {
+std::optional<DecodedAudio> FdkAacAudioDecoder::Read(int* samples_per_second) {
   SB_CHECK(BelongsToCurrentThread());
   SB_DCHECK(output_cb_);
   SB_DCHECK(!decoded_audios_.empty());
 
-  scoped_refptr<DecodedAudio> result;
+  std::optional<DecodedAudio> result;
   if (!decoded_audios_.empty()) {
-    result = decoded_audios_.front();
+    result = std::move(decoded_audios_.front());
     decoded_audios_.pop();
   }
   *samples_per_second = samples_per_second_;
@@ -92,8 +92,8 @@ void FdkAacAudioDecoder::Reset() {
   InitializeCodec();
 
   stream_ended_ = false;
-  decoded_audios_ = std::queue<scoped_refptr<DecodedAudio>>();  // clear
-  partially_decoded_audio_ = nullptr;
+  decoded_audios_ = std::queue<DecodedAudio>();  // clear
+  partially_decoded_audio_ = std::nullopt;
   partially_decoded_audio_data_in_bytes_ = 0;
   decoding_input_buffers_ = decltype(decoding_input_buffers_)();  // clear
   // Clean up stream information and deduced results.
@@ -117,7 +117,7 @@ void FdkAacAudioDecoder::WriteEndOfStream() {
   }
   stream_ended_ = true;
   // Put EOS into the queue.
-  decoded_audios_.push(new DecodedAudio);
+  decoded_audios_.push(DecodedAudio());
   Schedule(output_cb_);
 }
 
@@ -218,11 +218,11 @@ void FdkAacAudioDecoder::TryToOutputDecodedAudio(const uint8_t* data,
   while (size_in_bytes > 0 && !decoding_input_buffers_.empty()) {
     if (!partially_decoded_audio_) {
       SB_DCHECK_EQ(partially_decoded_audio_data_in_bytes_, 0);
-      partially_decoded_audio_ = new DecodedAudio(
-          num_channels_, kSbMediaAudioSampleTypeInt16Deprecated,
-          kSbMediaAudioFrameStorageTypeInterleaved,
-          decoding_input_buffers_.front()->timestamp(),
-          decoded_audio_size_in_bytes_);
+      partially_decoded_audio_ =
+          DecodedAudio(num_channels_, kSbMediaAudioSampleTypeInt16Deprecated,
+                       kSbMediaAudioFrameStorageTypeInterleaved,
+                       decoding_input_buffers_.front()->timestamp(),
+                       decoded_audio_size_in_bytes_);
     }
     int freespace =
         static_cast<int>(partially_decoded_audio_->size_in_bytes()) -
@@ -242,9 +242,9 @@ void FdkAacAudioDecoder::TryToOutputDecodedAudio(const uint8_t* data,
           samples_per_second_, sample_info.discarded_duration_from_front,
           sample_info.discarded_duration_from_back);
       decoding_input_buffers_.pop();
-      decoded_audios_.push(partially_decoded_audio_);
+      decoded_audios_.push(std::move(*partially_decoded_audio_));
       Schedule(output_cb_);
-      partially_decoded_audio_ = nullptr;
+      partially_decoded_audio_ = std::nullopt;
       partially_decoded_audio_data_in_bytes_ = 0;
       continue;
     }

--- a/starboard/shared/libfdkaac/fdk_aac_audio_decoder.h
+++ b/starboard/shared/libfdkaac/fdk_aac_audio_decoder.h
@@ -15,6 +15,7 @@
 #ifndef STARBOARD_SHARED_LIBFDKAAC_FDK_AAC_AUDIO_DECODER_H_
 #define STARBOARD_SHARED_LIBFDKAAC_FDK_AAC_AUDIO_DECODER_H_
 
+#include <optional>
 #include <queue>
 
 #include "starboard/common/ref_counted.h"
@@ -39,7 +40,7 @@ class FdkAacAudioDecoder : public AudioDecoder, private JobQueue::JobOwner {
   void Initialize(const OutputCB& output_cb, const ErrorCB& error_cb) override;
   void Decode(const InputBuffers& input_buffers,
               const ConsumedCB& consumed_cb) override;
-  scoped_refptr<DecodedAudio> Read(int* samples_per_second) override;
+  std::optional<DecodedAudio> Read(int* samples_per_second) override;
   void Reset() override;
   void WriteEndOfStream() override;
 
@@ -68,10 +69,10 @@ class FdkAacAudioDecoder : public AudioDecoder, private JobQueue::JobOwner {
   bool stream_ended_ = false;
   uint8_t output_buffer_[kMaxOutputBufferSizeInBytes];
 
-  std::queue<scoped_refptr<DecodedAudio>> decoded_audios_;
+  std::queue<DecodedAudio> decoded_audios_;
   // The DecodedAudio being filled up, will be appended to |decoded_audios_|
   // once it's fully filled (and |output_cb_| will be called).
-  scoped_refptr<DecodedAudio> partially_decoded_audio_;
+  std::optional<DecodedAudio> partially_decoded_audio_;
   int partially_decoded_audio_data_in_bytes_ = 0;
   // The input buffers being decoded.
   std::queue<scoped_refptr<InputBuffer>> decoding_input_buffers_;

--- a/starboard/shared/opus/opus_audio_decoder.cc
+++ b/starboard/shared/opus/opus_audio_decoder.cc
@@ -130,19 +130,19 @@ void OpusAudioDecoder::WriteEndOfStream() {
   }
 
   // Put EOS into the queue.
-  decoded_audios_.push(new DecodedAudio);
+  decoded_audios_.push(DecodedAudio());
 
   Schedule(output_cb_);
 }
 
-scoped_refptr<DecodedAudio> OpusAudioDecoder::Read(int* samples_per_second) {
+std::optional<DecodedAudio> OpusAudioDecoder::Read(int* samples_per_second) {
   SB_CHECK(BelongsToCurrentThread());
   SB_DCHECK(output_cb_);
   SB_DCHECK(!decoded_audios_.empty());
 
-  scoped_refptr<DecodedAudio> result;
+  std::optional<DecodedAudio> result;
   if (!decoded_audios_.empty()) {
-    result = decoded_audios_.front();
+    result = std::move(decoded_audios_.front());
     decoded_audios_.pop();
   }
   *samples_per_second = audio_stream_info_.samples_per_second;
@@ -238,7 +238,7 @@ bool OpusAudioDecoder::DecodeInternal(
   SB_DCHECK(output_cb_);
   SB_DCHECK(!stream_ended_ || !pending_audio_buffers_.empty());
 
-  scoped_refptr<DecodedAudio> decoded_audio = new DecodedAudio(
+  DecodedAudio decoded_audio(
       audio_stream_info_.number_of_channels, GetSampleType(),
       kSbMediaAudioFrameStorageTypeInterleaved, input_buffer->timestamp(),
       audio_stream_info_.number_of_channels * frames_per_au_ *
@@ -247,7 +247,7 @@ bool OpusAudioDecoder::DecodeInternal(
   const char kDecodeFunctionName[] = "opus_multistream_decode_float";
   int decoded_frames = opus_multistream_decode_float(
       decoder_, static_cast<const unsigned char*>(input_buffer->data()),
-      input_buffer->size(), reinterpret_cast<float*>(decoded_audio->data()),
+      input_buffer->size(), reinterpret_cast<float*>(decoded_audio.data()),
       frames_per_au_, 0);
   if (decoded_frames == OPUS_BUFFER_TOO_SMALL &&
       frames_per_au_ < kMaxOpusFramesPerAU) {
@@ -271,14 +271,14 @@ bool OpusAudioDecoder::DecodeInternal(
   }
 
   frames_per_au_ = decoded_frames;
-  decoded_audio->ShrinkTo(audio_stream_info_.number_of_channels *
-                          frames_per_au_ * GetBytesPerSample(GetSampleType()));
+  decoded_audio.ShrinkTo(audio_stream_info_.number_of_channels *
+                         frames_per_au_ * GetBytesPerSample(GetSampleType()));
   const auto& sample_info = input_buffer->audio_sample_info();
-  decoded_audio->AdjustForDiscardedDurations(
+  decoded_audio.AdjustForDiscardedDurations(
       audio_stream_info_.samples_per_second,
       sample_info.discarded_duration_from_front,
       sample_info.discarded_duration_from_back);
-  decoded_audios_.push(decoded_audio);
+  decoded_audios_.push(std::move(decoded_audio));
   output_cb_();
   return true;
 }

--- a/starboard/shared/opus/opus_audio_decoder.h
+++ b/starboard/shared/opus/opus_audio_decoder.h
@@ -17,6 +17,7 @@
 
 #include <deque>
 #include <memory>
+#include <optional>
 #include <queue>
 #include <vector>
 
@@ -49,7 +50,7 @@ class OpusAudioDecoder : public AudioDecoder, private JobQueue::JobOwner {
   void Decode(const InputBuffers& input_buffers,
               const ConsumedCB& consumed_cb) override;
   void WriteEndOfStream() override;
-  scoped_refptr<DecodedAudio> Read(int* samples_per_second) override;
+  std::optional<DecodedAudio> Read(int* samples_per_second) override;
   void Reset() override;
 
  private:
@@ -66,7 +67,7 @@ class OpusAudioDecoder : public AudioDecoder, private JobQueue::JobOwner {
 
   OpusMSDecoder* decoder_ = nullptr;
   bool stream_ended_ = false;
-  std::queue<scoped_refptr<DecodedAudio>> decoded_audios_;
+  std::queue<DecodedAudio> decoded_audios_;
   const AudioStreamInfo audio_stream_info_;
   int frames_per_au_;
 

--- a/starboard/shared/starboard/player/decoded_audio_internal.cc
+++ b/starboard/shared/starboard/player/decoded_audio_internal.cc
@@ -215,7 +215,7 @@ bool DecodedAudio::IsFormat(SbMediaAudioSampleType sample_type,
   return sample_type_ == sample_type && storage_type_ == storage_type;
 }
 
-scoped_refptr<DecodedAudio> DecodedAudio::SwitchFormatTo(
+DecodedAudio DecodedAudio::SwitchFormatTo(
     SbMediaAudioSampleType new_sample_type,
     SbMediaAudioFrameStorageType new_storage_type,
     std::optional<bool> force_simd) const {
@@ -224,11 +224,9 @@ scoped_refptr<DecodedAudio> DecodedAudio::SwitchFormatTo(
   SB_DCHECK(new_sample_type != sample_type_ ||
             new_storage_type != storage_type_);
 
-#if defined(USE_NEON_FOR_AUDIO)
-  bool enable_simd =
-      force_simd.value_or(GetSimdBasedAudioFormatSwitchingSetting());
-#else   // !defined(USE_NEON_FOR_AUDIO)
   bool enable_simd = false;
+#if defined(USE_NEON_FOR_AUDIO)
+  enable_simd = force_simd.value_or(GetSimdBasedAudioFormatSwitchingSetting());
 #endif  // defined(USE_NEON_FOR_AUDIO)
 
   if (new_storage_type == storage_type_) {
@@ -241,13 +239,13 @@ scoped_refptr<DecodedAudio> DecodedAudio::SwitchFormatTo(
 
   // Both sample types and storage types are different, use the slowest way.
   int new_size = GetBytesPerSample(new_sample_type) * frames() * channels();
-  auto new_decoded_audio = make_scoped_refptr<DecodedAudio>(
-      channels(), new_sample_type, new_storage_type, timestamp(), new_size);
+  DecodedAudio new_decoded_audio(channels(), new_sample_type, new_storage_type,
+                                 timestamp(), new_size);
 
 #if defined(USE_NEON_FOR_AUDIO)
   if (enable_simd && channels() == 2 && IsAligned(frames(), 8)) {
     if (SwitchFormatTo_NEON(new_sample_type, new_storage_type,
-                            new_decoded_audio.get())) {
+                            &new_decoded_audio)) {
       return new_decoded_audio;
     }
     SB_LOG(WARNING) << "SIMD format switching requested and aligned, but not "
@@ -271,7 +269,7 @@ scoped_refptr<DecodedAudio> DecodedAudio::SwitchFormatTo(
     const OldSampleType* old_samples =                                         \
         reinterpret_cast<const OldSampleType*>(this->data());                  \
     NewSampleType* new_samples =                                               \
-        reinterpret_cast<NewSampleType*>(new_decoded_audio->data());           \
+        reinterpret_cast<NewSampleType*>(new_decoded_audio.data());            \
                                                                                \
     for (int channel = 0; channel < channels(); ++channel) {                   \
       for (int frame = 0; frame < frames(); ++frame) {                         \
@@ -311,31 +309,33 @@ scoped_refptr<DecodedAudio> DecodedAudio::SwitchFormatTo(
   return new_decoded_audio;
 }
 
-scoped_refptr<DecodedAudio> DecodedAudio::Clone() const {
-  auto copy = make_scoped_refptr<DecodedAudio>(
-      channels(), sample_type(), storage_type(), timestamp(), size_in_bytes());
+DecodedAudio DecodedAudio::CloneForTesting() const {
+  DecodedAudio copy(channels(), sample_type(), storage_type(), timestamp(),
+                    size_in_bytes());
 
-  memcpy(copy->data(), data(), size_in_bytes());
+  if (size_in_bytes() > 0) {
+    memcpy(copy.data(), data(), size_in_bytes());
+  }
 
   return copy;
 }
 
-scoped_refptr<DecodedAudio> DecodedAudio::SwitchSampleTypeTo(
+DecodedAudio DecodedAudio::SwitchSampleTypeTo(
     SbMediaAudioSampleType new_sample_type,
     bool enable_simd) const {
   int new_size = GetBytesPerSample(new_sample_type) * frames() * channels();
-  auto new_decoded_audio = make_scoped_refptr<DecodedAudio>(
-      channels(), new_sample_type, storage_type(), timestamp(), new_size);
+  DecodedAudio new_decoded_audio(channels(), new_sample_type, storage_type(),
+                                 timestamp(), new_size);
 
   if (sample_type_ == kSbMediaAudioSampleTypeInt16Deprecated &&
       new_sample_type == kSbMediaAudioSampleTypeFloat32) {
     const int16_t* old_samples = reinterpret_cast<const int16_t*>(this->data());
-    float* new_samples = reinterpret_cast<float*>(new_decoded_audio->data());
+    float* new_samples = reinterpret_cast<float*>(new_decoded_audio.data());
     int total_samples = frames() * channels();
 
 #if defined(USE_NEON_FOR_AUDIO)
     if (enable_simd && IsAligned(total_samples, 16)) {
-      if (SwitchSampleTypeTo_NEON(new_sample_type, new_decoded_audio.get())) {
+      if (SwitchSampleTypeTo_NEON(new_sample_type, &new_decoded_audio)) {
         return new_decoded_audio;
       }
     }
@@ -347,13 +347,12 @@ scoped_refptr<DecodedAudio> DecodedAudio::SwitchSampleTypeTo(
   } else if (sample_type_ == kSbMediaAudioSampleTypeFloat32 &&
              new_sample_type == kSbMediaAudioSampleTypeInt16Deprecated) {
     const float* old_samples = reinterpret_cast<const float*>(this->data());
-    int16_t* new_samples =
-        reinterpret_cast<int16_t*>(new_decoded_audio->data());
+    int16_t* new_samples = reinterpret_cast<int16_t*>(new_decoded_audio.data());
     int total_samples = frames() * channels();
 
 #if defined(USE_NEON_FOR_AUDIO)
     if (enable_simd && IsAligned(total_samples, 16)) {
-      if (SwitchSampleTypeTo_NEON(new_sample_type, new_decoded_audio.get())) {
+      if (SwitchSampleTypeTo_NEON(new_sample_type, &new_decoded_audio)) {
         return new_decoded_audio;
       }
     }
@@ -367,19 +366,18 @@ scoped_refptr<DecodedAudio> DecodedAudio::SwitchSampleTypeTo(
   return new_decoded_audio;
 }
 
-scoped_refptr<DecodedAudio> DecodedAudio::SwitchStorageTypeTo(
+DecodedAudio DecodedAudio::SwitchStorageTypeTo(
     SbMediaAudioFrameStorageType new_storage_type,
     bool enable_simd) const {
-  auto new_decoded_audio = make_scoped_refptr<DecodedAudio>(
-      channels(), sample_type(), new_storage_type, timestamp(),
-      size_in_bytes());
+  DecodedAudio new_decoded_audio(channels(), sample_type(), new_storage_type,
+                                 timestamp(), size_in_bytes());
   int bytes_per_sample = GetBytesPerSample(sample_type());
   const uint8_t* old_samples = this->data();
-  uint8_t* new_samples = new_decoded_audio->data();
+  uint8_t* new_samples = new_decoded_audio.data();
 
 #if defined(USE_NEON_FOR_AUDIO)
   if (enable_simd && channels() == 2 && IsAligned(frames(), 8)) {
-    if (SwitchStorageTypeTo_NEON(new_storage_type, new_decoded_audio.get())) {
+    if (SwitchStorageTypeTo_NEON(new_storage_type, &new_decoded_audio)) {
       return new_decoded_audio;
     }
   }

--- a/starboard/shared/starboard/player/decoded_audio_internal.h
+++ b/starboard/shared/starboard/player/decoded_audio_internal.h
@@ -18,7 +18,6 @@
 #include <optional>
 #include <ostream>
 
-#include "starboard/common/ref_counted.h"
 #include "starboard/media.h"
 #include "starboard/shared/internal_only.h"
 #include "starboard/shared/starboard/player/buffer_internal.h"
@@ -27,7 +26,7 @@ namespace starboard {
 
 // Decoded audio frames produced by an audio decoder.  It can contain multiple
 // frames with continuous timestamps.
-class DecodedAudio : public RefCountedThreadSafe<DecodedAudio> {
+class DecodedAudio {
  public:
   DecodedAudio();  // Signal an EOS.
   // TODO(b/272837615): Remove `storage_type` support and always store data in
@@ -45,6 +44,14 @@ class DecodedAudio : public RefCountedThreadSafe<DecodedAudio> {
                int64_t timestamp,
                int size_in_bytes,
                Buffer&& storage);
+
+  // Move-only semantics
+  DecodedAudio(DecodedAudio&& other) = default;
+  DecodedAudio& operator=(DecodedAudio&& other) = default;
+
+  // Disable copy and assignment.
+  DecodedAudio(const DecodedAudio&) = delete;
+  void operator=(const DecodedAudio&) = delete;
 
   static void EnableSimdBasedAudioFormatSwitching();
 
@@ -90,19 +97,17 @@ class DecodedAudio : public RefCountedThreadSafe<DecodedAudio> {
   // the SIMD path, which is primarily intended for unit testing different
   // execution paths. When left as `nullopt` (default), it automatically
   // resolves to the global experimental setting.
-  scoped_refptr<DecodedAudio> SwitchFormatTo(
-      SbMediaAudioSampleType new_sample_type,
-      SbMediaAudioFrameStorageType new_storage_type,
-      std::optional<bool> force_simd = std::nullopt) const
-      SB_WARN_UNUSED_RESULT;
+  DecodedAudio SwitchFormatTo(SbMediaAudioSampleType new_sample_type,
+                              SbMediaAudioFrameStorageType new_storage_type,
+                              std::optional<bool> force_simd =
+                                  std::nullopt) const SB_WARN_UNUSED_RESULT;
 
-  scoped_refptr<DecodedAudio> Clone() const;
+  DecodedAudio CloneForTesting() const;
 
  private:
-  scoped_refptr<DecodedAudio> SwitchSampleTypeTo(
-      SbMediaAudioSampleType new_sample_type,
-      bool enable_simd) const;
-  scoped_refptr<DecodedAudio> SwitchStorageTypeTo(
+  DecodedAudio SwitchSampleTypeTo(SbMediaAudioSampleType new_sample_type,
+                                  bool enable_simd) const;
+  DecodedAudio SwitchStorageTypeTo(
       SbMediaAudioFrameStorageType new_storage_type,
       bool enable_simd) const;
 
@@ -118,9 +123,9 @@ class DecodedAudio : public RefCountedThreadSafe<DecodedAudio> {
   bool SwitchStorageTypeTo_NEON(SbMediaAudioFrameStorageType new_storage_type,
                                 DecodedAudio* destination_audio) const;
 
-  const int channels_;
-  const SbMediaAudioSampleType sample_type_;
-  const SbMediaAudioFrameStorageType storage_type_;
+  int channels_;
+  SbMediaAudioSampleType sample_type_;
+  SbMediaAudioFrameStorageType storage_type_;
   // The timestamp of the first audio frame in microseconds.
   int64_t timestamp_;
   Buffer storage_;
@@ -128,9 +133,6 @@ class DecodedAudio : public RefCountedThreadSafe<DecodedAudio> {
   // `storage_.data() + offset_in_bytes_`, `size_in_bytes_` bytes in total.
   int offset_in_bytes_ = 0;
   int size_in_bytes_ = 0;
-
-  DecodedAudio(const DecodedAudio&) = delete;
-  void operator=(const DecodedAudio&) = delete;
 };
 
 bool operator==(const DecodedAudio& left, const DecodedAudio& right);

--- a/starboard/shared/starboard/player/decoded_audio_test_internal.cc
+++ b/starboard/shared/starboard/player/decoded_audio_test_internal.cc
@@ -118,35 +118,7 @@ void Verify(const float* data,
 
 // Fill `decoded_audio` with sine wave samples, with phase shift of Pi/2 on each
 // channel.
-void Fill(scoped_refptr<DecodedAudio>* decoded_audio) {
-  SB_DCHECK(decoded_audio);
-  SB_DCHECK(*decoded_audio);
-
-  bool is_int16 =
-      (*decoded_audio)->sample_type() == kSbMediaAudioSampleTypeInt16Deprecated;
-  bool is_interleaved = (*decoded_audio)->storage_type() ==
-                        kSbMediaAudioFrameStorageTypeInterleaved;
-
-  for (int i = 0; i < (*decoded_audio)->channels(); ++i) {
-    if (is_int16 && is_interleaved) {
-      Fill((*decoded_audio)->data_as_int16() + i, kPi / 2 * i, kPi / 180,
-           (*decoded_audio)->frames(), (*decoded_audio)->channels());
-    } else if (!is_int16 && is_interleaved) {
-      Fill((*decoded_audio)->data_as_float32() + i, kPi / 2 * i, kPi / 180,
-           (*decoded_audio)->frames(), (*decoded_audio)->channels());
-    } else if (is_int16 && !is_interleaved) {
-      Fill((*decoded_audio)->data_as_int16() + (*decoded_audio)->frames() * i,
-           kPi / 2 * i, kPi / 180, (*decoded_audio)->frames(), 1);
-    } else if (!is_int16 && !is_interleaved) {
-      Fill((*decoded_audio)->data_as_float32() + (*decoded_audio)->frames() * i,
-           kPi / 2 * i, kPi / 180, (*decoded_audio)->frames(), 1);
-    }
-  }
-}
-
-// verify `decoded_audio` against sine wave samples, with phase shift of Pi/2 on
-// each channel.
-void Verify(const scoped_refptr<DecodedAudio>& decoded_audio) {
+void Fill(DecodedAudio* decoded_audio) {
   SB_DCHECK(decoded_audio);
 
   bool is_int16 =
@@ -156,43 +128,68 @@ void Verify(const scoped_refptr<DecodedAudio>& decoded_audio) {
 
   for (int i = 0; i < decoded_audio->channels(); ++i) {
     if (is_int16 && is_interleaved) {
+      Fill(decoded_audio->data_as_int16() + i, kPi / 2 * i, kPi / 180,
+           decoded_audio->frames(), decoded_audio->channels());
+    } else if (!is_int16 && is_interleaved) {
+      Fill(decoded_audio->data_as_float32() + i, kPi / 2 * i, kPi / 180,
+           decoded_audio->frames(), decoded_audio->channels());
+    } else if (is_int16 && !is_interleaved) {
+      Fill(decoded_audio->data_as_int16() + decoded_audio->frames() * i,
+           kPi / 2 * i, kPi / 180, decoded_audio->frames(), 1);
+    } else if (!is_int16 && !is_interleaved) {
+      Fill(decoded_audio->data_as_float32() + decoded_audio->frames() * i,
+           kPi / 2 * i, kPi / 180, decoded_audio->frames(), 1);
+    }
+  }
+}
+
+// verify `decoded_audio` against sine wave samples, with phase shift of Pi/2 on
+// each channel.
+void Verify(const DecodedAudio& decoded_audio) {
+  bool is_int16 =
+      decoded_audio.sample_type() == kSbMediaAudioSampleTypeInt16Deprecated;
+  bool is_interleaved =
+      decoded_audio.storage_type() == kSbMediaAudioFrameStorageTypeInterleaved;
+
+  for (int i = 0; i < decoded_audio.channels(); ++i) {
+    if (is_int16 && is_interleaved) {
       ASSERT_NO_FATAL_FAILURE(
-          Verify(decoded_audio->data_as_int16() + i, kPi / 2 * i, kPi / 180,
-                 decoded_audio->frames(), decoded_audio->channels()));
+          Verify(decoded_audio.data_as_int16() + i, kPi / 2 * i, kPi / 180,
+                 decoded_audio.frames(), decoded_audio.channels()));
     } else if (!is_int16 && is_interleaved) {
       ASSERT_NO_FATAL_FAILURE(
-          Verify(decoded_audio->data_as_float32() + i, kPi / 2 * i, kPi / 180,
-                 decoded_audio->frames(), decoded_audio->channels()));
+          Verify(decoded_audio.data_as_float32() + i, kPi / 2 * i, kPi / 180,
+                 decoded_audio.frames(), decoded_audio.channels()));
     } else if (is_int16 && !is_interleaved) {
       ASSERT_NO_FATAL_FAILURE(
-          Verify(decoded_audio->data_as_int16() + decoded_audio->frames() * i,
-                 kPi / 2 * i, kPi / 180, decoded_audio->frames(), 1));
+          Verify(decoded_audio.data_as_int16() + decoded_audio.frames() * i,
+                 kPi / 2 * i, kPi / 180, decoded_audio.frames(), 1));
     } else if (!is_int16 && !is_interleaved) {
       ASSERT_NO_FATAL_FAILURE(
-          Verify(decoded_audio->data_as_float32() + decoded_audio->frames() * i,
-                 kPi / 2 * i, kPi / 180, decoded_audio->frames(), 1));
+          Verify(decoded_audio.data_as_float32() + decoded_audio.frames() * i,
+                 kPi / 2 * i, kPi / 180, decoded_audio.frames(), 1));
     }
   }
 }
 
 TEST(DecodedAudioTest, DefaultCtor) {
-  scoped_refptr<DecodedAudio> decoded_audio(new DecodedAudio);
-  EXPECT_TRUE(decoded_audio->is_end_of_stream());
+  DecodedAudio decoded_audio;
+  EXPECT_TRUE(decoded_audio.is_end_of_stream());
 }
 
 TEST(DecodedAudioTest, CtorWithSize) {
   for (auto sample_type : kSampleTypes) {
     for (auto storage_type : kStorageTypes) {
-      scoped_refptr<DecodedAudio> decoded_audio(new DecodedAudio(
-          kChannels, sample_type, storage_type, kTimestampUsec, kSizeInBytes));
+      DecodedAudio decoded_audio(kChannels, sample_type, storage_type,
+                                 kTimestampUsec, kSizeInBytes);
 
-      EXPECT_FALSE(decoded_audio->is_end_of_stream());
-      EXPECT_EQ(decoded_audio->channels(), kChannels);
-      EXPECT_EQ(decoded_audio->sample_type(), sample_type);
-      EXPECT_EQ(decoded_audio->storage_type(), storage_type);
-      EXPECT_EQ(decoded_audio->size_in_bytes(), kSizeInBytes);
-      EXPECT_EQ(decoded_audio->frames(),
-                kSizeInBytes / GetBytesPerSample(decoded_audio->sample_type()) /
+      EXPECT_FALSE(decoded_audio.is_end_of_stream());
+      EXPECT_EQ(decoded_audio.channels(), kChannels);
+      EXPECT_EQ(decoded_audio.sample_type(), sample_type);
+      EXPECT_EQ(decoded_audio.storage_type(), storage_type);
+      EXPECT_EQ(decoded_audio.size_in_bytes(), kSizeInBytes);
+      EXPECT_EQ(decoded_audio.frames(),
+                kSizeInBytes / GetBytesPerSample(decoded_audio.sample_type()) /
                     kChannels);
 
       Fill(&decoded_audio);
@@ -207,68 +204,67 @@ TEST(DecodedAudioTest, CtorWithMoveCtor) {
 
   const uint8_t* original_data_pointer = original.data();
 
-  scoped_refptr<DecodedAudio> decoded_audio(
-      new DecodedAudio(kChannels, kSampleTypes[0], kStorageTypes[0],
-                       kTimestampUsec, 128, std::move(original)));
-  ASSERT_EQ(decoded_audio->size_in_bytes(), 128);
-  ASSERT_NE(decoded_audio->data(), nullptr);
-  ASSERT_EQ(decoded_audio->data(), original_data_pointer);
+  DecodedAudio decoded_audio(kChannels, kSampleTypes[0], kStorageTypes[0],
+                             kTimestampUsec, 128, std::move(original));
+  ASSERT_EQ(decoded_audio.size_in_bytes(), 128);
+  ASSERT_NE(decoded_audio.data(), nullptr);
+  ASSERT_EQ(decoded_audio.data(), original_data_pointer);
 
-  for (int i = 0; i < decoded_audio->size_in_bytes(); ++i) {
-    ASSERT_EQ(decoded_audio->data()[i], 'x');
+  for (int i = 0; i < decoded_audio.size_in_bytes(); ++i) {
+    ASSERT_EQ(decoded_audio.data()[i], 'x');
   }
 }
 
 TEST(DecodedAudioTest, AdjustForSeekTime) {
   for (int channels = 1; channels <= 6; ++channels) {
     for (auto sample_type : kSampleTypes) {
-      scoped_refptr<DecodedAudio> original_decoded_audio(new DecodedAudio(
+      DecodedAudio original_decoded_audio(
           kChannels, sample_type, kSbMediaAudioFrameStorageTypeInterleaved,
-          kTimestampUsec, kSizeInBytes));
+          kTimestampUsec, kSizeInBytes);
       Fill(&original_decoded_audio);
 
-      scoped_refptr<DecodedAudio> adjusted_decoded_audio =
-          original_decoded_audio->Clone();
+      DecodedAudio adjusted_decoded_audio =
+          original_decoded_audio.CloneForTesting();
 
       // Adjust to the beginning of `adjusted_decoded_audio` should be a no-op.
-      adjusted_decoded_audio->AdjustForSeekTime(
-          kSampleRate, adjusted_decoded_audio->timestamp());
-      ASSERT_EQ(*original_decoded_audio, *adjusted_decoded_audio);
+      adjusted_decoded_audio.AdjustForSeekTime(
+          kSampleRate, adjusted_decoded_audio.timestamp());
+      ASSERT_EQ(original_decoded_audio, adjusted_decoded_audio);
 
       // Adjust to an invalid timestamp before the time range of
       // `adjusted_decoded_audio`, it's a no-op.
-      adjusted_decoded_audio->AdjustForSeekTime(
-          kSampleRate, adjusted_decoded_audio->timestamp() - 1'000'000LL / 2);
-      ASSERT_EQ(*original_decoded_audio, *adjusted_decoded_audio);
+      adjusted_decoded_audio.AdjustForSeekTime(
+          kSampleRate, adjusted_decoded_audio.timestamp() - 1'000'000LL / 2);
+      ASSERT_EQ(original_decoded_audio, adjusted_decoded_audio);
 
       // Adjust to an invalid timestamp after the time range of
       // `adjusted_decoded_audio`, it's also a no-op.
-      adjusted_decoded_audio->AdjustForSeekTime(
-          kSampleRate, adjusted_decoded_audio->timestamp() + 1'000'000LL * 100);
-      ASSERT_EQ(*original_decoded_audio, *adjusted_decoded_audio);
+      adjusted_decoded_audio.AdjustForSeekTime(
+          kSampleRate, adjusted_decoded_audio.timestamp() + 1'000'000LL * 100);
+      ASSERT_EQ(original_decoded_audio, adjusted_decoded_audio);
 
       const int64_t duration =
-          AudioFramesToDuration(adjusted_decoded_audio->frames(), kSampleRate);
+          AudioFramesToDuration(adjusted_decoded_audio.frames(), kSampleRate);
       const int64_t duration_of_one_frame =
           AudioFramesToDuration(1, kSampleRate) + 1;
       for (int i = 1; i < 10; ++i) {
-        adjusted_decoded_audio = original_decoded_audio->Clone();
+        adjusted_decoded_audio = original_decoded_audio.CloneForTesting();
         // Adjust to the middle of `adjusted_decoded_audio`.
         int64_t seek_time =
-            adjusted_decoded_audio->timestamp() + duration * i / 10;
-        adjusted_decoded_audio->AdjustForSeekTime(kSampleRate, seek_time);
-        ASSERT_NEAR(adjusted_decoded_audio->frames(),
-                    original_decoded_audio->frames() * (10 - i) / 10, 1);
+            adjusted_decoded_audio.timestamp() + duration * i / 10;
+        adjusted_decoded_audio.AdjustForSeekTime(kSampleRate, seek_time);
+        ASSERT_NEAR(adjusted_decoded_audio.frames(),
+                    original_decoded_audio.frames() * (10 - i) / 10, 1);
 
-        ASSERT_LE(adjusted_decoded_audio->timestamp(), seek_time);
-        ASSERT_NEAR(adjusted_decoded_audio->timestamp(), seek_time,
+        ASSERT_LE(adjusted_decoded_audio.timestamp(), seek_time);
+        ASSERT_NEAR(adjusted_decoded_audio.timestamp(), seek_time,
                     duration_of_one_frame);
 
-        auto offset_in_bytes = original_decoded_audio->size_in_bytes() -
-                               adjusted_decoded_audio->size_in_bytes();
-        ASSERT_TRUE(memcmp(adjusted_decoded_audio->data(),
-                           original_decoded_audio->data() + offset_in_bytes,
-                           adjusted_decoded_audio->size_in_bytes()) == 0);
+        auto offset_in_bytes = original_decoded_audio.size_in_bytes() -
+                               adjusted_decoded_audio.size_in_bytes();
+        ASSERT_TRUE(memcmp(adjusted_decoded_audio.data(),
+                           original_decoded_audio.data() + offset_in_bytes,
+                           adjusted_decoded_audio.size_in_bytes()) == 0);
       }
     }
   }
@@ -277,42 +273,42 @@ TEST(DecodedAudioTest, AdjustForSeekTime) {
 TEST(DecodedAudioTest, AdjustForDiscardedDurations) {
   for (int channels = 1; channels <= 6; ++channels) {
     for (auto sample_type : kSampleTypes) {
-      scoped_refptr<DecodedAudio> original_decoded_audio(new DecodedAudio(
+      DecodedAudio original_decoded_audio(
           kChannels, sample_type, kSbMediaAudioFrameStorageTypeInterleaved,
-          kTimestampUsec, kSizeInBytes));
+          kTimestampUsec, kSizeInBytes);
       Fill(&original_decoded_audio);
 
-      scoped_refptr<DecodedAudio> adjusted_decoded_audio =
-          original_decoded_audio->Clone();
+      DecodedAudio adjusted_decoded_audio =
+          original_decoded_audio.CloneForTesting();
 
-      adjusted_decoded_audio->AdjustForDiscardedDurations(kSampleRate, 0, 0);
-      ASSERT_EQ(*original_decoded_audio, *adjusted_decoded_audio);
+      adjusted_decoded_audio.AdjustForDiscardedDurations(kSampleRate, 0, 0);
+      ASSERT_EQ(original_decoded_audio, adjusted_decoded_audio);
 
       auto duration_of_decoded_audio =
-          AudioFramesToDuration(original_decoded_audio->frames(), kSampleRate);
+          AudioFramesToDuration(original_decoded_audio.frames(), kSampleRate);
       auto quarter_duration = duration_of_decoded_audio / 4;
-      adjusted_decoded_audio->AdjustForDiscardedDurations(
+      adjusted_decoded_audio.AdjustForDiscardedDurations(
           kSampleRate, quarter_duration, quarter_duration);
-      ASSERT_NEAR(adjusted_decoded_audio->frames(),
-                  original_decoded_audio->frames() / 2, 2);
-      ASSERT_EQ(adjusted_decoded_audio->timestamp(),
-                original_decoded_audio->timestamp());
+      ASSERT_NEAR(adjusted_decoded_audio.frames(),
+                  original_decoded_audio.frames() / 2, 2);
+      ASSERT_EQ(adjusted_decoded_audio.timestamp(),
+                original_decoded_audio.timestamp());
 
-      adjusted_decoded_audio = original_decoded_audio->Clone();
+      adjusted_decoded_audio = original_decoded_audio.CloneForTesting();
       // Adjust more frames than it has from front
-      adjusted_decoded_audio->AdjustForDiscardedDurations(
+      adjusted_decoded_audio.AdjustForDiscardedDurations(
           kSampleRate, duration_of_decoded_audio * 2, 0);
-      ASSERT_EQ(adjusted_decoded_audio->frames(), 0);
-      ASSERT_EQ(adjusted_decoded_audio->timestamp(),
-                original_decoded_audio->timestamp());
+      ASSERT_EQ(adjusted_decoded_audio.frames(), 0);
+      ASSERT_EQ(adjusted_decoded_audio.timestamp(),
+                original_decoded_audio.timestamp());
 
-      adjusted_decoded_audio = original_decoded_audio->Clone();
+      adjusted_decoded_audio = original_decoded_audio.CloneForTesting();
       // Adjust more frames than it has from back
-      adjusted_decoded_audio->AdjustForDiscardedDurations(
+      adjusted_decoded_audio.AdjustForDiscardedDurations(
           kSampleRate, 0, duration_of_decoded_audio * 2);
-      ASSERT_EQ(adjusted_decoded_audio->frames(), 0);
-      ASSERT_EQ(adjusted_decoded_audio->timestamp(),
-                original_decoded_audio->timestamp());
+      ASSERT_EQ(adjusted_decoded_audio.frames(), 0);
+      ASSERT_EQ(adjusted_decoded_audio.timestamp(),
+                original_decoded_audio.timestamp());
     }
   }
 }
@@ -320,29 +316,29 @@ TEST(DecodedAudioTest, AdjustForDiscardedDurations) {
 TEST(DecodedAudioTest, SwitchFormatTo) {
   for (auto original_sample_type : kSampleTypes) {
     for (auto original_storage_type : kStorageTypes) {
-      scoped_refptr<DecodedAudio> original_decoded_audio(new DecodedAudio(
-          kChannels, original_sample_type, original_storage_type,
-          kTimestampUsec, kSizeInBytes));
+      DecodedAudio original_decoded_audio(kChannels, original_sample_type,
+                                          original_storage_type, kTimestampUsec,
+                                          kSizeInBytes);
 
       Fill(&original_decoded_audio);
 
       for (auto new_sample_type : kSampleTypes) {
         for (auto new_storage_type : kStorageTypes) {
-          if (!original_decoded_audio->IsFormat(new_sample_type,
-                                                new_storage_type)) {
-            scoped_refptr<DecodedAudio> new_decoded_audio =
-                original_decoded_audio->SwitchFormatTo(new_sample_type,
-                                                       new_storage_type);
+          if (!original_decoded_audio.IsFormat(new_sample_type,
+                                               new_storage_type)) {
+            DecodedAudio new_decoded_audio =
+                original_decoded_audio.SwitchFormatTo(new_sample_type,
+                                                      new_storage_type);
 
-            EXPECT_FALSE(new_decoded_audio->is_end_of_stream());
-            EXPECT_EQ(new_decoded_audio->channels(),
-                      original_decoded_audio->channels());
-            EXPECT_EQ(new_decoded_audio->timestamp(),
-                      original_decoded_audio->timestamp());
-            EXPECT_EQ(new_decoded_audio->frames(),
-                      original_decoded_audio->frames());
+            EXPECT_FALSE(new_decoded_audio.is_end_of_stream());
+            EXPECT_EQ(new_decoded_audio.channels(),
+                      original_decoded_audio.channels());
+            EXPECT_EQ(new_decoded_audio.timestamp(),
+                      original_decoded_audio.timestamp());
+            EXPECT_EQ(new_decoded_audio.frames(),
+                      original_decoded_audio.frames());
             EXPECT_TRUE(
-                new_decoded_audio->IsFormat(new_sample_type, new_storage_type));
+                new_decoded_audio.IsFormat(new_sample_type, new_storage_type));
 
             ASSERT_NO_FATAL_FAILURE(Verify(new_decoded_audio));
           }
@@ -354,73 +350,69 @@ TEST(DecodedAudioTest, SwitchFormatTo) {
 
 TEST(DecodedAudioTest, Clone) {
   for (auto sample_type : kSampleTypes) {
-    scoped_refptr<DecodedAudio> decoded_audio(new DecodedAudio(
-        kChannels, sample_type, kSbMediaAudioFrameStorageTypeInterleaved,
-        kTimestampUsec, kSizeInBytes));
+    DecodedAudio decoded_audio(kChannels, sample_type,
+                               kSbMediaAudioFrameStorageTypeInterleaved,
+                               kTimestampUsec, kSizeInBytes);
     Fill(&decoded_audio);
-    auto copy = decoded_audio->Clone();
-    ASSERT_EQ(*copy, *decoded_audio);
-    ASSERT_GT(decoded_audio->size_in_bytes(), 0);
-    decoded_audio->data()[0] = ~decoded_audio->data()[0];
-    ASSERT_NE(*copy, *decoded_audio);
+    auto copy = decoded_audio.CloneForTesting();
+    ASSERT_EQ(copy, decoded_audio);
+    ASSERT_GT(decoded_audio.size_in_bytes(), 0);
+    decoded_audio.data()[0] = ~decoded_audio.data()[0];
+    ASSERT_NE(copy, decoded_audio);
   }
 }
 
 class DecodedAudioNeonTest : public ::testing::Test {
  protected:
-  scoped_refptr<DecodedAudio> CreateInt16PlanarRamp(int total_samples) {
+  DecodedAudio CreateInt16PlanarRamp(int total_samples) {
     int size_in_bytes = total_samples * sizeof(int16_t);
-    auto base = make_scoped_refptr<DecodedAudio>(
-        kChannels, kSbMediaAudioSampleTypeInt16Deprecated,
-        kSbMediaAudioFrameStorageTypePlanar, kTimestampUsec, size_in_bytes);
-    int16_t* data = base->data_as_int16();
+    DecodedAudio base(kChannels, kSbMediaAudioSampleTypeInt16Deprecated,
+                      kSbMediaAudioFrameStorageTypePlanar, kTimestampUsec,
+                      size_in_bytes);
+    int16_t* data = base.data_as_int16();
     for (int i = 0; i < total_samples; ++i) {
       data[i] = static_cast<int16_t>(i - 32768);
     }
     return base;
   }
 
-  scoped_refptr<DecodedAudio> CreateFloat32InterleavedRamp(int total_samples) {
+  DecodedAudio CreateFloat32InterleavedRamp(int total_samples) {
     int size_in_bytes = total_samples * sizeof(float);
-    auto base = make_scoped_refptr<DecodedAudio>(
-        kChannels, kSbMediaAudioSampleTypeFloat32,
-        kSbMediaAudioFrameStorageTypeInterleaved, kTimestampUsec,
-        size_in_bytes);
-    float* data = base->data_as_float32();
+    DecodedAudio base(kChannels, kSbMediaAudioSampleTypeFloat32,
+                      kSbMediaAudioFrameStorageTypeInterleaved, kTimestampUsec,
+                      size_in_bytes);
+    float* data = base.data_as_float32();
     for (int i = 0; i < total_samples; ++i) {
       data[i] = -2.0f + 4.0f * (static_cast<float>(i) / total_samples);
     }
     return base;
   }
 
-  void VerifyContent(scoped_refptr<DecodedAudio> ref,
-                     scoped_refptr<DecodedAudio> simd) {
-    ASSERT_NE(ref, nullptr);
-    ASSERT_NE(simd, nullptr);
-    ASSERT_EQ(ref->size_in_bytes(), simd->size_in_bytes());
-    if (ref->sample_type() == kSbMediaAudioSampleTypeFloat32) {
-      const float* ref_data = ref->data_as_float32();
-      const float* simd_data = simd->data_as_float32();
-      int num_floats = ref->size_in_bytes() / sizeof(float);
+  void VerifyContent(const DecodedAudio& ref, const DecodedAudio& simd) {
+    ASSERT_EQ(ref.size_in_bytes(), simd.size_in_bytes());
+    if (ref.sample_type() == kSbMediaAudioSampleTypeFloat32) {
+      const float* ref_data = ref.data_as_float32();
+      const float* simd_data = simd.data_as_float32();
+      int num_floats = ref.size_in_bytes() / sizeof(float);
       for (int i = 0; i < num_floats; ++i) {
         ASSERT_FLOAT_EQ(ref_data[i], simd_data[i]) << "Mismatch at index " << i;
       }
     } else {
-      const int16_t* ref_data = ref->data_as_int16();
-      const int16_t* simd_data = simd->data_as_int16();
-      int num_ints = ref->size_in_bytes() / sizeof(int16_t);
+      const int16_t* ref_data = ref.data_as_int16();
+      const int16_t* simd_data = simd.data_as_int16();
+      int num_ints = ref.size_in_bytes() / sizeof(int16_t);
       for (int i = 0; i < num_ints; ++i) {
         ASSERT_EQ(ref_data[i], simd_data[i]) << "Mismatch at index " << i;
       }
     }
   }
 
-  void VerifySwitchFormat(scoped_refptr<DecodedAudio> base_audio,
+  void VerifySwitchFormat(const DecodedAudio& base_audio,
                           SbMediaAudioSampleType target_sample_type,
                           SbMediaAudioFrameStorageType target_storage_type) {
-    scoped_refptr<DecodedAudio> ref = base_audio->SwitchFormatTo(
+    DecodedAudio ref = base_audio.SwitchFormatTo(
         target_sample_type, target_storage_type, /*force_simd=*/false);
-    scoped_refptr<DecodedAudio> simd = base_audio->SwitchFormatTo(
+    DecodedAudio simd = base_audio.SwitchFormatTo(
         target_sample_type, target_storage_type, /*force_simd=*/true);
     VerifyContent(ref, simd);
   }
@@ -456,7 +448,7 @@ TEST_F(DecodedAudioNeonTest, SwitchFormatTo_NeonSimdExhaustive) {
                      kSbMediaAudioFrameStorageTypeInterleaved);
 
   // Test Case 6: Int16 Interleaved -> Int16 Planar
-  auto int16_interleaved = int16_planar_base->SwitchFormatTo(
+  auto int16_interleaved = int16_planar_base.SwitchFormatTo(
       kSbMediaAudioSampleTypeInt16Deprecated,
       kSbMediaAudioFrameStorageTypeInterleaved, /*force_simd=*/false);
   VerifySwitchFormat(int16_interleaved, kSbMediaAudioSampleTypeInt16Deprecated,
@@ -467,7 +459,7 @@ TEST_F(DecodedAudioNeonTest, SwitchFormatTo_NeonSimdExhaustive) {
                      kSbMediaAudioFrameStorageTypePlanar);
 
   // Test Case 8: Float32 Planar -> Float32 Interleaved
-  auto float_planar = float_interleaved_base->SwitchFormatTo(
+  auto float_planar = float_interleaved_base.SwitchFormatTo(
       kSbMediaAudioSampleTypeFloat32, kSbMediaAudioFrameStorageTypePlanar,
       /*force_simd=*/false);
   VerifySwitchFormat(float_planar, kSbMediaAudioSampleTypeFloat32,
@@ -499,7 +491,7 @@ TEST_F(DecodedAudioNeonTest, SwitchFormatTo_NeonSimdUnaligned) {
                      kSbMediaAudioFrameStorageTypeInterleaved);
 
   // Int16 Interleaved -> Int16 Planar
-  auto int16_interleaved = int16_planar_base->SwitchFormatTo(
+  auto int16_interleaved = int16_planar_base.SwitchFormatTo(
       kSbMediaAudioSampleTypeInt16Deprecated,
       kSbMediaAudioFrameStorageTypeInterleaved, /*force_simd=*/false);
   VerifySwitchFormat(int16_interleaved, kSbMediaAudioSampleTypeInt16Deprecated,
@@ -510,7 +502,7 @@ TEST_F(DecodedAudioNeonTest, SwitchFormatTo_NeonSimdUnaligned) {
                      kSbMediaAudioFrameStorageTypePlanar);
 
   // Float32 Planar -> Float32 Interleaved
-  auto float_planar = float_interleaved_base->SwitchFormatTo(
+  auto float_planar = float_interleaved_base.SwitchFormatTo(
       kSbMediaAudioSampleTypeFloat32, kSbMediaAudioFrameStorageTypePlanar,
       /*force_simd=*/false);
   VerifySwitchFormat(float_planar, kSbMediaAudioSampleTypeFloat32,

--- a/starboard/shared/starboard/player/filter/adaptive_audio_decoder_internal.cc
+++ b/starboard/shared/starboard/player/filter/adaptive_audio_decoder_internal.cc
@@ -143,17 +143,20 @@ void AdaptiveAudioDecoder::WriteEndOfStream() {
   if (first_input_written_) {
     audio_decoder_->WriteEndOfStream();
   } else {
-    decoded_audios_.push(new DecodedAudio);
+    decoded_audios_.push(DecodedAudio());
     Schedule(output_cb_);
   }
 }
 
-scoped_refptr<DecodedAudio> AdaptiveAudioDecoder::Read(
+std::optional<DecodedAudio> AdaptiveAudioDecoder::Read(
     int* samples_per_second) {
   SB_CHECK(BelongsToCurrentThread());
   SB_DCHECK(!decoded_audios_.empty());
+  if (decoded_audios_.empty()) {
+    return std::nullopt;
+  }
 
-  scoped_refptr<DecodedAudio> ret = decoded_audios_.front();
+  std::optional<DecodedAudio> ret = std::move(decoded_audios_.front());
   decoded_audios_.pop();
 
   SB_DCHECK(ret->is_end_of_stream() ||
@@ -221,8 +224,10 @@ void AdaptiveAudioDecoder::OnDecoderOutput() {
   SB_DCHECK(output_cb_);
 
   int decoded_sample_rate;
-  scoped_refptr<DecodedAudio> decoded_audio =
+  std::optional<DecodedAudio> decoded_audio =
       audio_decoder_->Read(&decoded_sample_rate);
+
+  SB_DCHECK(decoded_audio.has_value());
 
   if (!decoded_audio->is_end_of_stream() && !decoded_audio->frames()) {
     // Empty output doesn't need further process.
@@ -244,13 +249,13 @@ void AdaptiveAudioDecoder::OnDecoderOutput() {
   if (decoded_audio->is_end_of_stream()) {
     // Flush resampler.
     if (resampler_) {
-      scoped_refptr<DecodedAudio> resampler_output =
+      std::optional<DecodedAudio> resampler_output =
           resampler_->WriteEndOfStream();
       if (resampler_output && resampler_output->size_in_bytes() > 0) {
         if (channel_mixer_) {
-          resampler_output = channel_mixer_->Mix(resampler_output);
+          resampler_output = channel_mixer_->Mix(std::move(*resampler_output));
         }
-        decoded_audios_.push(resampler_output);
+        decoded_audios_.push(std::move(*resampler_output));
         Schedule(output_cb_);
       }
     }
@@ -262,7 +267,7 @@ void AdaptiveAudioDecoder::OnDecoderOutput() {
       Decode(input_buffers, ResetAndReturn(&pending_consumed_cb_));
     } else {
       SB_DCHECK(stream_ended_);
-      decoded_audios_.push(decoded_audio);
+      decoded_audios_.push(std::move(*decoded_audio));
       Schedule(output_cb_);
     }
     return;
@@ -291,7 +296,7 @@ void AdaptiveAudioDecoder::OnDecoderOutput() {
     }
   }
   if (resampler_) {
-    decoded_audio = resampler_->Resample(decoded_audio);
+    decoded_audio = resampler_->Resample(std::move(*decoded_audio));
   } else {
     // If |resampler_| is NULL, |output_samples_per_second_| should be the same
     // as |decoded_sample_rate|.
@@ -299,9 +304,9 @@ void AdaptiveAudioDecoder::OnDecoderOutput() {
   }
   if (decoded_audio && decoded_audio->size_in_bytes() > 0) {
     if (channel_mixer_) {
-      decoded_audio = channel_mixer_->Mix(decoded_audio);
+      decoded_audio = channel_mixer_->Mix(std::move(*decoded_audio));
     }
-    decoded_audios_.push(std::move(decoded_audio));
+    decoded_audios_.push(std::move(*decoded_audio));
     Schedule(output_cb_);
   }
 }

--- a/starboard/shared/starboard/player/filter/adaptive_audio_decoder_internal.h
+++ b/starboard/shared/starboard/player/filter/adaptive_audio_decoder_internal.h
@@ -16,9 +16,9 @@
 #define STARBOARD_SHARED_STARBOARD_PLAYER_FILTER_ADAPTIVE_AUDIO_DECODER_INTERNAL_H_
 
 #include <memory>
+#include <optional>
 #include <queue>
 
-#include "starboard/common/ref_counted.h"
 #include "starboard/media.h"
 #include "starboard/shared/internal_only.h"
 #include "starboard/shared/starboard/media/media_util.h"
@@ -61,7 +61,7 @@ class AdaptiveAudioDecoder : public AudioDecoder, private JobQueue::JobOwner {
   void Decode(const InputBuffers& input_buffers,
               const ConsumedCB& consumed_cb) override;
   void WriteEndOfStream() override;
-  scoped_refptr<DecodedAudio> Read(int* samples_per_second) override;
+  std::optional<DecodedAudio> Read(int* samples_per_second) override;
   void Reset() override;
 
  private:
@@ -88,7 +88,7 @@ class AdaptiveAudioDecoder : public AudioDecoder, private JobQueue::JobOwner {
   std::unique_ptr<AudioChannelLayoutMixer> channel_mixer_;
   InputBuffers pending_input_buffers_;
   ConsumedCB pending_consumed_cb_;
-  std::queue<scoped_refptr<DecodedAudio>> decoded_audios_;
+  std::queue<DecodedAudio> decoded_audios_;
   bool flushing_ = false;
   bool stream_ended_ = false;
   bool first_output_received_ = false;

--- a/starboard/shared/starboard/player/filter/audio_channel_layout_mixer.h
+++ b/starboard/shared/starboard/player/filter/audio_channel_layout_mixer.h
@@ -18,7 +18,6 @@
 #include <memory>
 #include <vector>
 
-#include "starboard/common/ref_counted.h"
 #include "starboard/media.h"
 #include "starboard/shared/internal_only.h"
 #include "starboard/shared/starboard/player/decoded_audio_internal.h"
@@ -29,8 +28,7 @@ class AudioChannelLayoutMixer {
  public:
   virtual ~AudioChannelLayoutMixer() {}
 
-  virtual scoped_refptr<DecodedAudio> Mix(
-      const scoped_refptr<DecodedAudio>& audio_data) = 0;
+  virtual DecodedAudio Mix(DecodedAudio audio_data) = 0;
 
   static std::unique_ptr<AudioChannelLayoutMixer> Create(
       SbMediaAudioSampleType sample_type,

--- a/starboard/shared/starboard/player/filter/audio_channel_layout_mixer_impl.cc
+++ b/starboard/shared/starboard/player/filter/audio_channel_layout_mixer_impl.cc
@@ -163,40 +163,38 @@ const float kFivePointOneToQuadMatrix[] = {
 // return |aux_buffer| instead.  Note that |aux_buffer| should be large enough
 // to hold samples from all channels of the frame.
 template <typename SampleType>
-const SampleType* GetInterleavedSamplesOfFrame(
-    const scoped_refptr<DecodedAudio>& input,
-    int frame_index,
-    SampleType* aux_buffer) {
+const SampleType* GetInterleavedSamplesOfFrame(const DecodedAudio& input,
+                                               int frame_index,
+                                               SampleType* aux_buffer) {
   const SampleType* input_buffer =
-      reinterpret_cast<const SampleType*>(input->data());
-  if (input->storage_type() == kSbMediaAudioFrameStorageTypeInterleaved) {
-    return input_buffer + frame_index * input->channels();
+      reinterpret_cast<const SampleType*>(input.data());
+  if (input.storage_type() == kSbMediaAudioFrameStorageTypeInterleaved) {
+    return input_buffer + frame_index * input.channels();
   }
-  SB_DCHECK_EQ(input->storage_type(), kSbMediaAudioFrameStorageTypePlanar);
-  for (int channel_index = 0; channel_index < input->channels();
+  SB_DCHECK_EQ(input.storage_type(), kSbMediaAudioFrameStorageTypePlanar);
+  for (int channel_index = 0; channel_index < input.channels();
        channel_index++) {
     aux_buffer[channel_index] =
-        input_buffer[channel_index * input->frames() + frame_index];
+        input_buffer[channel_index * input.frames() + frame_index];
   }
   return aux_buffer;
 }
 
 template <typename SampleType>
 void StoreInterleavedSamplesOfFrame(const SampleType* samples,
-                                    scoped_refptr<DecodedAudio>* destination,
+                                    DecodedAudio* destination,
                                     int frame_index) {
-  SampleType* dest_buffer =
-      reinterpret_cast<SampleType*>((*destination)->data());
-  for (int channel_index = 0; channel_index < (*destination)->channels();
+  SampleType* dest_buffer = reinterpret_cast<SampleType*>(destination->data());
+  for (int channel_index = 0; channel_index < destination->channels();
        channel_index++) {
-    if ((*destination)->storage_type() ==
+    if (destination->storage_type() ==
         kSbMediaAudioFrameStorageTypeInterleaved) {
-      dest_buffer[frame_index * (*destination)->channels() + channel_index] =
+      dest_buffer[frame_index * destination->channels() + channel_index] =
           samples[channel_index];
     } else {
-      SB_DCHECK_EQ((*destination)->storage_type(),
+      SB_DCHECK_EQ(destination->storage_type(),
                    kSbMediaAudioFrameStorageTypePlanar);
-      dest_buffer[channel_index * (*destination)->frames() + frame_index] =
+      dest_buffer[channel_index * destination->frames() + frame_index] =
           samples[channel_index];
     }
   }
@@ -248,16 +246,13 @@ class AudioChannelLayoutMixerImpl : public AudioChannelLayoutMixer {
                               SbMediaAudioFrameStorageType storage_type,
                               int output_channels);
 
-  scoped_refptr<DecodedAudio> Mix(
-      const scoped_refptr<DecodedAudio>& input) override;
+  DecodedAudio Mix(DecodedAudio input) override;
 
  private:
   template <typename SampleType>
-  scoped_refptr<DecodedAudio> Mix(const scoped_refptr<DecodedAudio>& input,
-                                  const float* matrix);
+  DecodedAudio Mix(const DecodedAudio& input, const float* matrix);
 
-  scoped_refptr<DecodedAudio> MixMonoToStereoOptimized(
-      const scoped_refptr<DecodedAudio>& input);
+  DecodedAudio MixMonoToStereoOptimized(const DecodedAudio& input);
 
   SbMediaAudioSampleType sample_type_;
   SbMediaAudioFrameStorageType storage_type_;
@@ -272,21 +267,20 @@ AudioChannelLayoutMixerImpl::AudioChannelLayoutMixerImpl(
       storage_type_(storage_type),
       output_channels_(output_channels) {}
 
-scoped_refptr<DecodedAudio> AudioChannelLayoutMixerImpl::Mix(
-    const scoped_refptr<DecodedAudio>& input) {
-  SB_DCHECK_EQ(input->sample_type(), sample_type_);
-  SB_DCHECK_EQ(input->storage_type(), storage_type_);
+DecodedAudio AudioChannelLayoutMixerImpl::Mix(DecodedAudio input) {
+  SB_DCHECK_EQ(input.sample_type(), sample_type_);
+  SB_DCHECK_EQ(input.storage_type(), storage_type_);
 
-  if (input->channels() == output_channels_) {
+  if (input.channels() == output_channels_) {
     return input;
   }
 
-  if (input->channels() == 1 && output_channels_ == 2) {
+  if (input.channels() == 1 && output_channels_ == 2) {
     return MixMonoToStereoOptimized(input);
   }
 
   const float* matrix = nullptr;
-  if (input->channels() == 1) {
+  if (input.channels() == 1) {
     if (output_channels_ == 2) {
       matrix = kMonoToStereoMatrix;
     } else if (output_channels_ == 4) {
@@ -294,7 +288,7 @@ scoped_refptr<DecodedAudio> AudioChannelLayoutMixerImpl::Mix(
     } else if (output_channels_ == 6) {
       matrix = kMonoToFivePointOneMatrix;
     }
-  } else if (input->channels() == 2) {
+  } else if (input.channels() == 2) {
     if (output_channels_ == 1) {
       matrix = kStereoToMonoMatrix;
     } else if (output_channels_ == 4) {
@@ -302,7 +296,7 @@ scoped_refptr<DecodedAudio> AudioChannelLayoutMixerImpl::Mix(
     } else if (output_channels_ == 6) {
       matrix = kStereoToFivePointOneMatrix;
     }
-  } else if (input->channels() == 4) {
+  } else if (input.channels() == 4) {
     if (output_channels_ == 1) {
       matrix = kQuadToMonoMatrix;
     } else if (output_channels_ == 2) {
@@ -310,7 +304,7 @@ scoped_refptr<DecodedAudio> AudioChannelLayoutMixerImpl::Mix(
     } else if (output_channels_ == 6) {
       matrix = kQuadToFivePointOneMatrix;
     }
-  } else if (input->channels() == 6) {
+  } else if (input.channels() == 6) {
     if (output_channels_ == 1) {
       matrix = kFivePointOneToMonoMatrix;
     } else if (output_channels_ == 2) {
@@ -321,9 +315,9 @@ scoped_refptr<DecodedAudio> AudioChannelLayoutMixerImpl::Mix(
   }
 
   if (!matrix) {
-    SB_NOTREACHED() << "Mixing " << input->channels() << " channels to "
+    SB_NOTREACHED() << "Mixing " << input.channels() << " channels to "
                     << output_channels_ << " channels is not supported.";
-    return scoped_refptr<DecodedAudio>();
+    return DecodedAudio();
   }
 
   if (sample_type_ == kSbMediaAudioSampleTypeInt16Deprecated) {
@@ -334,39 +328,36 @@ scoped_refptr<DecodedAudio> AudioChannelLayoutMixerImpl::Mix(
 }
 
 template <typename SampleType>
-scoped_refptr<DecodedAudio> AudioChannelLayoutMixerImpl::Mix(
-    const scoped_refptr<DecodedAudio>& input,
-    const float* matrix) {
-  size_t frames = input->frames();
-  scoped_refptr<DecodedAudio> output(new DecodedAudio(
-      output_channels_, sample_type_, storage_type_, input->timestamp(),
-      frames * output_channels_ * GetBytesPerSample(sample_type_)));
+DecodedAudio AudioChannelLayoutMixerImpl::Mix(const DecodedAudio& input,
+                                              const float* matrix) {
+  size_t frames = input.frames();
+  DecodedAudio output(
+      output_channels_, sample_type_, storage_type_, input.timestamp(),
+      frames * output_channels_ * GetBytesPerSample(sample_type_));
   SampleType aux_buffer[8];
   SampleType output_buffer[8];
   for (size_t frame_index = 0; frame_index < frames; frame_index++) {
     const SampleType* interleavedSamplesOfFrame =
         GetInterleavedSamplesOfFrame(input, frame_index, aux_buffer);
-    MixFrameWithMatrix(interleavedSamplesOfFrame, input->channels(), matrix,
+    MixFrameWithMatrix(interleavedSamplesOfFrame, input.channels(), matrix,
                        output_buffer, output_channels_);
     StoreInterleavedSamplesOfFrame(output_buffer, &output, frame_index);
   }
   return output;
 }
 
-scoped_refptr<DecodedAudio>
-AudioChannelLayoutMixerImpl::MixMonoToStereoOptimized(
-    const scoped_refptr<DecodedAudio>& input) {
+DecodedAudio AudioChannelLayoutMixerImpl::MixMonoToStereoOptimized(
+    const DecodedAudio& input) {
   SB_DCHECK_EQ(output_channels_, 2);
-  SB_DCHECK_EQ(input->channels(), 1);
+  SB_DCHECK_EQ(input.channels(), 1);
 
-  scoped_refptr<DecodedAudio> output(
-      new DecodedAudio(output_channels_, sample_type_, storage_type_,
-                       input->timestamp(), input->size_in_bytes() * 2));
+  DecodedAudio output(output_channels_, sample_type_, storage_type_,
+                      input.timestamp(), input.size_in_bytes() * 2);
   if (storage_type_ == kSbMediaAudioFrameStorageTypeInterleaved) {
-    size_t frames_left = input->frames();
+    size_t frames_left = input.frames();
     size_t bytes_per_sample = GetBytesPerSample(sample_type_);
-    const uint8_t* src_buffer_ptr = input->data();
-    uint8_t* dest_buffer_ptr = output->data();
+    const uint8_t* src_buffer_ptr = input.data();
+    uint8_t* dest_buffer_ptr = output.data();
     while (frames_left > 0) {
       memcpy(dest_buffer_ptr, src_buffer_ptr, bytes_per_sample);
       dest_buffer_ptr += bytes_per_sample;
@@ -377,9 +368,9 @@ AudioChannelLayoutMixerImpl::MixMonoToStereoOptimized(
     }
   } else {
     SB_DCHECK_EQ(storage_type_, kSbMediaAudioFrameStorageTypePlanar);
-    memcpy(output->data(), input->data(), input->size_in_bytes());
-    memcpy(output->data() + input->size_in_bytes(), input->data(),
-           input->size_in_bytes());
+    memcpy(output.data(), input.data(), input.size_in_bytes());
+    memcpy(output.data() + input.size_in_bytes(), input.data(),
+           input.size_in_bytes());
   }
   return output;
 }

--- a/starboard/shared/starboard/player/filter/audio_decoder_internal.h
+++ b/starboard/shared/starboard/player/filter/audio_decoder_internal.h
@@ -16,8 +16,8 @@
 #define STARBOARD_SHARED_STARBOARD_PLAYER_FILTER_AUDIO_DECODER_INTERNAL_H_
 
 #include <functional>
+#include <optional>
 
-#include "starboard/common/ref_counted.h"
 #include "starboard/media.h"
 #include "starboard/shared/internal_only.h"
 #include "starboard/shared/starboard/player/decoded_audio_internal.h"
@@ -64,7 +64,7 @@ class AudioDecoder {
   // combine multiple decoded audio access units into one.  The implementation
   // has to ensure that the particular resampler can handle such combined access
   // units as input.
-  virtual scoped_refptr<DecodedAudio> Read(int* samples_per_second) = 0;
+  virtual std::optional<DecodedAudio> Read(int* samples_per_second) = 0;
 
   // Clear any cached buffer of the codec and reset the state of the codec. This
   // function will be called during seek to ensure that the left over data from

--- a/starboard/shared/starboard/player/filter/audio_frame_discarder.cc
+++ b/starboard/shared/starboard/player/filter/audio_frame_discarder.cc
@@ -39,11 +39,10 @@ void AudioFrameDiscarder::OnInputBuffers(const InputBuffers& input_buffers) {
 
 void AudioFrameDiscarder::AdjustForDiscardedDurations(
     int sample_rate,
-    scoped_refptr<DecodedAudio>* decoded_audio) {
-  if (!decoded_audio || !*decoded_audio) {
+    DecodedAudio* decoded_audio) {
+  if (!decoded_audio) {
     SB_LOG(ERROR) << "No input buffer to adjust.";
     SB_DCHECK(decoded_audio);
-    SB_DCHECK(*decoded_audio);
     return;
   }
 
@@ -67,19 +66,18 @@ void AudioFrameDiscarder::AdjustForDiscardedDurations(
   // outputs have different timestamps than inputs, discarded durations will be
   // ignored.
   const int64_t kTimestampOffsetUsec = 10;
-  if (std::abs(input_info.timestamp - (*decoded_audio)->timestamp()) >
+  if (std::abs(input_info.timestamp - decoded_audio->timestamp()) >
       kTimestampOffsetUsec) {
     SB_LOG(WARNING) << "Inconsistent timestamps between InputBuffer (@"
                     << input_info.timestamp << ") and DecodedAudio (@"
-                    << (*decoded_audio)->timestamp() << ").";
+                    << decoded_audio->timestamp() << ").";
     return;
   }
 
-  (*decoded_audio)
-      ->AdjustForDiscardedDurations(sample_rate,
-                                    input_info.discarded_duration_from_front,
-                                    input_info.discarded_duration_from_back);
-  // `(*decoded_audio)->frames()` might be 0 here.  We don't set it to nullptr
+  decoded_audio->AdjustForDiscardedDurations(
+      sample_rate, input_info.discarded_duration_from_front,
+      input_info.discarded_duration_from_back);
+  // `decoded_audio->frames()` might be 0 here.  We don't set it to nullptr
   // in this case so the DecodedAudio instance is always valid (but might be
   // empty).
 }

--- a/starboard/shared/starboard/player/filter/audio_frame_discarder.h
+++ b/starboard/shared/starboard/player/filter/audio_frame_discarder.h
@@ -35,7 +35,7 @@ class AudioFrameDiscarder {
  public:
   void OnInputBuffers(const InputBuffers& input_buffers);
   void AdjustForDiscardedDurations(int sample_rate,
-                                   scoped_refptr<DecodedAudio>* decoded_audio);
+                                   DecodedAudio* decoded_audio);
   void OnDecodedAudioEndOfStream();
 
   void Reset();

--- a/starboard/shared/starboard/player/filter/audio_renderer_pcm_internal.cc
+++ b/starboard/shared/starboard/player/filter/audio_renderer_pcm_internal.cc
@@ -35,16 +35,15 @@ namespace {
 class IdentityAudioResampler : public AudioResampler {
  public:
   IdentityAudioResampler() : eos_reached_(false) {}
-  scoped_refptr<DecodedAudio> Resample(
-      scoped_refptr<DecodedAudio> audio_data) override {
+  std::optional<DecodedAudio> Resample(DecodedAudio audio_data) override {
     SB_DCHECK(!eos_reached_);
 
     return audio_data;
   }
-  scoped_refptr<DecodedAudio> WriteEndOfStream() override {
+  std::optional<DecodedAudio> WriteEndOfStream() override {
     SB_DCHECK(!eos_reached_);
     eos_reached_ = true;
-    return new DecodedAudio();
+    return std::nullopt;
   }
 
  private:
@@ -661,11 +660,11 @@ void AudioRendererPcm::ProcessAudioData() {
       return;
     }
 
-    scoped_refptr<DecodedAudio> resampled_audio;
+    std::optional<DecodedAudio> resampled_audio;
     int decoded_audio_sample_rate;
-    scoped_refptr<DecodedAudio> decoded_audio =
+    std::optional<DecodedAudio> decoded_audio =
         decoder_->Read(&decoded_audio_sample_rate);
-    SB_DCHECK(decoded_audio);
+    SB_DCHECK(decoded_audio.has_value());
     if (!audio_renderer_sink_->HasStarted()) {
       if (!decoded_audio->is_end_of_stream()) {
         decoded_audio->AdjustForSeekTime(decoded_audio_sample_rate,
@@ -699,7 +698,7 @@ void AudioRendererPcm::ProcessAudioData() {
         continue;
       }
 
-      resampled_audio = resampler_->Resample(decoded_audio);
+      resampled_audio = resampler_->Resample(std::move(*decoded_audio));
     }
 
     if (resampled_audio && resampled_audio->size_in_bytes() > 0) {
@@ -712,7 +711,7 @@ void AudioRendererPcm::ProcessAudioData() {
             kSbMediaAudioSampleTypeFloat32,
             kSbMediaAudioFrameStorageTypeInterleaved);
       }
-      time_stretcher_.EnqueueBuffer(resampled_audio);
+      time_stretcher_.EnqueueBuffer(std::move(*resampled_audio));
     }
 
     // Loop until no audio is appended, i.e. AppendAudioToFrameBuffer() returns
@@ -773,28 +772,27 @@ bool AudioRendererPcm::AppendAudioToFrameBuffer(bool* is_frame_buffer_full) {
     adjusted_playback_rate = 1.0;
   }
 
-  scoped_refptr<DecodedAudio> decoded_audio = time_stretcher_.Read(
+  DecodedAudio decoded_audio = time_stretcher_.Read(
       max_cached_frames_ - frames_in_buffer, adjusted_playback_rate);
-  SB_DCHECK(decoded_audio);
 
   {
     std::lock_guard lock(mutex_);
-    if (decoded_audio->frames() == 0 && eos_state_ == kEOSDecoded) {
+    if (decoded_audio.frames() == 0 && eos_state_ == kEOSDecoded) {
       eos_state_ = kEOSSentToSink;
     }
-    audio_frame_tracker_.AddFrames(decoded_audio->frames(),
+    audio_frame_tracker_.AddFrames(decoded_audio.frames(),
                                    adjusted_playback_rate);
   }
 
   // |time_stretcher_| only support kSbMediaAudioSampleTypeFloat32 and
   // kSbMediaAudioFrameStorageTypeInterleaved.
-  if (!decoded_audio->IsFormat(sink_sample_type_,
-                               kSbMediaAudioFrameStorageTypeInterleaved)) {
-    decoded_audio = decoded_audio->SwitchFormatTo(
+  if (!decoded_audio.IsFormat(sink_sample_type_,
+                              kSbMediaAudioFrameStorageTypeInterleaved)) {
+    decoded_audio = decoded_audio.SwitchFormatTo(
         sink_sample_type_, kSbMediaAudioFrameStorageTypeInterleaved);
   }
-  const uint8_t* source_buffer = decoded_audio->data();
-  int frames_to_append = decoded_audio->frames();
+  const uint8_t* source_buffer = decoded_audio.data();
+  int frames_to_append = decoded_audio.frames();
   int frames_appended = 0;
 
   if (frames_to_append > max_cached_frames_ - offset_to_append) {

--- a/starboard/shared/starboard/player/filter/audio_resampler.h
+++ b/starboard/shared/starboard/player/filter/audio_resampler.h
@@ -16,8 +16,8 @@
 #define STARBOARD_SHARED_STARBOARD_PLAYER_FILTER_AUDIO_RESAMPLER_H_
 
 #include <memory>
+#include <optional>
 
-#include "starboard/common/ref_counted.h"
 #include "starboard/media.h"
 #include "starboard/shared/internal_only.h"
 #include "starboard/shared/starboard/player/decoded_audio_internal.h"
@@ -37,14 +37,13 @@ class AudioResampler {
 
   // Write frames to the AudioResampler.  The format of the frames is determined
   // by the input formats passed to Create().
-  virtual scoped_refptr<DecodedAudio> Resample(
-      scoped_refptr<DecodedAudio> audio_data) = 0;
+  virtual std::optional<DecodedAudio> Resample(DecodedAudio audio_data) = 0;
 
   // Signal that the last audio input frame has been written.  The resampler
   // should allow for reading of any audio data inside its internal cache.  The
   // caller should continue call Read() after calling this function until Read()
   // returns EOS.
-  virtual scoped_refptr<DecodedAudio> WriteEndOfStream() = 0;
+  virtual std::optional<DecodedAudio> WriteEndOfStream() = 0;
 
   // Create an AudioResampler that takes input specified by |source_*| and
   // produce output specified by |destination_*|.  The input and output have to

--- a/starboard/shared/starboard/player/filter/audio_resampler_impl.cc
+++ b/starboard/shared/starboard/player/filter/audio_resampler_impl.cc
@@ -45,10 +45,9 @@ class AudioResamplerImpl : public AudioResampler {
                                    static_cast<double>(destination_sample_rate),
                                channels) {}
 
-  scoped_refptr<DecodedAudio> Resample(
-      scoped_refptr<DecodedAudio> buffer) override;
+  std::optional<DecodedAudio> Resample(DecodedAudio buffer) override;
 
-  scoped_refptr<DecodedAudio> WriteEndOfStream() override;
+  std::optional<DecodedAudio> WriteEndOfStream() override;
 
  private:
   const SbMediaAudioSampleType destination_sample_type_;
@@ -56,7 +55,7 @@ class AudioResamplerImpl : public AudioResampler {
 
   InterleavedSincResampler interleaved_resampler_;
 
-  std::deque<scoped_refptr<DecodedAudio>> audio_inputs_;
+  std::deque<DecodedAudio> audio_inputs_;
 
   size_t frames_to_resample_ = 0;
   size_t frames_resampled_ = 0;
@@ -80,7 +79,7 @@ std::unique_ptr<AudioResampler> AudioResampler::Create(
       destination_sample_rate, channels));
 }
 
-scoped_refptr<DecodedAudio> AudioResamplerImpl::WriteEndOfStream() {
+std::optional<DecodedAudio> AudioResamplerImpl::WriteEndOfStream() {
   double sample_rate_ratio = interleaved_resampler_.GetSampleRateRatio();
   int out_num_of_frames =
       round(frames_to_resample_ / sample_rate_ratio) - frames_outputted_;
@@ -92,73 +91,71 @@ scoped_refptr<DecodedAudio> AudioResamplerImpl::WriteEndOfStream() {
       interleaved_resampler_.QueueBuffer(nullptr, 0);
       int channels = interleaved_resampler_.channels();
       int resampled_audio_size = out_num_of_frames * channels * sizeof(float);
-      scoped_refptr<DecodedAudio> resampled_audio = new DecodedAudio(
-          channels, kSbMediaAudioSampleTypeFloat32,
-          kSbMediaAudioFrameStorageTypeInterleaved,
-          audio_inputs_.front()->timestamp(), resampled_audio_size);
+      DecodedAudio resampled_audio(channels, kSbMediaAudioSampleTypeFloat32,
+                                   kSbMediaAudioFrameStorageTypeInterleaved,
+                                   audio_inputs_.front().timestamp(),
+                                   resampled_audio_size);
 
-      float* dst = reinterpret_cast<float*>(resampled_audio->data());
+      float* dst = reinterpret_cast<float*>(resampled_audio.data());
       interleaved_resampler_.Resample(dst, out_num_of_frames);
 
-      if (!resampled_audio->IsFormat(destination_sample_type_,
-                                     destination_storage_type_)) {
-        resampled_audio = resampled_audio->SwitchFormatTo(
+      if (!resampled_audio.IsFormat(destination_sample_type_,
+                                    destination_storage_type_)) {
+        resampled_audio = resampled_audio.SwitchFormatTo(
             destination_sample_type_, destination_storage_type_);
       }
       return resampled_audio;
     }
   }
 
-  return new DecodedAudio;
+  return std::nullopt;
 }
 
-scoped_refptr<DecodedAudio> AudioResamplerImpl::Resample(
-    scoped_refptr<DecodedAudio> audio_input) {
-  SB_DCHECK_EQ(audio_input->channels(), interleaved_resampler_.channels());
+std::optional<DecodedAudio> AudioResamplerImpl::Resample(
+    DecodedAudio audio_input) {
+  SB_DCHECK_EQ(audio_input.channels(), interleaved_resampler_.channels());
 
   // It does nothing if source sample type is float and source storage type is
   // interleaved.
-  if (!audio_input->IsFormat(kSbMediaAudioSampleTypeFloat32,
-                             kSbMediaAudioFrameStorageTypeInterleaved)) {
+  if (!audio_input.IsFormat(kSbMediaAudioSampleTypeFloat32,
+                            kSbMediaAudioFrameStorageTypeInterleaved)) {
     audio_input =
-        audio_input->SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
-                                    kSbMediaAudioFrameStorageTypeInterleaved);
+        audio_input.SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
+                                   kSbMediaAudioFrameStorageTypeInterleaved);
   }
 
-  audio_inputs_.push_back(audio_input);
-
-  // Enqueue the input.
-  int num_of_input_frames = audio_input->frames();
+  int num_of_input_frames = audio_input.frames();
   frames_to_resample_ += num_of_input_frames;
-  float* input_samples = reinterpret_cast<float*>(audio_input->data());
+
+  audio_inputs_.push_back(std::move(audio_input));
+  float* input_samples = reinterpret_cast<float*>(audio_inputs_.back().data());
   interleaved_resampler_.QueueBuffer(input_samples, num_of_input_frames);
 
   // Check if we have enough frames to output.
-  scoped_refptr<DecodedAudio>& next_audio_to_output = audio_inputs_.front();
+  DecodedAudio& next_audio_to_output = audio_inputs_.front();
   int num_of_output_frames =
       static_cast<int>(
-          ceil((frames_resampled_ + next_audio_to_output->frames()) /
+          ceil((frames_resampled_ + next_audio_to_output.frames()) /
                interleaved_resampler_.GetSampleRateRatio())) -
       frames_outputted_;
-  int channels = next_audio_to_output->channels();
+  int channels = next_audio_to_output.channels();
 
-  scoped_refptr<DecodedAudio> resampled_audio = nullptr;
+  std::optional<DecodedAudio> resampled_audio;
   if (interleaved_resampler_.HasEnoughData(num_of_output_frames)) {
     int output_audio_size = num_of_output_frames * channels * sizeof(float);
-    resampled_audio =
-        new DecodedAudio(channels, kSbMediaAudioSampleTypeFloat32,
-                         kSbMediaAudioFrameStorageTypeInterleaved,
-                         next_audio_to_output->timestamp(), output_audio_size);
-    float* dst = reinterpret_cast<float*>(resampled_audio->data());
+    DecodedAudio output(channels, kSbMediaAudioSampleTypeFloat32,
+                        kSbMediaAudioFrameStorageTypeInterleaved,
+                        next_audio_to_output.timestamp(), output_audio_size);
+    float* dst = reinterpret_cast<float*>(output.data());
     interleaved_resampler_.Resample(dst, num_of_output_frames);
-    frames_resampled_ += next_audio_to_output->frames();
+    frames_resampled_ += next_audio_to_output.frames();
     frames_outputted_ += num_of_output_frames;
 
-    if (!resampled_audio->IsFormat(destination_sample_type_,
-                                   destination_storage_type_)) {
-      resampled_audio = resampled_audio->SwitchFormatTo(
-          destination_sample_type_, destination_storage_type_);
+    if (!output.IsFormat(destination_sample_type_, destination_storage_type_)) {
+      output = output.SwitchFormatTo(destination_sample_type_,
+                                     destination_storage_type_);
     }
+    resampled_audio = std::move(output);
 
     audio_inputs_.pop_front();
   }

--- a/starboard/shared/starboard/player/filter/audio_time_stretcher.cc
+++ b/starboard/shared/starboard/player/filter/audio_time_stretcher.cc
@@ -148,35 +148,35 @@ void AudioTimeStretcher::Initialize(SbMediaAudioSampleType sample_type,
   transition_window_.reset(new float[ola_window_size_ * 2]);
   GetPeriodicHanningWindow(2 * ola_window_size_, transition_window_.get());
 
-  wsola_output_ = new DecodedAudio(
+  wsola_output_ = DecodedAudio(
       channels_, sample_type_, kSbMediaAudioFrameStorageTypeInterleaved, 0,
       (ola_window_size_ + ola_hop_size_) * bytes_per_frame_);
   // Initialize for overlap-and-add of the first block.
-  memset(wsola_output_->data(), 0, wsola_output_->size_in_bytes());
+  memset(wsola_output_.data(), 0, wsola_output_.size_in_bytes());
 
   // Auxiliary containers.
-  optimal_block_ = new DecodedAudio(channels_, sample_type_,
-                                    kSbMediaAudioFrameStorageTypeInterleaved, 0,
-                                    ola_window_size_ * bytes_per_frame_);
-  search_block_ = new DecodedAudio(
+  optimal_block_ = DecodedAudio(channels_, sample_type_,
+                                kSbMediaAudioFrameStorageTypeInterleaved, 0,
+                                ola_window_size_ * bytes_per_frame_);
+  search_block_ = DecodedAudio(
       channels_, sample_type_, kSbMediaAudioFrameStorageTypeInterleaved, 0,
       (num_candidate_blocks_ + (ola_window_size_ - 1)) * bytes_per_frame_);
-  target_block_ = new DecodedAudio(channels_, sample_type_,
-                                   kSbMediaAudioFrameStorageTypeInterleaved, 0,
-                                   ola_window_size_ * bytes_per_frame_);
+  target_block_ = DecodedAudio(channels_, sample_type_,
+                               kSbMediaAudioFrameStorageTypeInterleaved, 0,
+                               ola_window_size_ * bytes_per_frame_);
 }
 
-scoped_refptr<DecodedAudio> AudioTimeStretcher::Read(int requested_frames,
-                                                     double playback_rate) {
+DecodedAudio AudioTimeStretcher::Read(int requested_frames,
+                                      double playback_rate) {
   SB_DCHECK_GT(bytes_per_frame_, 0);
   SB_DCHECK_GE(playback_rate, 0);
 
-  scoped_refptr<DecodedAudio> dest = new DecodedAudio(
-      channels_, sample_type_, kSbMediaAudioFrameStorageTypeInterleaved, 0,
-      requested_frames * bytes_per_frame_);
+  DecodedAudio dest(channels_, sample_type_,
+                    kSbMediaAudioFrameStorageTypeInterleaved, 0,
+                    requested_frames * bytes_per_frame_);
 
   if (playback_rate == 0) {
-    dest->ShrinkTo(0);
+    dest.ShrinkTo(0);
     return dest;
   }
 
@@ -196,7 +196,7 @@ scoped_refptr<DecodedAudio> AudioTimeStretcher::Read(int requested_frames,
     // audio_buffer_.frames()+1.
     int seek_frames = std::min(static_cast<int>(muted_partial_frame_),
                                audio_buffer_.frames());
-    memset(dest->data(), 0, frames_to_render * bytes_per_frame_);
+    memset(dest.data(), 0, frames_to_render * bytes_per_frame_);
     audio_buffer_.SeekFrames(seek_frames);
 
     // Determine the partial frame that remains to be skipped for next call. If
@@ -205,7 +205,7 @@ scoped_refptr<DecodedAudio> AudioTimeStretcher::Read(int requested_frames,
     // another playback rate that mutes, the code will attempt to line up the
     // frames again.
     muted_partial_frame_ -= seek_frames;
-    dest->ShrinkTo(frames_to_render * bytes_per_frame_);
+    dest.ShrinkTo(frames_to_render * bytes_per_frame_);
     return dest;
   }
 
@@ -217,19 +217,19 @@ scoped_refptr<DecodedAudio> AudioTimeStretcher::Read(int requested_frames,
   if (ola_window_size_ <= faster_step && slower_step >= ola_window_size_) {
     const int frames_to_copy =
         std::min(audio_buffer_.frames(), requested_frames);
-    const int frames_read = audio_buffer_.ReadFrames(frames_to_copy, 0, dest);
+    const int frames_read = audio_buffer_.ReadFrames(frames_to_copy, 0, &dest);
     SB_DCHECK_EQ(frames_read, frames_to_copy);
-    dest->ShrinkTo(frames_read * bytes_per_frame_);
+    dest.ShrinkTo(frames_read * bytes_per_frame_);
     return dest;
   }
 
   int rendered_frames = 0;
   do {
     rendered_frames += WriteCompletedFramesTo(
-        requested_frames - rendered_frames, rendered_frames, dest);
+        requested_frames - rendered_frames, rendered_frames, &dest);
   } while (rendered_frames < requested_frames &&
            RunOneWsolaIteration(playback_rate));
-  dest->ShrinkTo(rendered_frames * bytes_per_frame_);
+  dest.ShrinkTo(rendered_frames * bytes_per_frame_);
   return dest;
 }
 
@@ -239,7 +239,7 @@ void AudioTimeStretcher::FlushBuffers() {
   output_time_ = 0.0;
   search_block_index_ = 0;
   target_block_index_ = 0;
-  memset(wsola_output_->data(), 0, wsola_output_->size_in_bytes());
+  memset(wsola_output_.data(), 0, wsola_output_.size_in_bytes());
   num_complete_frames_ = 0;
 
   // Reset |capacity_| so growth triggered by underflows doesn't penalize seek
@@ -247,10 +247,9 @@ void AudioTimeStretcher::FlushBuffers() {
   capacity_ = initial_capacity_;
 }
 
-void AudioTimeStretcher::EnqueueBuffer(
-    const scoped_refptr<DecodedAudio>& audio_data) {
-  SB_DCHECK(!audio_data->is_end_of_stream());
-  audio_buffer_.Append(audio_data);
+void AudioTimeStretcher::EnqueueBuffer(DecodedAudio&& audio_data) {
+  SB_DCHECK(!audio_data.is_end_of_stream());
+  audio_buffer_.Append(std::move(audio_data));
 }
 
 bool AudioTimeStretcher::IsQueueFull() const {
@@ -266,10 +265,10 @@ void AudioTimeStretcher::GetOptimalBlock() {
   const int kExcludeIntervalLengthFrames = 160;
   if (TargetIsWithinSearchRegion()) {
     optimal_index = target_block_index_;
-    PeekAudioWithZeroPrepend(optimal_index, optimal_block_.get());
+    PeekAudioWithZeroPrepend(optimal_index, &optimal_block_);
   } else {
-    PeekAudioWithZeroPrepend(target_block_index_, target_block_.get());
-    PeekAudioWithZeroPrepend(search_block_index_, search_block_.get());
+    PeekAudioWithZeroPrepend(target_block_index_, &target_block_);
+    PeekAudioWithZeroPrepend(search_block_index_, &search_block_);
     int last_optimal =
         target_block_index_ - ola_hop_size_ - search_block_index_;
     Interval exclude_interval =
@@ -278,14 +277,14 @@ void AudioTimeStretcher::GetOptimalBlock() {
 
     // |optimal_index| is in frames and it is relative to the beginning of the
     // |search_block_|.
-    optimal_index = OptimalIndex(search_block_.get(), target_block_.get(),
+    optimal_index = OptimalIndex(&search_block_, &target_block_,
                                  kSbMediaAudioFrameStorageTypeInterleaved,
                                  exclude_interval);
 
     // Translate |index| w.r.t. the beginning of |audio_buffer_| and extract the
     // optimal block.
     optimal_index += search_block_index_;
-    PeekAudioWithZeroPrepend(optimal_index, optimal_block_.get());
+    PeekAudioWithZeroPrepend(optimal_index, &optimal_block_);
 
     // Make a transition from target block to the optimal block if different.
     // Target block has the best continuation to the current output.
@@ -296,9 +295,9 @@ void AudioTimeStretcher::GetOptimalBlock() {
     // where target-block has higher weight close to zero (weight of 1 at index
     // 0) and lower weight close the end.
     for (int k = 0; k < channels_; ++k) {
-      float* ch_opt = reinterpret_cast<float*>(optimal_block_->data()) + k;
+      float* ch_opt = reinterpret_cast<float*>(optimal_block_.data()) + k;
       const float* const ch_target =
-          reinterpret_cast<float*>(target_block_->data()) + k;
+          reinterpret_cast<float*>(target_block_.data()) + k;
       for (int n = 0; n < ola_window_size_; ++n) {
         ch_opt[n * channels_] =
             ch_opt[n * channels_] * transition_window_[n] +
@@ -322,13 +321,13 @@ int AudioTimeStretcher::WriteCompletedFramesTo(int requested_frames,
     return 0;  // There is nothing to read from |wsola_output_|, return.
   }
 
-  memcpy(dest->data() + bytes_per_frame_ * dest_offset, wsola_output_->data(),
+  memcpy(dest->data() + bytes_per_frame_ * dest_offset, wsola_output_.data(),
          rendered_frames * bytes_per_frame_);
 
   // Remove the frames which are read.
-  int frames_to_move = wsola_output_->frames() - rendered_frames;
-  memmove(wsola_output_->data(),
-          wsola_output_->data() + rendered_frames * bytes_per_frame_,
+  int frames_to_move = wsola_output_.frames() - rendered_frames;
+  memmove(wsola_output_.data(),
+          wsola_output_.data() + rendered_frames * bytes_per_frame_,
           frames_to_move * bytes_per_frame_);
   num_complete_frames_ -= rendered_frames;
   return rendered_frames;
@@ -365,8 +364,8 @@ bool AudioTimeStretcher::RunOneWsolaIteration(double playback_rate) {
   // Overlap-and-add.
   for (int k = 0; k < channels_; ++k) {
     const float* const ch_opt_frame =
-        reinterpret_cast<const float*>(optimal_block_->data()) + k;
-    float* ch_output = reinterpret_cast<float*>(wsola_output_->data()) + k +
+        reinterpret_cast<const float*>(optimal_block_.data()) + k;
+    float* ch_output = reinterpret_cast<float*>(wsola_output_.data()) + k +
                        num_complete_frames_ * channels_;
     for (int n = 0; n < ola_hop_size_; ++n) {
       ch_output[n * channels_] =
@@ -376,8 +375,8 @@ bool AudioTimeStretcher::RunOneWsolaIteration(double playback_rate) {
   }
   // Copy the second half to the output.
   const float* const ch_opt_frame =
-      reinterpret_cast<const float*>(optimal_block_->data());
-  float* ch_output = reinterpret_cast<float*>(wsola_output_->data()) +
+      reinterpret_cast<const float*>(optimal_block_.data());
+  float* ch_output = reinterpret_cast<float*>(wsola_output_.data()) +
                      num_complete_frames_ * channels_;
   memcpy(&ch_output[ola_hop_size_ * channels_],
          &ch_opt_frame[ola_hop_size_ * channels_],

--- a/starboard/shared/starboard/player/filter/audio_time_stretcher.h
+++ b/starboard/shared/starboard/player/filter/audio_time_stretcher.h
@@ -36,8 +36,8 @@
 #define STARBOARD_SHARED_STARBOARD_PLAYER_FILTER_AUDIO_TIME_STRETCHER_H_
 
 #include <memory>
+#include <optional>
 
-#include "starboard/common/ref_counted.h"
 #include "starboard/shared/internal_only.h"
 #include "starboard/shared/starboard/player/decoded_audio_internal.h"
 #include "starboard/shared/starboard/player/filter/decoded_audio_queue.h"
@@ -63,14 +63,14 @@ class AudioTimeStretcher {
   // |dest_offset| is the offset in frames for writing into |dest|.
   //
   // Returns the number of frames copied into |dest|.
-  scoped_refptr<DecodedAudio> Read(int requested_frames, double playback_rate);
+  DecodedAudio Read(int requested_frames, double playback_rate);
 
   // Clears |audio_buffer_|.
   void FlushBuffers();
 
   // Enqueues a buffer. It is called from the owner of the algorithm after a
   // read completes.
-  void EnqueueBuffer(const scoped_refptr<DecodedAudio>& audio_data);
+  void EnqueueBuffer(DecodedAudio&& audio_data);
 
   // Returns true if |audio_buffer_| is at or exceeds capacity.
   bool IsQueueFull() const;
@@ -186,7 +186,7 @@ class AudioTimeStretcher {
   // number of requested samples. Furthermore, due to overlap-and-add,
   // the last half-window of the output is incomplete, which is stored in this
   // buffer.
-  scoped_refptr<DecodedAudio> wsola_output_;
+  DecodedAudio wsola_output_;
 
   // Overlap-and-add window.
   std::unique_ptr<float[]> ola_window_;
@@ -200,15 +200,15 @@ class AudioTimeStretcher {
   // Stores the optimal block in every iteration. This is the most
   // similar block to |target_block_| within |search_block_| and it is
   // overlap-and-added to |wsola_output_|.
-  scoped_refptr<DecodedAudio> optimal_block_;
+  DecodedAudio optimal_block_;
 
   // A block of data that search is performed over to find the |optimal_block_|.
-  scoped_refptr<DecodedAudio> search_block_;
+  DecodedAudio search_block_;
 
   // Stores the target block, denoted as |target| above. |search_block_| is
   // searched for a block (|optimal_block_|) that is most similar to
   // |target_block_|.
-  scoped_refptr<DecodedAudio> target_block_;
+  DecodedAudio target_block_;
 
   // The initial and maximum capacity calculated by Initialize().
   int initial_capacity_;

--- a/starboard/shared/starboard/player/filter/decoded_audio_queue.cc
+++ b/starboard/shared/starboard/player/filter/decoded_audio_queue.cc
@@ -38,18 +38,17 @@ void DecodedAudioQueue::Clear() {
   frames_ = 0;
 }
 
-void DecodedAudioQueue::Append(
-    const scoped_refptr<DecodedAudio>& decoded_audio) {
-  SB_DCHECK_EQ(decoded_audio->storage_type(),
+void DecodedAudioQueue::Append(DecodedAudio&& decoded_audio) {
+  SB_DCHECK_EQ(decoded_audio.storage_type(),
                kSbMediaAudioFrameStorageTypeInterleaved);
+  // Update the |frames_| counter since we have added frames.
+  frames_ += decoded_audio.frames();
+  SB_CHECK_GT(frames_, 0);  // make sure it doesn't overflow.
+
   // Add the buffer to the queue. Inserting into deque invalidates all
   // iterators, so point to the first buffer.
-  buffers_.push_back(decoded_audio);
+  buffers_.push_back(std::move(decoded_audio));
   current_buffer_ = buffers_.begin();
-
-  // Update the |frames_| counter since we have added frames.
-  frames_ += decoded_audio->frames();
-  SB_CHECK_GT(frames_, 0);  // make sure it doesn't overflow.
 }
 
 int DecodedAudioQueue::ReadFrames(int frames,
@@ -93,9 +92,9 @@ int DecodedAudioQueue::InternalRead(int frames,
       break;
     }
 
-    scoped_refptr<DecodedAudio> buffer = *current_buffer;
+    const DecodedAudio& buffer = *current_buffer;
 
-    int remaining_frames_in_buffer = buffer->frames() - current_buffer_offset;
+    int remaining_frames_in_buffer = buffer.frames() - current_buffer_offset;
 
     if (frames_to_skip > 0) {
       // If there are frames to skip, do it first. May need to skip into
@@ -111,17 +110,17 @@ int DecodedAudioQueue::InternalRead(int frames,
 
       // if |dest| is NULL, there's no need to copy.
       if (dest) {
-        SB_DCHECK_EQ(buffer->channels(), dest->channels());
+        SB_DCHECK_EQ(buffer.channels(), dest->channels());
         if (dest->sample_type() == kSbMediaAudioSampleTypeFloat32) {
-          const float* source = reinterpret_cast<const float*>(buffer->data()) +
-                                buffer->channels() * current_buffer_offset;
+          const float* source = reinterpret_cast<const float*>(buffer.data()) +
+                                buffer.channels() * current_buffer_offset;
           float* destination = reinterpret_cast<float*>(dest->data()) +
                                dest->channels() * (dest_frame_offset + taken);
           memcpy(destination, source, copied * dest->channels() * 4);
         } else {
           const int16_t* source =
-              reinterpret_cast<const int16_t*>(buffer->data()) +
-              buffer->channels() * current_buffer_offset;
+              reinterpret_cast<const int16_t*>(buffer.data()) +
+              buffer.channels() * current_buffer_offset;
           int16_t* destination = reinterpret_cast<int16_t*>(dest->data()) +
                                  dest->channels() * (dest_frame_offset + taken);
           memcpy(destination, source, copied * dest->channels() * 2);
@@ -138,7 +137,7 @@ int DecodedAudioQueue::InternalRead(int frames,
     }
 
     // Has the buffer has been consumed?
-    if (current_buffer_offset == buffer->frames()) {
+    if (current_buffer_offset == buffer.frames()) {
       // If we are at the last buffer, no more data to be copied, so stop.
       BufferQueue::iterator next = current_buffer + 1;
       if (next == buffers_.end()) {

--- a/starboard/shared/starboard/player/filter/decoded_audio_queue.h
+++ b/starboard/shared/starboard/player/filter/decoded_audio_queue.h
@@ -42,7 +42,7 @@ class DecodedAudioQueue {
   void Clear();
 
   // Appends |decoded_audio| to this queue.
-  void Append(const scoped_refptr<DecodedAudio>& decoded_audio);
+  void Append(DecodedAudio&& decoded_audio);
 
   // Reads a maximum of |frames| frames into |dest| from the current position.
   // Returns the number of frames read. The current position will advance by the
@@ -70,7 +70,7 @@ class DecodedAudioQueue {
 
  private:
   // Definition of the buffer queue.
-  using BufferQueue = std::deque<scoped_refptr<DecodedAudio>>;
+  using BufferQueue = std::deque<DecodedAudio>;
 
   // An internal method shared by ReadFrames() and SeekFrames() that actually
   // does reading. It reads a maximum of |frames| frames into |dest|. Returns

--- a/starboard/shared/starboard/player/filter/mock_audio_decoder.h
+++ b/starboard/shared/starboard/player/filter/mock_audio_decoder.h
@@ -15,6 +15,8 @@
 #ifndef STARBOARD_SHARED_STARBOARD_PLAYER_FILTER_MOCK_AUDIO_DECODER_H_
 #define STARBOARD_SHARED_STARBOARD_PLAYER_FILTER_MOCK_AUDIO_DECODER_H_
 
+#include <optional>
+
 #include "starboard/common/ref_counted.h"
 #include "starboard/media.h"
 #include "starboard/shared/internal_only.h"
@@ -34,7 +36,7 @@ class MockAudioDecoder : public AudioDecoder {
   MOCK_METHOD2(Initialize, void(const OutputCB&, const ErrorCB&));
   MOCK_METHOD2(Decode, void(const InputBuffers&, const ConsumedCB&));
   MOCK_METHOD0(WriteEndOfStream, void());
-  MOCK_METHOD1(Read, scoped_refptr<DecodedAudio>(int*));
+  MOCK_METHOD1(Read, std::optional<DecodedAudio>(int*));
   MOCK_METHOD0(Reset, void());
 };
 

--- a/starboard/shared/starboard/player/filter/stub_audio_decoder.cc
+++ b/starboard/shared/starboard/player/filter/stub_audio_decoder.cc
@@ -51,22 +51,21 @@ int CalculateFramesPerInputBuffer(int sample_rate,
   return AudioDurationToFrames(duration, sample_rate);
 }
 
-scoped_refptr<DecodedAudio> CreateDecodedAudio(
-    int64_t timestamp,
-    SbMediaAudioSampleType sample_type,
-    int number_of_channels,
-    int frames) {
+DecodedAudio CreateDecodedAudio(int64_t timestamp,
+                                SbMediaAudioSampleType sample_type,
+                                int number_of_channels,
+                                int frames) {
   int sample_size = GetBytesPerSample(sample_type);
-  scoped_refptr<DecodedAudio> decoded_audio(new DecodedAudio(
+  DecodedAudio decoded_audio(
       number_of_channels, sample_type, kSbMediaAudioFrameStorageTypeInterleaved,
-      timestamp, sample_size * number_of_channels * frames));
+      timestamp, sample_size * number_of_channels * frames);
 
-  for (int j = 0; j < decoded_audio->size_in_bytes() / sample_size; ++j) {
+  for (int j = 0; j < decoded_audio.size_in_bytes() / sample_size; ++j) {
     if (sample_size == 2) {
-      *(reinterpret_cast<int16_t*>(decoded_audio->data()) + j) = j;
+      *(reinterpret_cast<int16_t*>(decoded_audio.data()) + j) = j;
     } else {
       SB_DCHECK_EQ(sample_size, 4);
-      *(reinterpret_cast<float*>(decoded_audio->data()) + j) =
+      *(reinterpret_cast<float*>(decoded_audio.data()) + j) =
           ((j % 1024) - 512) / 512.0f;
     }
   }
@@ -119,19 +118,19 @@ void StubAudioDecoder::WriteEndOfStream() {
         std::bind(&StubAudioDecoder::DecodeEndOfStream, this));
     return;
   }
-  decoded_audios_.push(new DecodedAudio());
+  decoded_audios_.push(DecodedAudio());
   output_cb_();
 }
 
-scoped_refptr<DecodedAudio> StubAudioDecoder::Read(int* samples_per_second) {
+std::optional<DecodedAudio> StubAudioDecoder::Read(int* samples_per_second) {
   SB_CHECK(BelongsToCurrentThread());
 
   *samples_per_second = samples_per_second_;
   std::lock_guard lock(decoded_audios_mutex_);
   if (decoded_audios_.empty()) {
-    return scoped_refptr<DecodedAudio>();
+    return std::nullopt;
   }
-  auto result = decoded_audios_.front();
+  std::optional<DecodedAudio> result = std::move(decoded_audios_.front());
   decoded_audios_.pop();
   return result;
 }
@@ -175,11 +174,11 @@ void StubAudioDecoder::DecodeOneBuffer(
       frames_per_input_ = frames_per_input;
     }
 
-    scoped_refptr<DecodedAudio> decoded_audio =
+    DecodedAudio decoded_audio =
         CreateDecodedAudio(last_input_buffer_->timestamp(), sample_type_,
                            number_of_channels_, *frames_per_input_);
 
-    decoded_audio->AdjustForDiscardedDurations(
+    decoded_audio.AdjustForDiscardedDurations(
         samples_per_second_,
         last_input_buffer_->audio_sample_info().discarded_duration_from_front,
         last_input_buffer_->audio_sample_info().discarded_duration_from_back);
@@ -198,14 +197,14 @@ void StubAudioDecoder::DecodeOneBuffer(
 
       for (int i = 0; i < kNumDecodedAudioObjects; ++i) {
         size_t frames_of_output =
-            decoded_audio->frames() / kNumDecodedAudioObjects;
+            decoded_audio.frames() / kNumDecodedAudioObjects;
         size_t size_in_bytes_of_output =
             frames_of_output * sample_size * number_of_channels_;
 
         if (i == kNumDecodedAudioObjects - 1) {
           // It's the last one, send out all remaining data.
           size_in_bytes_of_output =
-              decoded_audio->size_in_bytes() - offset_in_bytes;
+              decoded_audio.size_in_bytes() - offset_in_bytes;
           SB_DCHECK(size_in_bytes_of_output %
                         (sample_size * number_of_channels_) ==
                     0);
@@ -214,16 +213,15 @@ void StubAudioDecoder::DecodeOneBuffer(
         auto offset_in_frames =
             offset_in_bytes / (sample_size * number_of_channels_);
         int64_t timestamp =
-            decoded_audio->timestamp() +
+            decoded_audio.timestamp() +
             AudioDurationToFrames(offset_in_frames, samples_per_second_);
 
-        scoped_refptr<DecodedAudio> current_decoded_audio(
-            new DecodedAudio(number_of_channels_, sample_type_,
-                             kSbMediaAudioFrameStorageTypeInterleaved,
-                             timestamp, size_in_bytes_of_output));
-        memcpy(current_decoded_audio->data(),
-               decoded_audio->data() + offset_in_bytes,
-               size_in_bytes_of_output);
+        DecodedAudio current_decoded_audio(
+            number_of_channels_, sample_type_,
+            kSbMediaAudioFrameStorageTypeInterleaved, timestamp,
+            size_in_bytes_of_output);
+        memcpy(current_decoded_audio.data(),
+               decoded_audio.data() + offset_in_bytes, size_in_bytes_of_output);
         offset_in_bytes += size_in_bytes_of_output;
 
         std::lock_guard lock(decoded_audios_mutex_);
@@ -255,7 +253,7 @@ void StubAudioDecoder::DecodeEndOfStream() {
 
     SB_DCHECK(frames_per_input_);
 
-    scoped_refptr<DecodedAudio> decoded_audio =
+    DecodedAudio decoded_audio =
         CreateDecodedAudio(last_input_buffer_->timestamp(), sample_type_,
                            number_of_channels_, *frames_per_input_);
 
@@ -266,18 +264,18 @@ void StubAudioDecoder::DecodeEndOfStream() {
     SB_DCHECK(AudioDurationToFrames(
                   discarded_duration_from_front + discarded_duration_from_back,
                   last_input_buffer_->audio_stream_info().samples_per_second) <=
-              decoded_audio->frames());
+              decoded_audio.frames());
 
-    decoded_audio->AdjustForDiscardedDurations(samples_per_second_,
-                                               discarded_duration_from_front,
-                                               discarded_duration_from_back);
+    decoded_audio.AdjustForDiscardedDurations(samples_per_second_,
+                                              discarded_duration_from_front,
+                                              discarded_duration_from_back);
 
     std::lock_guard lock(decoded_audios_mutex_);
     decoded_audios_.push(std::move(decoded_audio));
     Schedule(output_cb_);
   }
   std::lock_guard lock(decoded_audios_mutex_);
-  decoded_audios_.push(new DecodedAudio());
+  decoded_audios_.push(DecodedAudio());
   Schedule(output_cb_);
 }
 

--- a/starboard/shared/starboard/player/filter/stub_audio_decoder.h
+++ b/starboard/shared/starboard/player/filter/stub_audio_decoder.h
@@ -40,7 +40,7 @@ class StubAudioDecoder : public AudioDecoder, private JobQueue::JobOwner {
   void Decode(const InputBuffers& input_buffer,
               const ConsumedCB& consumed_cb) override;
   void WriteEndOfStream() override;
-  scoped_refptr<DecodedAudio> Read(int* samples_per_second) override;
+  std::optional<DecodedAudio> Read(int* samples_per_second) override;
   void Reset() override;
 
  private:
@@ -59,7 +59,7 @@ class StubAudioDecoder : public AudioDecoder, private JobQueue::JobOwner {
 
   std::unique_ptr<JobThread> decoder_thread_;
   std::mutex decoded_audios_mutex_;
-  std::queue<scoped_refptr<DecodedAudio>> decoded_audios_;
+  std::queue<DecodedAudio> decoded_audios_;
   scoped_refptr<InputBuffer> last_input_buffer_;
   std::optional<int> frames_per_input_;
   // Used to determine when to send multiple DecodedAudios in DecodeOneBuffer().

--- a/starboard/shared/starboard/player/filter/testing/adaptive_audio_decoder_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/adaptive_audio_decoder_test.cc
@@ -21,6 +21,7 @@
 #include <memory>
 #include <mutex>
 #include <numeric>
+#include <optional>
 #include <queue>
 #include <string>
 
@@ -181,7 +182,7 @@ class AdaptiveAudioDecoderTest
   }
 
   vector<std::unique_ptr<VideoDmpReader>> dmp_readers_;
-  scoped_refptr<DecodedAudio> last_decoded_audio_;
+  std::optional<DecodedAudio> last_decoded_audio_;
   deque<scoped_refptr<InputBuffer>> written_inputs_;
   int num_of_output_frames_ = 0;
   int output_sample_rate_;
@@ -222,9 +223,9 @@ class AdaptiveAudioDecoderTest
 
   void ReadFromDecoder() {
     int samples_per_second;
-    scoped_refptr<DecodedAudio> decoded_audio =
+    std::optional<DecodedAudio> decoded_audio =
         audio_decoder_->Read(&samples_per_second);
-    ASSERT_TRUE(decoded_audio);
+    ASSERT_TRUE(decoded_audio.has_value());
     if (first_output_received_) {
       ASSERT_EQ(output_sample_rate_, samples_per_second);
     } else {
@@ -233,7 +234,7 @@ class AdaptiveAudioDecoderTest
     }
 
     if (decoded_audio->is_end_of_stream()) {
-      last_decoded_audio_ = decoded_audio;
+      last_decoded_audio_ = std::move(decoded_audio);
       return;
     }
 
@@ -253,7 +254,7 @@ class AdaptiveAudioDecoderTest
       }
     }
 
-    last_decoded_audio_ = decoded_audio;
+    last_decoded_audio_ = std::move(decoded_audio);
     num_of_output_frames_ += last_decoded_audio_->frames();
   }
 

--- a/starboard/shared/starboard/player/filter/testing/audio_channel_layout_mixer_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_channel_layout_mixer_test.cc
@@ -44,7 +44,7 @@ class AudioChannelLayoutMixerTest
               storage_type_ == kSbMediaAudioFrameStorageTypePlanar);
   }
 
-  scoped_refptr<DecodedAudio> GetTestDecodedAudio(int num_of_channels) {
+  DecodedAudio GetTestDecodedAudio(int num_of_channels) {
     // Interleaved test audio data, stored in float.
     const float kMonoInputAudioData[] = {
         -1.0f, -0.5f, 0.0f, 0.5f, 1.0f,
@@ -80,13 +80,13 @@ class AudioChannelLayoutMixerTest
       SB_NOTREACHED() << "Invalid number of channels.";
     }
 
-    scoped_refptr<DecodedAudio> decoded_audio(new DecodedAudio(
+    DecodedAudio decoded_audio(
         num_of_channels, sample_type_, storage_type_, 0,
         kInputFrames * num_of_channels *
-            (sample_type_ == kSbMediaAudioSampleTypeFloat32 ? 4 : 2)));
+            (sample_type_ == kSbMediaAudioSampleTypeFloat32 ? 4 : 2));
 
     if (sample_type_ == kSbMediaAudioSampleTypeFloat32) {
-      float* dest_buffer = reinterpret_cast<float*>(decoded_audio->data());
+      float* dest_buffer = reinterpret_cast<float*>(decoded_audio.data());
       for (size_t i = 0; i < num_of_channels * kInputFrames; i++) {
         int src_index = i;
         if (storage_type_ == kSbMediaAudioFrameStorageTypePlanar) {
@@ -95,7 +95,7 @@ class AudioChannelLayoutMixerTest
         dest_buffer[i] = data_buffer[src_index];
       }
     } else {
-      int16_t* dest_buffer = reinterpret_cast<int16_t*>(decoded_audio->data());
+      int16_t* dest_buffer = reinterpret_cast<int16_t*>(decoded_audio.data());
       for (size_t i = 0; i < num_of_channels * kInputFrames; i++) {
         int src_index = i;
         if (storage_type_ == kSbMediaAudioFrameStorageTypePlanar) {
@@ -108,26 +108,27 @@ class AudioChannelLayoutMixerTest
     return decoded_audio;
   }
 
-  void AssertExpectedAndOutputMatch(const scoped_refptr<DecodedAudio>& input,
-                                    const scoped_refptr<DecodedAudio>& output,
+  void AssertExpectedAndOutputMatch(const DecodedAudio& input,
+                                    const DecodedAudio& output,
                                     int output_num_of_channels,
                                     const float* expected_output) {
-    ASSERT_EQ(output_num_of_channels, output->channels());
-    ASSERT_EQ(input->sample_type(), output->sample_type());
-    ASSERT_EQ(input->storage_type(), output->storage_type());
-    ASSERT_EQ(input->timestamp(), output->timestamp());
-    ASSERT_EQ(input->size_in_bytes() * output->channels(),
-              output->size_in_bytes() * input->channels());
+    ASSERT_EQ(output_num_of_channels, output.channels());
+    ASSERT_EQ(input.sample_type(), output.sample_type());
+    ASSERT_EQ(input.storage_type(), output.storage_type());
+    ASSERT_EQ(input.timestamp(), output.timestamp());
+    ASSERT_EQ(input.size_in_bytes() * output.channels(),
+              output.size_in_bytes() * input.channels());
 
     if (sample_type_ == kSbMediaAudioSampleTypeFloat32) {
-      float* output_buffer = reinterpret_cast<float*>(output->data());
+      const float* output_buffer =
+          reinterpret_cast<const float*>(output.data());
       for (size_t i = 0;
-           i < static_cast<size_t>(output->frames()) * output_num_of_channels;
+           i < static_cast<size_t>(output.frames()) * output_num_of_channels;
            i++) {
         size_t src_index = i;
         if (storage_type_ == kSbMediaAudioFrameStorageTypePlanar) {
-          src_index = i % output->frames() * output_num_of_channels +
-                      i / output->frames();
+          src_index = i % output.frames() * output_num_of_channels +
+                      i / output.frames();
         }
         if (expected_output[src_index] >= 1.0f) {
           ASSERT_GE(output_buffer[i], 0.999f);
@@ -139,14 +140,15 @@ class AudioChannelLayoutMixerTest
         }
       }
     } else {
-      int16_t* output_buffer = reinterpret_cast<int16_t*>(output->data());
+      const int16_t* output_buffer =
+          reinterpret_cast<const int16_t*>(output.data());
       for (size_t i = 0;
-           i < static_cast<size_t>(output->frames()) * output_num_of_channels;
+           i < static_cast<size_t>(output.frames()) * output_num_of_channels;
            i++) {
         size_t src_index = i;
         if (storage_type_ == kSbMediaAudioFrameStorageTypePlanar) {
-          src_index = i % output->frames() * output_num_of_channels +
-                      i / output->frames();
+          src_index = i % output.frames() * output_num_of_channels +
+                      i / output.frames();
         }
         ASSERT_LE(
             fabs(expected_output[src_index] -
@@ -185,33 +187,33 @@ TEST_P(AudioChannelLayoutMixerTest, MixToMono) {
   const float kExpectedMonoToMonoOutput[] = {
       -1.0f, -0.5f, 0.0f, 0.5f, 1.0f,
   };
-  scoped_refptr<DecodedAudio> mono_input = GetTestDecodedAudio(1);
-  scoped_refptr<DecodedAudio> mono_output = mixer->Mix(mono_input);
+  DecodedAudio mono_input = GetTestDecodedAudio(1);
+  DecodedAudio mono_output = mixer->Mix(mono_input.CloneForTesting());
   AssertExpectedAndOutputMatch(mono_input, mono_output, 1,
                                kExpectedMonoToMonoOutput);
 
   const float kExpectedStereoToMonoOutput[] = {
       -0.25f, 0.0f, 0.0f, 0.5f, 1.0f,
   };
-  scoped_refptr<DecodedAudio> stereo_input = GetTestDecodedAudio(2);
-  scoped_refptr<DecodedAudio> stereo_output = mixer->Mix(stereo_input);
+  DecodedAudio stereo_input = GetTestDecodedAudio(2);
+  DecodedAudio stereo_output = mixer->Mix(stereo_input.CloneForTesting());
   AssertExpectedAndOutputMatch(stereo_input, stereo_output, 1,
                                kExpectedStereoToMonoOutput);
 
   const float kExpectedQuadToMonoOutput[] = {
       0.0f, -0.25f, 0.0f, 0.5f, 1.0f,
   };
-  scoped_refptr<DecodedAudio> quad_input = GetTestDecodedAudio(4);
-  scoped_refptr<DecodedAudio> quad_output = mixer->Mix(quad_input);
+  DecodedAudio quad_input = GetTestDecodedAudio(4);
+  DecodedAudio quad_output = mixer->Mix(quad_input.CloneForTesting());
   AssertExpectedAndOutputMatch(quad_input, quad_output, 1,
                                kExpectedQuadToMonoOutput);
 
   const float kExpectedFivePointOneToMonoOutput[] = {
       0.0f, 0.0f, 0.0f, 1.0f, 1.0f,
   };
-  scoped_refptr<DecodedAudio> five_point_one_input = GetTestDecodedAudio(6);
-  scoped_refptr<DecodedAudio> five_point_one_output =
-      mixer->Mix(five_point_one_input);
+  DecodedAudio five_point_one_input = GetTestDecodedAudio(6);
+  DecodedAudio five_point_one_output =
+      mixer->Mix(five_point_one_input.CloneForTesting());
   AssertExpectedAndOutputMatch(five_point_one_input, five_point_one_output, 1,
                                kExpectedFivePointOneToMonoOutput);
 }
@@ -224,33 +226,33 @@ TEST_P(AudioChannelLayoutMixerTest, MixToStereo) {
   const float kExpectedMonoToStereoOutput[] = {
       -1.0f, -1.0f, -0.5f, -0.5f, 0.0f, 0.0f, 0.5f, 0.5f, 1.0f, 1.0f,
   };
-  scoped_refptr<DecodedAudio> mono_input = GetTestDecodedAudio(1);
-  scoped_refptr<DecodedAudio> mono_output = mixer->Mix(mono_input);
+  DecodedAudio mono_input = GetTestDecodedAudio(1);
+  DecodedAudio mono_output = mixer->Mix(mono_input.CloneForTesting());
   AssertExpectedAndOutputMatch(mono_input, mono_output, 2,
                                kExpectedMonoToStereoOutput);
 
   const float kExpectedStereoToStereoOutput[] = {
       -1.0f, 0.5f, -0.5f, 0.5f, 0.0f, 0.0f, 0.5f, 0.5f, 1.0f, 1.0f,
   };
-  scoped_refptr<DecodedAudio> stereo_input = GetTestDecodedAudio(2);
-  scoped_refptr<DecodedAudio> stereo_output = mixer->Mix(stereo_input);
+  DecodedAudio stereo_input = GetTestDecodedAudio(2);
+  DecodedAudio stereo_output = mixer->Mix(stereo_input.CloneForTesting());
   AssertExpectedAndOutputMatch(stereo_input, stereo_output, 2,
                                kExpectedStereoToStereoOutput);
 
   const float kExpectedQuadToStereoOutput[] = {
       -0.5f, 0.5f, -0.5f, 0.0f, 0.0f, 0.0f, 0.5f, 0.5f, 1.0f, 1.0f,
   };
-  scoped_refptr<DecodedAudio> quad_input = GetTestDecodedAudio(4);
-  scoped_refptr<DecodedAudio> quad_output = mixer->Mix(quad_input);
+  DecodedAudio quad_input = GetTestDecodedAudio(4);
+  DecodedAudio quad_output = mixer->Mix(quad_input.CloneForTesting());
   AssertExpectedAndOutputMatch(quad_input, quad_output, 2,
                                kExpectedQuadToStereoOutput);
 
   const float kExpectedFivePointOneToStereoOutput[] = {
       -1.0f, 1.0f, -0.5f, 0.5f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f, 1.0f,
   };
-  scoped_refptr<DecodedAudio> five_point_one_input = GetTestDecodedAudio(6);
-  scoped_refptr<DecodedAudio> five_point_one_output =
-      mixer->Mix(five_point_one_input);
+  DecodedAudio five_point_one_input = GetTestDecodedAudio(6);
+  DecodedAudio five_point_one_output =
+      mixer->Mix(five_point_one_input.CloneForTesting());
   AssertExpectedAndOutputMatch(five_point_one_input, five_point_one_output, 2,
                                kExpectedFivePointOneToStereoOutput);
 }
@@ -264,8 +266,8 @@ TEST_P(AudioChannelLayoutMixerTest, MixToQuad) {
       -1.0f, -1.0f, 0.0f, 0.0f, -0.5f, -0.5f, 0.0f, 0.0f, 0.0f, 0.0f,
       0.0f,  0.0f,  0.5f, 0.5f, 0.0f,  0.0f,  1.0f, 1.0f, 0.0f, 0.0f,
   };
-  scoped_refptr<DecodedAudio> mono_input = GetTestDecodedAudio(1);
-  scoped_refptr<DecodedAudio> mono_output = mixer->Mix(mono_input);
+  DecodedAudio mono_input = GetTestDecodedAudio(1);
+  DecodedAudio mono_output = mixer->Mix(mono_input.CloneForTesting());
   AssertExpectedAndOutputMatch(mono_input, mono_output, 4,
                                kExpectedMonoToQuadOutput);
 
@@ -273,8 +275,8 @@ TEST_P(AudioChannelLayoutMixerTest, MixToQuad) {
       -1.0f, 0.5f, 0.0f, 0.0f, -0.5f, 0.5f, 0.0f, 0.0f, 0.0f, 0.0f,
       0.0f,  0.0f, 0.5f, 0.5f, 0.0f,  0.0f, 1.0f, 1.0f, 0.0f, 0.0f,
   };
-  scoped_refptr<DecodedAudio> stereo_input = GetTestDecodedAudio(2);
-  scoped_refptr<DecodedAudio> stereo_output = mixer->Mix(stereo_input);
+  DecodedAudio stereo_input = GetTestDecodedAudio(2);
+  DecodedAudio stereo_output = mixer->Mix(stereo_input.CloneForTesting());
   AssertExpectedAndOutputMatch(stereo_input, stereo_output, 4,
                                kExpectedStereoToQuadOutput);
 
@@ -282,8 +284,8 @@ TEST_P(AudioChannelLayoutMixerTest, MixToQuad) {
       -1.0f, 1.0f, 0.0f, 0.0f, -0.5f, 0.5f, -0.5f, -0.5f, 0.0f, 0.0f,
       0.0f,  0.0f, 0.5f, 0.5f, 0.5f,  0.5f, 1.0f,  1.0f,  1.0f, 1.0f,
   };
-  scoped_refptr<DecodedAudio> quad_input = GetTestDecodedAudio(4);
-  scoped_refptr<DecodedAudio> quad_output = mixer->Mix(quad_input);
+  DecodedAudio quad_input = GetTestDecodedAudio(4);
+  DecodedAudio quad_output = mixer->Mix(quad_input.CloneForTesting());
   AssertExpectedAndOutputMatch(quad_input, quad_output, 4,
                                kExpectedQuadToQuadOutput);
 
@@ -292,9 +294,9 @@ TEST_P(AudioChannelLayoutMixerTest, MixToQuad) {
       -0.5f,    0.0f, 0.0f,  0.0f,  0.0f,     0.8535f, 0.8535f,
       0.5f,     0.5f, 1.0f,  1.0f,  1.0f,     1.0f,
   };
-  scoped_refptr<DecodedAudio> five_point_one_input = GetTestDecodedAudio(6);
-  scoped_refptr<DecodedAudio> five_point_one_output =
-      mixer->Mix(five_point_one_input);
+  DecodedAudio five_point_one_input = GetTestDecodedAudio(6);
+  DecodedAudio five_point_one_output =
+      mixer->Mix(five_point_one_input.CloneForTesting());
   AssertExpectedAndOutputMatch(five_point_one_input, five_point_one_output, 4,
                                kExpectedFivePointOneToQuadOutput);
 }
@@ -309,8 +311,8 @@ TEST_P(AudioChannelLayoutMixerTest, MixToFivePointOne) {
       0.0f, 0.0f, 0.0f,  0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,  0.0f,
       0.5f, 0.0f, 0.0f,  0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f,  0.0f,
   };
-  scoped_refptr<DecodedAudio> mono_input = GetTestDecodedAudio(1);
-  scoped_refptr<DecodedAudio> mono_output = mixer->Mix(mono_input);
+  DecodedAudio mono_input = GetTestDecodedAudio(1);
+  DecodedAudio mono_output = mixer->Mix(mono_input.CloneForTesting());
   AssertExpectedAndOutputMatch(mono_input, mono_output, 6,
                                kExpectedMonoToFivePointOneOutput);
 
@@ -319,8 +321,8 @@ TEST_P(AudioChannelLayoutMixerTest, MixToFivePointOne) {
       0.0f,  0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,  0.0f, 0.5f, 0.5f,
       0.0f,  0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f,  0.0f, 0.0f, 0.0f,
   };
-  scoped_refptr<DecodedAudio> stereo_input = GetTestDecodedAudio(2);
-  scoped_refptr<DecodedAudio> stereo_output = mixer->Mix(stereo_input);
+  DecodedAudio stereo_input = GetTestDecodedAudio(2);
+  DecodedAudio stereo_output = mixer->Mix(stereo_input.CloneForTesting());
   AssertExpectedAndOutputMatch(stereo_input, stereo_output, 6,
                                kExpectedStereoToFivePointOneOutput);
 
@@ -329,8 +331,8 @@ TEST_P(AudioChannelLayoutMixerTest, MixToFivePointOne) {
       -0.5f, -0.5f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,  0.0f, 0.5f, 0.5f,
       0.0f,  0.0f,  0.5f, 0.5f, 1.0f, 1.0f, 0.0f,  0.0f, 1.0f, 1.0f,
   };
-  scoped_refptr<DecodedAudio> quad_input = GetTestDecodedAudio(4);
-  scoped_refptr<DecodedAudio> quad_output = mixer->Mix(quad_input);
+  DecodedAudio quad_input = GetTestDecodedAudio(4);
+  DecodedAudio quad_output = mixer->Mix(quad_input.CloneForTesting());
   AssertExpectedAndOutputMatch(quad_input, quad_output, 6,
                                kExpectedQuadToFivePointOneOutput);
 
@@ -339,9 +341,9 @@ TEST_P(AudioChannelLayoutMixerTest, MixToFivePointOne) {
       -0.5f, -0.5f, 0.0f, 0.0f,  0.0f,  0.0f,  0.0f,  0.0f, 0.5f, 0.5f,
       0.5f,  0.5f,  0.5f, 0.5f,  1.0f,  1.0f,  1.0f,  1.0f, 1.0f, 1.0f,
   };
-  scoped_refptr<DecodedAudio> five_point_one_input = GetTestDecodedAudio(6);
-  scoped_refptr<DecodedAudio> five_point_one_output =
-      mixer->Mix(five_point_one_input);
+  DecodedAudio five_point_one_input = GetTestDecodedAudio(6);
+  DecodedAudio five_point_one_output =
+      mixer->Mix(five_point_one_input.CloneForTesting());
   AssertExpectedAndOutputMatch(five_point_one_input, five_point_one_output, 6,
                                kExpectedFivePointOneToFivePointOneOutput);
 }

--- a/starboard/shared/starboard/player/filter/testing/audio_decoder_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_decoder_test.cc
@@ -52,44 +52,43 @@ using ::testing::ValuesIn;
 
 const int64_t kWaitForNextEventTimeOut = 5'000'000;  // 5 seconds
 
-scoped_refptr<DecodedAudio> ConsolidateDecodedAudios(
-    const std::vector<scoped_refptr<DecodedAudio>>& decoded_audios) {
+DecodedAudio ConsolidateDecodedAudios(
+    const std::vector<DecodedAudio>& decoded_audios) {
   if (decoded_audios.empty()) {
-    return new DecodedAudio(2, kSbMediaAudioSampleTypeFloat32,
-                            kSbMediaAudioFrameStorageTypeInterleaved, 0, 0);
+    return DecodedAudio(2, kSbMediaAudioSampleTypeFloat32,
+                        kSbMediaAudioFrameStorageTypeInterleaved, 0, 0);
   }
 
   int total_size_in_bytes = 0;
-  int channels = decoded_audios.front()->channels();
-  auto sample_type = decoded_audios.front()->sample_type();
+  int channels = decoded_audios.front().channels();
+  auto sample_type = decoded_audios.front().sample_type();
 
-  for (auto decoded_audio : decoded_audios) {
-    SB_DCHECK_EQ(decoded_audio->channels(), channels);
-    SB_DCHECK_EQ(decoded_audio->sample_type(), sample_type);
-    SB_DCHECK_EQ(decoded_audio->storage_type(),
+  for (const auto& decoded_audio : decoded_audios) {
+    SB_DCHECK_EQ(decoded_audio.channels(), channels);
+    SB_DCHECK_EQ(decoded_audio.sample_type(), sample_type);
+    SB_DCHECK_EQ(decoded_audio.storage_type(),
                  kSbMediaAudioFrameStorageTypeInterleaved);
-    total_size_in_bytes += decoded_audio->size_in_bytes();
+    total_size_in_bytes += decoded_audio.size_in_bytes();
   }
 
-  scoped_refptr<DecodedAudio> consolidated = new DecodedAudio(
+  DecodedAudio consolidated(
       channels, sample_type, kSbMediaAudioFrameStorageTypeInterleaved,
-      decoded_audios.front()->timestamp(), total_size_in_bytes);
+      decoded_audios.front().timestamp(), total_size_in_bytes);
 
   int offset_in_bytes = 0;
-  for (auto decoded_audio : decoded_audios) {
-    memcpy(consolidated->data() + offset_in_bytes, decoded_audio->data(),
-           decoded_audio->size_in_bytes());
-    offset_in_bytes += decoded_audio->size_in_bytes();
+  for (const auto& decoded_audio : decoded_audios) {
+    memcpy(consolidated.data() + offset_in_bytes, decoded_audio.data(),
+           decoded_audio.size_in_bytes());
+    offset_in_bytes += decoded_audio.size_in_bytes();
   }
 
   return consolidated;
 }
 
-int GetTotalFrames(
-    const std::vector<scoped_refptr<DecodedAudio>>& decoded_audios) {
+int GetTotalFrames(const std::vector<DecodedAudio>& decoded_audios) {
   int total_frames = 0;
-  for (auto decoded_audio : decoded_audios) {
-    total_frames += decoded_audio->frames();
+  for (const auto& decoded_audio : decoded_audios) {
+    total_frames += decoded_audio.frames();
   }
   return total_frames;
 }
@@ -200,21 +199,21 @@ class AudioDecoderTest
   }
 
   // This has to be called when OnOutput() is called.
-  void ReadFromDecoder(scoped_refptr<DecodedAudio>* decoded_audio) {
-    ASSERT_TRUE(decoded_audio);
+  void ReadFromDecoder(bool* is_eos) {
+    ASSERT_TRUE(is_eos);
 
     int decoded_sample_rate;
-    scoped_refptr<DecodedAudio> local_decoded_audio =
+    std::optional<DecodedAudio> local_decoded_audio =
         audio_decoder_->Read(&decoded_sample_rate);
-    ASSERT_TRUE(local_decoded_audio);
+    ASSERT_TRUE(local_decoded_audio.has_value());
     if (!first_output_received_) {
       first_output_received_ = true;
       decoded_audio_sample_type_ = local_decoded_audio->sample_type();
       decoded_audio_sample_rate_ = decoded_sample_rate;
     }
 
-    if (local_decoded_audio->is_end_of_stream()) {
-      *decoded_audio = local_decoded_audio;
+    *is_eos = local_decoded_audio->is_end_of_stream();
+    if (*is_eos) {
       return;
     }
 
@@ -222,7 +221,7 @@ class AudioDecoderTest
     ASSERT_EQ(decoded_audio_sample_rate_, decoded_sample_rate);
 
     if (!decoded_audios_.empty()) {
-      ASSERT_LT(decoded_audios_.back()->timestamp(),
+      ASSERT_LT(decoded_audios_.back().timestamp(),
                 local_decoded_audio->timestamp());
     }
     if (!using_stub_decoder_ && invalid_inputs_.empty()) {
@@ -230,8 +229,7 @@ class AudioDecoderTest
                   written_inputs_.front()->timestamp(), 5);
       written_inputs_.pop_front();
     }
-    decoded_audios_.push_back(local_decoded_audio);
-    *decoded_audio = local_decoded_audio;
+    decoded_audios_.push_back(std::move(*local_decoded_audio));
   }
 
   void WriteMultipleInputs(size_t start_index,
@@ -263,10 +261,9 @@ class AudioDecoderTest
         return;
       }
       ASSERT_EQ(kOutput, event);
-      scoped_refptr<DecodedAudio> decoded_audio;
-      ASSERT_NO_FATAL_FAILURE(ReadFromDecoder(&decoded_audio));
-      ASSERT_TRUE(decoded_audio);
-      ASSERT_FALSE(decoded_audio->is_end_of_stream());
+      bool is_eos = false;
+      ASSERT_NO_FATAL_FAILURE(ReadFromDecoder(&is_eos));
+      ASSERT_FALSE(is_eos);
     }
   }
 
@@ -292,10 +289,9 @@ class AudioDecoderTest
         continue;
       }
       ASSERT_EQ(kOutput, event);
-      scoped_refptr<DecodedAudio> decoded_audio;
-      ASSERT_NO_FATAL_FAILURE(ReadFromDecoder(&decoded_audio));
-      ASSERT_TRUE(decoded_audio);
-      ASSERT_FALSE(decoded_audio->is_end_of_stream());
+      bool is_eos = false;
+      ASSERT_NO_FATAL_FAILURE(ReadFromDecoder(&is_eos));
+      ASSERT_FALSE(is_eos);
     }
   }
 
@@ -319,10 +315,9 @@ class AudioDecoderTest
         continue;
       }
       ASSERT_EQ(kOutput, event);
-      scoped_refptr<DecodedAudio> decoded_audio;
-      ASSERT_NO_FATAL_FAILURE(ReadFromDecoder(&decoded_audio));
-      ASSERT_TRUE(decoded_audio);
-      if (decoded_audio->is_end_of_stream()) {
+      bool is_eos = false;
+      ASSERT_NO_FATAL_FAILURE(ReadFromDecoder(&is_eos));
+      if (is_eos) {
         break;
       }
     }
@@ -363,10 +358,9 @@ class AudioDecoderTest
         continue;
       }
       ASSERT_EQ(kOutput, event);
-      scoped_refptr<DecodedAudio> decoded_audio;
-      ASSERT_NO_FATAL_FAILURE(ReadFromDecoder(&decoded_audio));
-      ASSERT_TRUE(decoded_audio);
-      ASSERT_FALSE(decoded_audio->is_end_of_stream());
+      bool is_eos = false;
+      ASSERT_NO_FATAL_FAILURE(ReadFromDecoder(&is_eos));
+      ASSERT_FALSE(is_eos);
     }
   }
 
@@ -396,10 +390,9 @@ class AudioDecoderTest
         FAIL();
       }
       ASSERT_EQ(kOutput, event);
-      scoped_refptr<DecodedAudio> decoded_audio;
-      ASSERT_NO_FATAL_FAILURE(ReadFromDecoder(&decoded_audio));
-      ASSERT_TRUE(decoded_audio);
-      ASSERT_FALSE(decoded_audio->is_end_of_stream());
+      bool is_eos = false;
+      ASSERT_NO_FATAL_FAILURE(ReadFromDecoder(&is_eos));
+      ASSERT_FALSE(is_eos);
       break;
     }
   }
@@ -477,7 +470,7 @@ class AudioDecoderTest
   bool can_accept_more_input_ = true;
   scoped_refptr<InputBuffer> last_input_buffer_;
   std::deque<scoped_refptr<InputBuffer>> written_inputs_;
-  std::vector<scoped_refptr<DecodedAudio>> decoded_audios_;
+  std::vector<DecodedAudio> decoded_audios_;
 
   bool eos_written_ = false;
 
@@ -721,17 +714,16 @@ TEST_P(AudioDecoderTest, ContinuedLimitedInput) {
     WaitForDecodedAudio();
     ASSERT_FALSE(decoded_audios_.empty());
     while ((last_input_buffer_->timestamp() -
-            decoded_audios_.back()->timestamp()) > duration ||
+            decoded_audios_.back().timestamp()) > duration ||
            !can_accept_more_input_) {
       ASSERT_NO_FATAL_FAILURE(WaitForNextEvent(&event));
       if (event == kConsumed) {
         continue;
       }
       ASSERT_EQ(kOutput, event);
-      scoped_refptr<DecodedAudio> decoded_audio;
-      ASSERT_NO_FATAL_FAILURE(ReadFromDecoder(&decoded_audio));
-      ASSERT_TRUE(decoded_audio);
-      ASSERT_FALSE(decoded_audio->is_end_of_stream());
+      bool is_eos = false;
+      ASSERT_NO_FATAL_FAILURE(ReadFromDecoder(&is_eos));
+      ASSERT_FALSE(is_eos);
     }
   }
   WriteEndOfStream();
@@ -773,9 +765,9 @@ TEST_P(AudioDecoderTest, PartialAudio) {
           break;
         }
         ASSERT_EQ(kOutput, event);
-        scoped_refptr<DecodedAudio> decoded_audio;
-        ASSERT_NO_FATAL_FAILURE(ReadFromDecoder(&decoded_audio));
-        ASSERT_TRUE(decoded_audio);
+        bool is_eos = false;
+        ASSERT_NO_FATAL_FAILURE(ReadFromDecoder(&is_eos));
+        ASSERT_FALSE(is_eos);
       }
     }
 
@@ -783,15 +775,16 @@ TEST_P(AudioDecoderTest, PartialAudio) {
     ASSERT_FALSE(decoded_audios_.empty());
     ASSERT_NO_FATAL_FAILURE(AssertOutputFormatValid());
 
-    auto reference_decoded_audio = ConsolidateDecodedAudios(decoded_audios_);
-    ASSERT_GT(reference_decoded_audio->frames(), 1);
+    DecodedAudio reference_decoded_audio =
+        ConsolidateDecodedAudios(decoded_audios_);
+    ASSERT_GT(reference_decoded_audio.frames(), 1);
 
     // Discard 1/4 of the duration from front, and back.  The resulting audio
     // will keep 1/2 of the frames in the middle. This has to be called before
     // `ResetDecoder()` as it resets `decoded_audio_sample_rate_`.
     ASSERT_GT(decoded_audio_sample_rate_, 0);
     auto frames_per_access_unit =
-        reference_decoded_audio->frames() / number_of_input_to_write;
+        reference_decoded_audio.frames() / number_of_input_to_write;
     int64_t duration_to_discard =
         AudioFramesToDuration(frames_per_access_unit,
                               decoded_audio_sample_rate_) /
@@ -818,9 +811,9 @@ TEST_P(AudioDecoderTest, PartialAudio) {
           break;
         }
         ASSERT_EQ(kOutput, event);
-        scoped_refptr<DecodedAudio> decoded_audio;
-        ASSERT_NO_FATAL_FAILURE(ReadFromDecoder(&decoded_audio));
-        ASSERT_TRUE(decoded_audio);
+        bool is_eos = false;
+        ASSERT_NO_FATAL_FAILURE(ReadFromDecoder(&is_eos));
+        ASSERT_FALSE(is_eos);
       }
     }
 
@@ -828,38 +821,38 @@ TEST_P(AudioDecoderTest, PartialAudio) {
     ASSERT_FALSE(decoded_audios_.empty());
     ASSERT_NO_FATAL_FAILURE(AssertOutputFormatValid());
 
-    auto partial_decoded_audio = ConsolidateDecodedAudios(decoded_audios_);
+    DecodedAudio partial_decoded_audio =
+        ConsolidateDecodedAudios(decoded_audios_);
 
-    ASSERT_EQ(reference_decoded_audio->sample_type(),
-              partial_decoded_audio->sample_type());
-    ASSERT_EQ(reference_decoded_audio->storage_type(),
-              partial_decoded_audio->storage_type());
-    ASSERT_GT(reference_decoded_audio->frames(),
-              partial_decoded_audio->frames());
+    ASSERT_EQ(reference_decoded_audio.sample_type(),
+              partial_decoded_audio.sample_type());
+    ASSERT_EQ(reference_decoded_audio.storage_type(),
+              partial_decoded_audio.storage_type());
+    ASSERT_GT(reference_decoded_audio.frames(), partial_decoded_audio.frames());
 
-    auto bytes_per_frame = reference_decoded_audio->size_in_bytes() /
-                           reference_decoded_audio->frames();
+    auto bytes_per_frame = reference_decoded_audio.size_in_bytes() /
+                           reference_decoded_audio.frames();
     // |partial_decoded_audio| should contain exactly the same data as
     // |reference_decoded_audio|, begin from about 1/4 of an access unit.  We
     // search from (1/4 access unit - 1) in |reference_decoded_audio| to allow
     // for up to one frame of error during calculation.
     auto reference_search_begin =
-        reference_decoded_audio->data() +
+        reference_decoded_audio.data() +
         (frames_per_access_unit / 4 - 1) * bytes_per_frame;
-    auto reference_search_end = reference_decoded_audio->data() +
-                                reference_decoded_audio->size_in_bytes();
+    auto reference_search_end = reference_decoded_audio.data() +
+                                reference_decoded_audio.size_in_bytes();
     auto offset_index = std::search(
         reference_search_begin, reference_search_end,
-        partial_decoded_audio->data(),
-        partial_decoded_audio->data() + partial_decoded_audio->size_in_bytes());
+        partial_decoded_audio.data(),
+        partial_decoded_audio.data() + partial_decoded_audio.size_in_bytes());
     ASSERT_FALSE(offset_index == reference_search_end);
     auto offset_in_bytes = offset_index - reference_search_begin;
     auto offset_in_frames = offset_in_bytes / bytes_per_frame;
 
     constexpr int kEpsilonInFrames = 2;
     EXPECT_LE(offset_in_frames, kEpsilonInFrames);
-    EXPECT_NEAR(reference_decoded_audio->frames() - frames_per_access_unit / 2,
-                partial_decoded_audio->frames(), kEpsilonInFrames);
+    EXPECT_NEAR(reference_decoded_audio.frames() - frames_per_access_unit / 2,
+                partial_decoded_audio.frames(), kEpsilonInFrames);
   }
 }
 

--- a/starboard/shared/starboard/player/filter/testing/audio_frame_discarder_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_frame_discarder_test.cc
@@ -38,14 +38,13 @@ class AudioFrameDiscarderTest : public ::testing::TestWithParam<const char*> {
   VideoDmpReader dmp_reader_;
 };
 
-scoped_refptr<DecodedAudio> MakeDecodedAudio(int channels, int64_t timestamp) {
-  scoped_refptr<DecodedAudio> decoded_audio = new DecodedAudio(
+DecodedAudio MakeDecodedAudio(int channels, int64_t timestamp) {
+  DecodedAudio decoded_audio(
       channels, kSbMediaAudioSampleTypeFloat32,
       kSbMediaAudioFrameStorageTypeInterleaved, timestamp,
       GetBytesPerSample(kSbMediaAudioSampleTypeFloat32) * channels * 1536);
 
-  memset(decoded_audio->data(), timestamp % 256,
-         decoded_audio->size_in_bytes());
+  memset(decoded_audio.data(), timestamp % 256, decoded_audio.size_in_bytes());
 
   return decoded_audio;
 }
@@ -59,7 +58,7 @@ TEST_P(AudioFrameDiscarderTest, Empty) {
 
 TEST_P(AudioFrameDiscarderTest, NonPartialAudio) {
   InputBuffers input_buffers;
-  std::vector<scoped_refptr<DecodedAudio>> decoded_audios;
+  std::vector<DecodedAudio> decoded_audios;
   const auto& audio_stream_info = dmp_reader_.audio_stream_info();
 
   for (int i = 0; i < std::min<int>(32, dmp_reader_.number_of_audio_buffers());
@@ -75,30 +74,30 @@ TEST_P(AudioFrameDiscarderTest, NonPartialAudio) {
 
   for (size_t i = 0; i < input_buffers.size(); ++i) {
     discarder.OnInputBuffers({input_buffers[i]});
-    auto copy = decoded_audios[i]->Clone();
+    DecodedAudio copy = decoded_audios[i].CloneForTesting();
     discarder.AdjustForDiscardedDurations(audio_stream_info.samples_per_second,
                                           &copy);
-    ASSERT_EQ(*copy, *decoded_audios[i]);
+    ASSERT_EQ(copy, decoded_audios[i]);
   }
 
   discarder.Reset();
 
   discarder.OnInputBuffers(input_buffers);
 
-  for (auto decoded_audio : decoded_audios) {
-    auto copy = decoded_audio->Clone();
+  for (const auto& decoded_audio : decoded_audios) {
+    DecodedAudio copy = decoded_audio.CloneForTesting();
     discarder.AdjustForDiscardedDurations(audio_stream_info.samples_per_second,
                                           &copy);
-    ASSERT_EQ(*copy, *decoded_audio);
+    ASSERT_EQ(copy, decoded_audio);
   }
 }
 
 TEST_P(AudioFrameDiscarderTest, PartialAudio) {
   InputBuffers input_buffers;
-  std::vector<scoped_refptr<DecodedAudio>> decoded_audios;
+  std::vector<DecodedAudio> decoded_audios;
   const auto& audio_stream_info = dmp_reader_.audio_stream_info();
   const int64_t duration = AudioFramesToDuration(
-      MakeDecodedAudio(audio_stream_info.number_of_channels, 0)->frames(),
+      MakeDecodedAudio(audio_stream_info.number_of_channels, 0).frames(),
       audio_stream_info.samples_per_second);
 
   for (int i = 0; i < std::min<int>(32, dmp_reader_.number_of_audio_buffers());
@@ -120,13 +119,13 @@ TEST_P(AudioFrameDiscarderTest, PartialAudio) {
 
   for (size_t i = 0; i < input_buffers.size(); ++i) {
     discarder.OnInputBuffers({input_buffers[i]});
-    auto copy = decoded_audios[i]->Clone();
+    DecodedAudio copy = decoded_audios[i].CloneForTesting();
     discarder.AdjustForDiscardedDurations(audio_stream_info.samples_per_second,
                                           &copy);
     if (i % 2 == 0) {
-      ASSERT_NEAR(copy->frames(), decoded_audios[i]->frames() / 2, 2);
+      ASSERT_NEAR(copy.frames(), decoded_audios[i].frames() / 2, 2);
     } else {
-      ASSERT_EQ(*copy, *decoded_audios[i]);
+      ASSERT_EQ(copy, decoded_audios[i]);
     }
   }
 
@@ -135,13 +134,13 @@ TEST_P(AudioFrameDiscarderTest, PartialAudio) {
   discarder.OnInputBuffers(input_buffers);
 
   for (size_t i = 0; i < decoded_audios.size(); ++i) {
-    auto copy = decoded_audios[i]->Clone();
+    DecodedAudio copy = decoded_audios[i].CloneForTesting();
     discarder.AdjustForDiscardedDurations(audio_stream_info.samples_per_second,
                                           &copy);
     if (i % 2 == 0) {
-      ASSERT_NEAR(copy->frames(), decoded_audios[i]->frames() / 2, 2);
+      ASSERT_NEAR(copy.frames(), decoded_audios[i].frames() / 2, 2);
     } else {
-      ASSERT_EQ(*copy, *decoded_audios[i]);
+      ASSERT_EQ(copy, decoded_audios[i]);
     }
   }
 }

--- a/starboard/shared/starboard/player/filter/testing/audio_renderer_internal_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_renderer_internal_test.cc
@@ -14,6 +14,7 @@
 
 #include <functional>
 #include <memory>
+#include <optional>
 #include <set>
 
 #include "starboard/common/log.h"
@@ -33,6 +34,7 @@ namespace {
 using ::testing::_;
 using ::testing::AnyNumber;
 using ::testing::AtLeast;
+using ::testing::ByMove;
 using ::testing::DoAll;
 using ::testing::InSequence;
 using ::testing::InvokeWithoutArgs;
@@ -67,9 +69,10 @@ class AudioRendererTest : public ::testing::Test {
                                           kDefaultSamplesPerSecond);
 
     ON_CALL(*audio_decoder_, Read(_))
-        .WillByDefault(
-            DoAll(SetArgPointee<0>(kDefaultSamplesPerSecond),
-                  Return(scoped_refptr<DecodedAudio>(new DecodedAudio()))));
+        .WillByDefault(DoAll(
+            SetArgPointee<0>(kDefaultSamplesPerSecond), InvokeWithoutArgs([]() {
+              return std::optional<DecodedAudio>(DecodedAudio());
+            })));
     ON_CALL(*audio_renderer_sink_, Start(_, _, _, _, _, _, _, _))
         .WillByDefault(DoAll(InvokeWithoutArgs([this]() {
                                audio_renderer_sink_->SetHasStarted(true);
@@ -140,9 +143,9 @@ class AudioRendererTest : public ::testing::Test {
       scoped_refptr<InputBuffer> input_buffer = CreateInputBuffer(timestamp);
       WriteSample(input_buffer);
       CallConsumedCB();
-      scoped_refptr<DecodedAudio> decoded_audio =
+      DecodedAudio decoded_audio =
           CreateDecodedAudio(timestamp, kFramesPerBuffer);
-      SendDecoderOutput(decoded_audio);
+      SendDecoderOutput(std::move(decoded_audio));
       frames_written += kFramesPerBuffer;
     }
 
@@ -186,12 +189,13 @@ class AudioRendererTest : public ::testing::Test {
     job_queue_.RunUntilIdle();
   }
 
-  void SendDecoderOutput(const scoped_refptr<DecodedAudio>& decoded_audio) {
+  void SendDecoderOutput(DecodedAudio decoded_audio) {
     ASSERT_TRUE(output_cb_);
 
     EXPECT_CALL(*audio_decoder_, Read(_))
         .WillOnce(DoAll(SetArgPointee<0>(kDefaultSamplesPerSecond),
-                        Return(decoded_audio)));
+                        Return(ByMove(std::optional<DecodedAudio>(
+                            std::move(decoded_audio))))));
     output_cb_();
     job_queue_.RunUntilIdle();
   }
@@ -208,12 +212,11 @@ class AudioRendererTest : public ::testing::Test {
     return new InputBuffer(DeallocateSampleCB, NULL, this, sample_info);
   }
 
-  scoped_refptr<DecodedAudio> CreateDecodedAudio(int64_t timestamp,
-                                                 int frames) {
-    scoped_refptr<DecodedAudio> decoded_audio = new DecodedAudio(
+  DecodedAudio CreateDecodedAudio(int64_t timestamp, int frames) {
+    DecodedAudio decoded_audio(
         kDefaultNumberOfChannels, sample_type_, storage_type_, timestamp,
         frames * kDefaultNumberOfChannels * GetBytesPerSample(sample_type_));
-    memset(decoded_audio->data(), 0, decoded_audio->size_in_bytes());
+    memset(decoded_audio.data(), 0, decoded_audio.size_in_bytes());
     return decoded_audio;
   }
 
@@ -334,7 +337,7 @@ TEST_F(AudioRendererTest, SunnyDay) {
 
   audio_renderer_->Play();
 
-  SendDecoderOutput(new DecodedAudio);
+  SendDecoderOutput(DecodedAudio());
 
   int64_t media_time = audio_renderer_->GetCurrentMediaTime(
       &is_playing, &is_eos_played, &is_underflow, &playback_rate);
@@ -423,7 +426,7 @@ TEST_F(AudioRendererTest, SunnyDayWithDoublePlaybackRateAndInt16Samples) {
 
   audio_renderer_->Play();
 
-  SendDecoderOutput(new DecodedAudio);
+  SendDecoderOutput(DecodedAudio());
 
   int64_t media_time = audio_renderer_->GetCurrentMediaTime(
       &is_playing, &is_eos_played, &is_underflow, &playback_rate);
@@ -482,7 +485,7 @@ TEST_F(AudioRendererTest, StartPlayBeforePreroll) {
 
   int frames_written = FillRendererWithDecodedAudioAndWriteEOS(0);
 
-  SendDecoderOutput(new DecodedAudio);
+  SendDecoderOutput(DecodedAudio());
 
   bool is_playing = false;
   bool is_eos_played = true;
@@ -555,7 +558,7 @@ TEST_F(AudioRendererTest, DecoderReturnsEOSWithoutAnyData) {
   EXPECT_FALSE(prerolled_);
 
   // Return EOS from decoder without sending any audio data, which is valid.
-  SendDecoderOutput(new DecodedAudio);
+  SendDecoderOutput(DecodedAudio());
 
   EXPECT_TRUE(audio_renderer_->IsEndOfStreamPlayed());
   EXPECT_TRUE(prerolled_);
@@ -605,7 +608,7 @@ TEST_F(AudioRendererTest, DecoderConsumeAllInputBeforeReturningData) {
   EXPECT_FALSE(prerolled_);
 
   // Return EOS from decoder without sending any audio data, which is valid.
-  SendDecoderOutput(new DecodedAudio);
+  SendDecoderOutput(DecodedAudio());
 
   EXPECT_TRUE(audio_renderer_->IsEndOfStreamPlayed());
   EXPECT_TRUE(prerolled_);
@@ -668,7 +671,7 @@ TEST_F(AudioRendererTest, MoreNumberOfOutputBuffersThanInputBuffers) {
 
   audio_renderer_->Play();
 
-  SendDecoderOutput(new DecodedAudio);
+  SendDecoderOutput(DecodedAudio());
 
   int64_t media_time = audio_renderer_->GetCurrentMediaTime(
       &is_playing, &is_eos_played, &is_underflow, &playback_rate);
@@ -763,7 +766,7 @@ TEST_F(AudioRendererTest, LessNumberOfOutputBuffersThanInputBuffers) {
 
   audio_renderer_->Play();
 
-  SendDecoderOutput(new DecodedAudio);
+  SendDecoderOutput(DecodedAudio());
 
   int64_t media_time = audio_renderer_->GetCurrentMediaTime(
       &is_playing, &is_eos_played, &is_underflow, &playback_rate);
@@ -837,7 +840,7 @@ TEST_F(AudioRendererTest, Seek) {
 
   audio_renderer_->Play();
 
-  SendDecoderOutput(new DecodedAudio);
+  SendDecoderOutput(DecodedAudio());
 
   int64_t media_time = audio_renderer_->GetCurrentMediaTime(
       &is_playing, &is_eos_played, &is_underflow, &playback_rate);
@@ -873,7 +876,7 @@ TEST_F(AudioRendererTest, Seek) {
   EXPECT_TRUE(prerolled_);
 
   audio_renderer_->Play();
-  SendDecoderOutput(new DecodedAudio);
+  SendDecoderOutput(DecodedAudio());
 
   renderer_callback_->GetSourceStatus(&frames_in_buffer, &offset_in_frames,
                                       &is_playing, &is_eos_reached);

--- a/starboard/shared/starboard/player/filter/testing/audio_resampler_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_resampler_test.cc
@@ -14,6 +14,7 @@
 
 #include "starboard/shared/starboard/player/filter/audio_resampler.h"
 
+#include <optional>
 #include <tuple>
 #include <vector>
 
@@ -94,11 +95,11 @@ class AudioResamplerTest
               ? sizeof(int16_t)
               : sizeof(float);
       int audio_size = kSamplesPerInput * channels_ * sample_size;
-      scoped_refptr<DecodedAudio> input = new DecodedAudio(
-          channels_, source_sample_type_, source_storage_type_,
-          1'000'000LL * total_frames / source_sample_rate_, audio_size);
+      DecodedAudio input(channels_, source_sample_type_, source_storage_type_,
+                         1'000'000LL * total_frames / source_sample_rate_,
+                         audio_size);
       total_frames += kSamplesPerInput;
-      inputs_.push_back(input);
+      inputs_.push_back(std::move(input));
     }
   }
 
@@ -110,7 +111,7 @@ class AudioResamplerTest
   int destination_sample_rate_;
   int channels_;
 
-  std::vector<scoped_refptr<DecodedAudio>> inputs_;
+  std::vector<DecodedAudio> inputs_;
 };
 
 TEST_P(AudioResamplerTest, SunnyDay) {
@@ -120,17 +121,18 @@ TEST_P(AudioResamplerTest, SunnyDay) {
       destination_sample_rate_, channels_);
 
   int total_input_frames = 0;
-  std::vector<scoped_refptr<DecodedAudio>> outputs;
-  for (auto input : inputs_) {
-    scoped_refptr<DecodedAudio> output = resampler->Resample(input);
-    total_input_frames += input->frames();
-    if (output) {
-      outputs.push_back(output);
+  std::vector<DecodedAudio> outputs;
+  for (const auto& input : inputs_) {
+    std::optional<DecodedAudio> output =
+        resampler->Resample(input.CloneForTesting());
+    total_input_frames += input.frames();
+    if (output.has_value()) {
+      outputs.push_back(std::move(*output));
     }
   }
-  scoped_refptr<DecodedAudio> output = resampler->WriteEndOfStream();
-  if (output) {
-    outputs.push_back(output);
+  std::optional<DecodedAudio> output = resampler->WriteEndOfStream();
+  if (output.has_value()) {
+    outputs.push_back(std::move(*output));
   }
 
   // Theoretically, if the input is too small, the last output could consist
@@ -140,11 +142,11 @@ TEST_P(AudioResamplerTest, SunnyDay) {
   EXPECT_EQ(inputs_.size(), outputs.size());
   int total_output_frames = 0;
   for (size_t i = 0; i < outputs.size(); i++) {
-    EXPECT_EQ(inputs_[i]->timestamp(), outputs[i]->timestamp());
-    total_output_frames += outputs[i]->frames();
+    EXPECT_EQ(inputs_[i].timestamp(), outputs[i].timestamp());
+    total_output_frames += outputs[i].frames();
     EXPECT_NEAR(
-        inputs_[i]->frames() * destination_sample_rate_ / source_sample_rate_,
-        outputs[i]->frames(), 5);
+        inputs_[i].frames() * destination_sample_rate_ / source_sample_rate_,
+        outputs[i].frames(), 5);
   }
   EXPECT_NEAR(
       total_input_frames * destination_sample_rate_ / source_sample_rate_,

--- a/starboard/shared/starboard/player/filter/testing/decoded_audio_benchmark.cc
+++ b/starboard/shared/starboard/player/filter/testing/decoded_audio_benchmark.cc
@@ -23,11 +23,11 @@ constexpr int64_t kTimestampUsec = 1'000'000;
 constexpr int kNumFrames = 2048;  // Realistic audio frame size
 constexpr int kSizeInBytes = kNumFrames * kChannels * sizeof(int16_t);
 
-scoped_refptr<DecodedAudio> CreateInt16PlanarBuffer() {
-  auto buffer = make_scoped_refptr<DecodedAudio>(
-      kChannels, kSbMediaAudioSampleTypeInt16Deprecated,
-      kSbMediaAudioFrameStorageTypePlanar, kTimestampUsec, kSizeInBytes);
-  int16_t* data = buffer->data_as_int16();
+DecodedAudio CreateInt16PlanarBuffer() {
+  DecodedAudio buffer(kChannels, kSbMediaAudioSampleTypeInt16Deprecated,
+                      kSbMediaAudioFrameStorageTypePlanar, kTimestampUsec,
+                      kSizeInBytes);
+  int16_t* data = buffer.data_as_int16();
   for (int i = 0; i < kNumFrames * kChannels; ++i) {
     // Generates a linear ramp covering the full range of int16_t [-32768,
     // 32767].
@@ -36,12 +36,12 @@ scoped_refptr<DecodedAudio> CreateInt16PlanarBuffer() {
   return buffer;
 }
 
-scoped_refptr<DecodedAudio> CreateFloatInterleavedBuffer() {
+DecodedAudio CreateFloatInterleavedBuffer() {
   int float_size = kNumFrames * kChannels * sizeof(float);
-  auto buffer = make_scoped_refptr<DecodedAudio>(
-      kChannels, kSbMediaAudioSampleTypeFloat32,
-      kSbMediaAudioFrameStorageTypeInterleaved, kTimestampUsec, float_size);
-  float* data = buffer->data_as_float32();
+  DecodedAudio buffer(kChannels, kSbMediaAudioSampleTypeFloat32,
+                      kSbMediaAudioFrameStorageTypeInterleaved, kTimestampUsec,
+                      float_size);
+  float* data = buffer.data_as_float32();
   for (int i = 0; i < kNumFrames * kChannels; ++i) {
     // Generates a linear ramp of float values in [-1.0f, 1.0f] spanning the
     // full audio range.
@@ -50,11 +50,11 @@ scoped_refptr<DecodedAudio> CreateFloatInterleavedBuffer() {
   return buffer;
 }
 
-scoped_refptr<DecodedAudio> CreateInt16InterleavedBuffer() {
-  auto buffer = make_scoped_refptr<DecodedAudio>(
-      kChannels, kSbMediaAudioSampleTypeInt16Deprecated,
-      kSbMediaAudioFrameStorageTypeInterleaved, kTimestampUsec, kSizeInBytes);
-  int16_t* data = buffer->data_as_int16();
+DecodedAudio CreateInt16InterleavedBuffer() {
+  DecodedAudio buffer(kChannels, kSbMediaAudioSampleTypeInt16Deprecated,
+                      kSbMediaAudioFrameStorageTypeInterleaved, kTimestampUsec,
+                      kSizeInBytes);
+  int16_t* data = buffer.data_as_int16();
   for (int i = 0; i < kNumFrames * kChannels; ++i) {
     // Generates a linear ramp covering the full range of int16_t [-32768,
     // 32767].
@@ -63,12 +63,12 @@ scoped_refptr<DecodedAudio> CreateInt16InterleavedBuffer() {
   return buffer;
 }
 
-scoped_refptr<DecodedAudio> CreateFloatPlanarBuffer() {
+DecodedAudio CreateFloatPlanarBuffer() {
   int float_size = kNumFrames * kChannels * sizeof(float);
-  auto buffer = make_scoped_refptr<DecodedAudio>(
-      kChannels, kSbMediaAudioSampleTypeFloat32,
-      kSbMediaAudioFrameStorageTypePlanar, kTimestampUsec, float_size);
-  float* data = buffer->data_as_float32();
+  DecodedAudio buffer(kChannels, kSbMediaAudioSampleTypeFloat32,
+                      kSbMediaAudioFrameStorageTypePlanar, kTimestampUsec,
+                      float_size);
+  float* data = buffer.data_as_float32();
   for (int i = 0; i < kNumFrames * kChannels; ++i) {
     // Generates a linear ramp of float values in [-1.0f, 1.0f] spanning the
     // full audio range.
@@ -81,9 +81,9 @@ void BM_SwitchFormat_Int16PlanarToFloatInterleaved_Cpp(
     benchmark::State& state) {
   auto src = CreateInt16PlanarBuffer();
   for (auto _ : state) {
-    auto dst = src->SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
-                                   kSbMediaAudioFrameStorageTypeInterleaved,
-                                   /*force_simd=*/false);
+    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
+                                  kSbMediaAudioFrameStorageTypeInterleaved,
+                                  /*force_simd=*/false);
     benchmark::DoNotOptimize(dst);
   }
   state.SetItemsProcessed(state.iterations() * kNumFrames);
@@ -94,9 +94,9 @@ void BM_SwitchFormat_Int16PlanarToFloatInterleaved_Neon(
     benchmark::State& state) {
   auto src = CreateInt16PlanarBuffer();
   for (auto _ : state) {
-    auto dst = src->SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
-                                   kSbMediaAudioFrameStorageTypeInterleaved,
-                                   /*force_simd=*/true);
+    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
+                                  kSbMediaAudioFrameStorageTypeInterleaved,
+                                  /*force_simd=*/true);
     benchmark::DoNotOptimize(dst);
   }
   state.SetItemsProcessed(state.iterations() * kNumFrames);
@@ -107,9 +107,9 @@ void BM_SwitchFormat_FloatInterleavedToInt16Planar_Cpp(
     benchmark::State& state) {
   auto src = CreateFloatInterleavedBuffer();
   for (auto _ : state) {
-    auto dst = src->SwitchFormatTo(kSbMediaAudioSampleTypeInt16Deprecated,
-                                   kSbMediaAudioFrameStorageTypePlanar,
-                                   /*force_simd=*/false);
+    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeInt16Deprecated,
+                                  kSbMediaAudioFrameStorageTypePlanar,
+                                  /*force_simd=*/false);
     benchmark::DoNotOptimize(dst);
   }
   state.SetItemsProcessed(state.iterations() * kNumFrames);
@@ -120,9 +120,9 @@ void BM_SwitchFormat_FloatInterleavedToInt16Planar_Neon(
     benchmark::State& state) {
   auto src = CreateFloatInterleavedBuffer();
   for (auto _ : state) {
-    auto dst = src->SwitchFormatTo(kSbMediaAudioSampleTypeInt16Deprecated,
-                                   kSbMediaAudioFrameStorageTypePlanar,
-                                   /*force_simd=*/true);
+    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeInt16Deprecated,
+                                  kSbMediaAudioFrameStorageTypePlanar,
+                                  /*force_simd=*/true);
     benchmark::DoNotOptimize(dst);
   }
   state.SetItemsProcessed(state.iterations() * kNumFrames);
@@ -133,9 +133,9 @@ void BM_SwitchSampleType_Int16ToFloat_Cpp(benchmark::State& state) {
   auto src = CreateInt16PlanarBuffer();  // SwitchSampleTypeTo keeps same
                                          // storage (planar)
   for (auto _ : state) {
-    auto dst = src->SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
-                                   kSbMediaAudioFrameStorageTypePlanar,
-                                   /*force_simd=*/false);
+    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
+                                  kSbMediaAudioFrameStorageTypePlanar,
+                                  /*force_simd=*/false);
     benchmark::DoNotOptimize(dst);
   }
   state.SetItemsProcessed(state.iterations() * kNumFrames);
@@ -145,9 +145,9 @@ BENCHMARK(BM_SwitchSampleType_Int16ToFloat_Cpp);
 void BM_SwitchSampleType_Int16ToFloat_Neon(benchmark::State& state) {
   auto src = CreateInt16PlanarBuffer();
   for (auto _ : state) {
-    auto dst = src->SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
-                                   kSbMediaAudioFrameStorageTypePlanar,
-                                   /*force_simd=*/true);
+    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
+                                  kSbMediaAudioFrameStorageTypePlanar,
+                                  /*force_simd=*/true);
     benchmark::DoNotOptimize(dst);
   }
   state.SetItemsProcessed(state.iterations() * kNumFrames);
@@ -157,9 +157,9 @@ BENCHMARK(BM_SwitchSampleType_Int16ToFloat_Neon);
 void BM_SwitchSampleType_FloatToInt16_Cpp(benchmark::State& state) {
   auto src = CreateFloatInterleavedBuffer();  // keeps interleaved
   for (auto _ : state) {
-    auto dst = src->SwitchFormatTo(kSbMediaAudioSampleTypeInt16Deprecated,
-                                   kSbMediaAudioFrameStorageTypeInterleaved,
-                                   /*force_simd=*/false);
+    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeInt16Deprecated,
+                                  kSbMediaAudioFrameStorageTypeInterleaved,
+                                  /*force_simd=*/false);
     benchmark::DoNotOptimize(dst);
   }
   state.SetItemsProcessed(state.iterations() * kNumFrames);
@@ -169,9 +169,9 @@ BENCHMARK(BM_SwitchSampleType_FloatToInt16_Cpp);
 void BM_SwitchSampleType_FloatToInt16_Neon(benchmark::State& state) {
   auto src = CreateFloatInterleavedBuffer();
   for (auto _ : state) {
-    auto dst = src->SwitchFormatTo(kSbMediaAudioSampleTypeInt16Deprecated,
-                                   kSbMediaAudioFrameStorageTypeInterleaved,
-                                   /*force_simd=*/true);
+    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeInt16Deprecated,
+                                  kSbMediaAudioFrameStorageTypeInterleaved,
+                                  /*force_simd=*/true);
     benchmark::DoNotOptimize(dst);
   }
   state.SetItemsProcessed(state.iterations() * kNumFrames);
@@ -182,9 +182,9 @@ void BM_SwitchStorageType_Int16InterleavedToPlanar_Cpp(
     benchmark::State& state) {
   auto src = CreateInt16InterleavedBuffer();
   for (auto _ : state) {
-    auto dst = src->SwitchFormatTo(kSbMediaAudioSampleTypeInt16Deprecated,
-                                   kSbMediaAudioFrameStorageTypePlanar,
-                                   /*force_simd=*/false);
+    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeInt16Deprecated,
+                                  kSbMediaAudioFrameStorageTypePlanar,
+                                  /*force_simd=*/false);
     benchmark::DoNotOptimize(dst);
   }
   state.SetItemsProcessed(state.iterations() * kNumFrames);
@@ -195,9 +195,9 @@ void BM_SwitchStorageType_Int16InterleavedToPlanar_Neon(
     benchmark::State& state) {
   auto src = CreateInt16InterleavedBuffer();
   for (auto _ : state) {
-    auto dst = src->SwitchFormatTo(kSbMediaAudioSampleTypeInt16Deprecated,
-                                   kSbMediaAudioFrameStorageTypePlanar,
-                                   /*force_simd=*/true);
+    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeInt16Deprecated,
+                                  kSbMediaAudioFrameStorageTypePlanar,
+                                  /*force_simd=*/true);
     benchmark::DoNotOptimize(dst);
   }
   state.SetItemsProcessed(state.iterations() * kNumFrames);
@@ -208,9 +208,9 @@ void BM_SwitchStorageType_Int16PlanarToInterleaved_Cpp(
     benchmark::State& state) {
   auto src = CreateInt16PlanarBuffer();
   for (auto _ : state) {
-    auto dst = src->SwitchFormatTo(kSbMediaAudioSampleTypeInt16Deprecated,
-                                   kSbMediaAudioFrameStorageTypeInterleaved,
-                                   /*force_simd=*/false);
+    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeInt16Deprecated,
+                                  kSbMediaAudioFrameStorageTypeInterleaved,
+                                  /*force_simd=*/false);
     benchmark::DoNotOptimize(dst);
   }
   state.SetItemsProcessed(state.iterations() * kNumFrames);
@@ -221,9 +221,9 @@ void BM_SwitchStorageType_Int16PlanarToInterleaved_Neon(
     benchmark::State& state) {
   auto src = CreateInt16PlanarBuffer();
   for (auto _ : state) {
-    auto dst = src->SwitchFormatTo(kSbMediaAudioSampleTypeInt16Deprecated,
-                                   kSbMediaAudioFrameStorageTypeInterleaved,
-                                   /*force_simd=*/true);
+    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeInt16Deprecated,
+                                  kSbMediaAudioFrameStorageTypeInterleaved,
+                                  /*force_simd=*/true);
     benchmark::DoNotOptimize(dst);
   }
   state.SetItemsProcessed(state.iterations() * kNumFrames);
@@ -234,9 +234,9 @@ void BM_SwitchStorageType_FloatInterleavedToPlanar_Cpp(
     benchmark::State& state) {
   auto src = CreateFloatInterleavedBuffer();
   for (auto _ : state) {
-    auto dst = src->SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
-                                   kSbMediaAudioFrameStorageTypePlanar,
-                                   /*force_simd=*/false);
+    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
+                                  kSbMediaAudioFrameStorageTypePlanar,
+                                  /*force_simd=*/false);
     benchmark::DoNotOptimize(dst);
   }
   state.SetItemsProcessed(state.iterations() * kNumFrames);
@@ -247,9 +247,9 @@ void BM_SwitchStorageType_FloatInterleavedToPlanar_Neon(
     benchmark::State& state) {
   auto src = CreateFloatInterleavedBuffer();
   for (auto _ : state) {
-    auto dst = src->SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
-                                   kSbMediaAudioFrameStorageTypePlanar,
-                                   /*force_simd=*/true);
+    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
+                                  kSbMediaAudioFrameStorageTypePlanar,
+                                  /*force_simd=*/true);
     benchmark::DoNotOptimize(dst);
   }
   state.SetItemsProcessed(state.iterations() * kNumFrames);
@@ -260,9 +260,9 @@ void BM_SwitchStorageType_FloatPlanarToInterleaved_Cpp(
     benchmark::State& state) {
   auto src = CreateFloatPlanarBuffer();
   for (auto _ : state) {
-    auto dst = src->SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
-                                   kSbMediaAudioFrameStorageTypeInterleaved,
-                                   /*force_simd=*/false);
+    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
+                                  kSbMediaAudioFrameStorageTypeInterleaved,
+                                  /*force_simd=*/false);
     benchmark::DoNotOptimize(dst);
   }
   state.SetItemsProcessed(state.iterations() * kNumFrames);
@@ -273,9 +273,9 @@ void BM_SwitchStorageType_FloatPlanarToInterleaved_Neon(
     benchmark::State& state) {
   auto src = CreateFloatPlanarBuffer();
   for (auto _ : state) {
-    auto dst = src->SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
-                                   kSbMediaAudioFrameStorageTypeInterleaved,
-                                   /*force_simd=*/true);
+    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
+                                  kSbMediaAudioFrameStorageTypeInterleaved,
+                                  /*force_simd=*/true);
     benchmark::DoNotOptimize(dst);
   }
   state.SetItemsProcessed(state.iterations() * kNumFrames);

--- a/starboard/shared/starboard/player/filter/testing/wsola_internal_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/wsola_internal_test.cc
@@ -34,19 +34,18 @@ constexpr float kFrequency = 440.0f;
 
 // A helper function to create a simple DecodedAudio object for testing.
 // It allocates memory and fills it with a simple sine wave.
-scoped_refptr<DecodedAudio> CreateTestDecodedAudio(int frames,
-                                                   int channels,
-                                                   int sample_rate,
-                                                   float frequency,
-                                                   float amplitude) {
+DecodedAudio CreateTestDecodedAudio(int frames,
+                                    int channels,
+                                    int sample_rate,
+                                    float frequency,
+                                    float amplitude) {
   const int kBytesPerFrame = channels * sizeof(float);
   const int kBufferSize = frames * kBytesPerFrame;
 
-  scoped_refptr<DecodedAudio> audio = new DecodedAudio(
-      channels, kSbMediaAudioSampleTypeFloat32,
-      kSbMediaAudioFrameStorageTypeInterleaved, 0, kBufferSize);
+  DecodedAudio audio(channels, kSbMediaAudioSampleTypeFloat32,
+                     kSbMediaAudioFrameStorageTypeInterleaved, 0, kBufferSize);
 
-  float* data = audio->data_as_float32();
+  float* data = audio.data_as_float32();
   for (int i = 0; i < frames; ++i) {
     for (int c = 0; c < channels; ++c) {
       data[i * channels + c] =
@@ -61,21 +60,21 @@ TEST(WsolaInternalTest, OptimalIndex_ExactMatch) {
   const int kChannels = 1;
   const float kAmplitude = 0.5f;
 
-  scoped_refptr<DecodedAudio> target_block = CreateTestDecodedAudio(
-      50, kChannels, kSampleRate, kFrequency, kAmplitude);
-  scoped_refptr<DecodedAudio> search_block = CreateTestDecodedAudio(
+  DecodedAudio target_block = CreateTestDecodedAudio(50, kChannels, kSampleRate,
+                                                     kFrequency, kAmplitude);
+  DecodedAudio search_block = CreateTestDecodedAudio(
       kFrames, kChannels, kSampleRate, kFrequency, kAmplitude);
 
   // Place an exact match at index 25
-  float* search_data = search_block->data_as_float32();
-  float* target_data = target_block->data_as_float32();
+  float* search_data = search_block.data_as_float32();
+  float* target_data = target_block.data_as_float32();
   memcpy(search_data + 25 * kChannels, target_data,
          50 * kChannels * sizeof(float));
 
   Interval exclude_interval = {-1, -1};  // No exclusion
 
   int optimal_index =
-      OptimalIndex(search_block.get(), target_block.get(),
+      OptimalIndex(&search_block, &target_block,
                    kSbMediaAudioFrameStorageTypeInterleaved, exclude_interval);
   // Due to floating point precision and quadratic interpolation, it might not
   // be exactly 25, but should be very close. We test for a small range.
@@ -86,20 +85,20 @@ TEST(WsolaInternalTest, OptimalIndex_NoMatch) {
   const int kFrames = 100;
   const int kChannels = 1;
 
-  scoped_refptr<DecodedAudio> target_block =
+  DecodedAudio target_block =
       CreateTestDecodedAudio(50, kChannels, kSampleRate, 440.0f, 0.5f);
-  scoped_refptr<DecodedAudio> search_block = CreateTestDecodedAudio(
+  DecodedAudio search_block = CreateTestDecodedAudio(
       kFrames, kChannels, kSampleRate, 1000.0f, 0.5f);  // Different frequency
 
   Interval exclude_interval = {-1, -1};  // No exclusion
 
   int optimal_index =
-      OptimalIndex(search_block.get(), target_block.get(),
+      OptimalIndex(&search_block, &target_block,
                    kSbMediaAudioFrameStorageTypeInterleaved, exclude_interval);
   // With no clear match, the result is less predictable, but it shouldn't crash
   // and should return a valid index within the search range.
   EXPECT_GE(optimal_index, 0);
-  EXPECT_LE(optimal_index, kFrames - target_block->frames());
+  EXPECT_LE(optimal_index, kFrames - target_block.frames());
 }
 
 TEST(WsolaInternalTest, OptimalIndex_ExcludeInterval) {
@@ -107,14 +106,14 @@ TEST(WsolaInternalTest, OptimalIndex_ExcludeInterval) {
   const int kChannels = 1;
   const float kAmplitude = 0.5f;
 
-  scoped_refptr<DecodedAudio> target_block = CreateTestDecodedAudio(
-      20, kChannels, kSampleRate, kFrequency, kAmplitude);
-  scoped_refptr<DecodedAudio> search_block = CreateTestDecodedAudio(
+  DecodedAudio target_block = CreateTestDecodedAudio(20, kChannels, kSampleRate,
+                                                     kFrequency, kAmplitude);
+  DecodedAudio search_block = CreateTestDecodedAudio(
       kFrames, kChannels, kSampleRate, kFrequency, kAmplitude);
 
   // Create an exact match within the exclusion interval
-  float* search_data = search_block->data_as_float32();
-  float* target_data = target_block->data_as_float32();
+  float* search_data = search_block.data_as_float32();
+  float* target_data = target_block.data_as_float32();
   memcpy(search_data + 10 * kChannels, target_data,
          20 * kChannels * sizeof(float));  // Match at 10
 
@@ -125,7 +124,7 @@ TEST(WsolaInternalTest, OptimalIndex_ExcludeInterval) {
   Interval exclude_interval = {5, 15};  // Exclude indices from 5 to 15
 
   int optimal_index =
-      OptimalIndex(search_block.get(), target_block.get(),
+      OptimalIndex(&search_block, &target_block,
                    kSbMediaAudioFrameStorageTypeInterleaved, exclude_interval);
 
   // The match at 10 should be excluded, so it should find the match at 50.
@@ -136,20 +135,20 @@ TEST(WsolaInternalTest, OptimalIndex_SmallBlocks) {
   const int kFrames = 20;
   const int kChannels = 1;
 
-  scoped_refptr<DecodedAudio> target_block =
+  DecodedAudio target_block =
       CreateTestDecodedAudio(5, kChannels, kSampleRate, 440.0f, 0.5f);
-  scoped_refptr<DecodedAudio> search_block =
+  DecodedAudio search_block =
       CreateTestDecodedAudio(kFrames, kChannels, kSampleRate, 440.0f, 0.5f);
 
-  float* search_data = search_block->data_as_float32();
-  float* target_data = target_block->data_as_float32();
+  float* search_data = search_block.data_as_float32();
+  float* target_data = target_block.data_as_float32();
   memcpy(search_data + 10 * kChannels, target_data,
          5 * kChannels * sizeof(float));
 
   Interval exclude_interval = {-1, -1};
 
   int optimal_index =
-      OptimalIndex(search_block.get(), target_block.get(),
+      OptimalIndex(&search_block, &target_block,
                    kSbMediaAudioFrameStorageTypeInterleaved, exclude_interval);
   EXPECT_NEAR(optimal_index, 10, 1);
 }

--- a/starboard/tvos/shared/media/audio_decoder.h
+++ b/starboard/tvos/shared/media/audio_decoder.h
@@ -17,6 +17,7 @@
 
 #import <AVFoundation/AVFoundation.h>
 
+#include <optional>
 #include <queue>
 
 #include "starboard/shared/starboard/media/media_util.h"
@@ -36,7 +37,7 @@ class TvosAudioDecoder : public AudioDecoder, private JobQueue::JobOwner {
   void Decode(const InputBuffers& input_buffers,
               const ConsumedCB& consumed_cb) override;
   void WriteEndOfStream() override;
-  scoped_refptr<DecodedAudio> Read(int* samples_per_second) override;
+  std::optional<DecodedAudio> Read(int* samples_per_second) override;
   void Reset() override;
 
  private:
@@ -64,7 +65,7 @@ class TvosAudioDecoder : public AudioDecoder, private JobQueue::JobOwner {
   const AudioStreamInfo audio_stream_info_;
   OutputCB output_cb_;
   ErrorCB error_cb_;
-  std::queue<scoped_refptr<DecodedAudio>> decoded_audios_;
+  std::queue<DecodedAudio> decoded_audios_;
   int bytes_per_frame_;
   UInt32 input_format_id_;
   UInt32 input_header_size_ = 0;

--- a/starboard/tvos/shared/media/audio_decoder.mm
+++ b/starboard/tvos/shared/media/audio_decoder.mm
@@ -92,11 +92,11 @@ void TvosAudioDecoder::Decode(const InputBuffers& input_buffers,
 
     auto output_byte_size = expected_output_frames_in_packet * bytes_per_frame_;
 
-    scoped_refptr<DecodedAudio> decoded_audio = new DecodedAudio(
-        audio_stream_info_.number_of_channels, kSbMediaAudioSampleTypeFloat32,
-        kSbMediaAudioFrameStorageTypeInterleaved, input_buffer->timestamp(),
-        output_byte_size);
-    audio_buffer_list_.mBuffers[0].mData = decoded_audio->data();
+    DecodedAudio decoded_audio(audio_stream_info_.number_of_channels,
+                               kSbMediaAudioSampleTypeFloat32,
+                               kSbMediaAudioFrameStorageTypeInterleaved,
+                               input_buffer->timestamp(), output_byte_size);
+    audio_buffer_list_.mBuffers[0].mData = decoded_audio.data();
     audio_buffer_list_.mBuffers[0].mDataByteSize = output_byte_size;
 
     UInt32 actual_output_frames_in_packets = expected_output_frames_in_packet;
@@ -137,7 +137,7 @@ void TvosAudioDecoder::Decode(const InputBuffers& input_buffers,
     audio_frame_discarder_.AdjustForDiscardedDurations(
         audio_stream_info_.samples_per_second, &decoded_audio);
 
-    decoded_audios_.push(decoded_audio);
+    decoded_audios_.push(std::move(decoded_audio));
     Schedule(output_cb_);
     return;
   }
@@ -151,21 +151,21 @@ void TvosAudioDecoder::WriteEndOfStream() {
 
   stream_ended_ = true;
   // Put EOS into the queue.
-  decoded_audios_.push(new DecodedAudio);
+  decoded_audios_.push(DecodedAudio());
 
   audio_frame_discarder_.OnDecodedAudioEndOfStream();
 
   Schedule(output_cb_);
 }
 
-scoped_refptr<DecodedAudio> TvosAudioDecoder::Read(int* samples_per_second) {
+std::optional<DecodedAudio> TvosAudioDecoder::Read(int* samples_per_second) {
   SB_DCHECK(BelongsToCurrentThread());
   SB_DCHECK(output_cb_);
   SB_DCHECK(!decoded_audios_.empty());
 
-  scoped_refptr<DecodedAudio> result;
+  std::optional<DecodedAudio> result;
   if (!decoded_audios_.empty()) {
-    result = decoded_audios_.front();
+    result = std::move(decoded_audios_.front());
     decoded_audios_.pop();
   }
   *samples_per_second = audio_stream_info_.samples_per_second;

--- a/starboard/tvos/shared/media/av_audio_sample_buffer_builder.mm
+++ b/starboard/tvos/shared/media/av_audio_sample_buffer_builder.mm
@@ -185,7 +185,7 @@ class OpusAVSampleBufferBuilder : public AVAudioSampleBufferBuilder {
     int frams_size = frames_in_packet * samples_per_frame;
     SB_DCHECK(frams_size > 0);
 
-    scoped_refptr<DecodedAudio> decoded_audio = new DecodedAudio(
+    DecodedAudio decoded_audio(
         audio_stream_info_.number_of_channels, kSbMediaAudioSampleTypeFloat32,
         kSbMediaAudioFrameStorageTypeInterleaved,
         input_buffer->timestamp() + media_time_offset,
@@ -193,22 +193,22 @@ class OpusAVSampleBufferBuilder : public AVAudioSampleBufferBuilder {
             GetBytesPerSample(kSbMediaAudioSampleTypeFloat32));
     int decoded_frames = opus_multistream_decode_float(
         opus_decoder_, static_cast<const unsigned char*>(input_buffer->data()),
-        input_buffer->size(), reinterpret_cast<float*>(decoded_audio->data()),
+        input_buffer->size(), reinterpret_cast<float*>(decoded_audio.data()),
         frams_size, 0);
 
     SB_DCHECK(decoded_frames == frams_size);
 
     CMBlockBufferRef block;
     OSStatus status = CMBlockBufferCreateWithMemoryBlock(
-        NULL, NULL, decoded_audio->size_in_bytes(), NULL, NULL, 0,
-        decoded_audio->size_in_bytes(), 0, &block);
+        NULL, NULL, decoded_audio.size_in_bytes(), NULL, NULL, 0,
+        decoded_audio.size_in_bytes(), 0, &block);
     if (status != 0) {
       RecordOSError("BlockBufferCreate", status);
       return false;
     }
 
-    status = CMBlockBufferReplaceDataBytes(decoded_audio->data(), block, 0,
-                                           decoded_audio->size_in_bytes());
+    status = CMBlockBufferReplaceDataBytes(decoded_audio.data(), block, 0,
+                                           decoded_audio.size_in_bytes());
     if (status != 0) {
       RecordOSError("BlockCopyData", status);
       CFRelease(block);


### PR DESCRIPTION
Refactor DecodedAudio from RefCountedThreadSafe to a plain object
passed via move semantics. This change eliminates reference counting
overhead and clarifies ownership throughout the media pipeline.

Updated Starboard player, filter, and platform implementations,
including Android, tvOS, FFmpeg, FDK AAC, and Opus, to pass
DecodedAudio by value or move.

Bug: 550523546