### PR TITLE
performance: Add MeasureApplicationUsageMemory API for accurate memory bounds on 3P devices

### DIFF
--- a/cobalt/browser/performance/performance_impl.cc
+++ b/cobalt/browser/performance/performance_impl.cc
@@ -119,6 +119,7 @@ void PerformanceImpl::MeasureSystemMemoryInfo(
 #endif
 
 #if BUILDFLAG(IS_STARBOARD)
+        // TODO(b/555849706): Migrate Android/iOS to use Starboard memory APIs.
         int64_t limit = SbSystemGetTotalCPUMemory();
         if (limit > 0) {
           info->application_limit_memory = static_cast<uint64_t>(limit);
@@ -130,6 +131,7 @@ void PerformanceImpl::MeasureSystemMemoryInfo(
 #endif
 
 #if BUILDFLAG(IS_STARBOARD)
+        // TODO(b/555849706): Migrate Android/iOS to use Starboard memory APIs.
         if (SbSystemHasCapability(kSbSystemCapabilityCanQueryGPUMemoryStats)) {
           info->used_gpu_memory = SbSystemGetUsedGPUMemory();
         }
@@ -307,6 +309,7 @@ void PerformanceImpl::MeasureUsedPssMemory(
 void PerformanceImpl::MeasureApplicationLimitMemory(
     MeasureApplicationLimitMemoryCallback callback) {
 #if BUILDFLAG(IS_STARBOARD)
+  // TODO(b/555849706): Migrate Android/iOS to use Starboard memory APIs.
   base::ThreadPool::PostTaskAndReplyWithResult(
       FROM_HERE, {base::MayBlock(), base::TaskPriority::USER_VISIBLE},
       base::BindOnce([]() -> uint64_t {
@@ -322,6 +325,7 @@ void PerformanceImpl::MeasureApplicationLimitMemory(
 void PerformanceImpl::MeasureApplicationUsageMemory(
     MeasureApplicationUsageMemoryCallback callback) {
 #if BUILDFLAG(IS_STARBOARD)
+  // TODO(b/555849706): Migrate Android/iOS to use Starboard memory APIs.
   int64_t usage = SbSystemGetUsedCPUMemory();
   std::move(callback).Run(usage > 0 ? static_cast<uint64_t>(usage) : 0);
 #else
@@ -343,6 +347,7 @@ void PerformanceImpl::MeasureApplicationUsageMemory(
 void PerformanceImpl::MeasureUsedGpuMemory(
     MeasureUsedGpuMemoryCallback callback) {
 #if BUILDFLAG(IS_STARBOARD)
+  // TODO(b/555849706): Migrate Android/iOS to use Starboard memory APIs.
   if (!SbSystemHasCapability(kSbSystemCapabilityCanQueryGPUMemoryStats)) {
     std::move(callback).Run(false, 0);
     return;

--- a/cobalt/browser/performance/performance_impl.cc
+++ b/cobalt/browser/performance/performance_impl.cc
@@ -123,6 +123,10 @@ void PerformanceImpl::MeasureSystemMemoryInfo(
         if (limit > 0) {
           info->application_limit_memory = static_cast<uint64_t>(limit);
         }
+        int64_t usage = SbSystemGetUsedCPUMemory();
+        if (usage > 0) {
+          info->application_usage_memory = static_cast<uint64_t>(usage);
+        }
 #endif
 
 #if BUILDFLAG(IS_STARBOARD)

--- a/cobalt/browser/performance/performance_impl.cc
+++ b/cobalt/browser/performance/performance_impl.cc
@@ -315,6 +315,27 @@ void PerformanceImpl::MeasureApplicationLimitMemory(
 #endif
 }
 
+void PerformanceImpl::MeasureApplicationUsageMemory(
+    MeasureApplicationUsageMemoryCallback callback) {
+#if BUILDFLAG(IS_STARBOARD)
+  int64_t usage = SbSystemGetUsedCPUMemory();
+  std::move(callback).Run(usage > 0 ? static_cast<uint64_t>(usage) : 0);
+#else
+  base::ThreadPool::PostTaskAndReplyWithResult(
+      FROM_HERE, {base::MayBlock(), base::TaskPriority::USER_VISIBLE},
+      base::BindOnce([]() -> uint64_t {
+        auto process_metrics = base::ProcessMetrics::CreateProcessMetrics(
+            base::GetCurrentProcessHandle());
+        if (!process_metrics) {
+          return 0;
+        }
+        auto info = process_metrics->GetMemoryInfo();
+        return info.has_value() ? info->resident_set_bytes : 0;
+      }),
+      std::move(callback));
+#endif
+}
+
 void PerformanceImpl::MeasureUsedGpuMemory(
     MeasureUsedGpuMemoryCallback callback) {
 #if BUILDFLAG(IS_STARBOARD)

--- a/cobalt/browser/performance/performance_impl.h
+++ b/cobalt/browser/performance/performance_impl.h
@@ -57,6 +57,8 @@ class PerformanceImpl
   void MeasureUsedPssMemory(MeasureUsedPssMemoryCallback) override;
   void MeasureApplicationLimitMemory(
       MeasureApplicationLimitMemoryCallback) override;
+  void MeasureApplicationUsageMemory(
+      MeasureApplicationUsageMemoryCallback) override;
   void MeasureUsedGpuMemory(MeasureUsedGpuMemoryCallback) override;
   void GetAppStartupTimeStamp(GetAppStartupTimeStampCallback callback) override;
 

--- a/cobalt/browser/performance/public/mojom/performance.mojom
+++ b/cobalt/browser/performance/public/mojom/performance.mojom
@@ -76,6 +76,11 @@ interface CobaltPerformance {
   // Get the application CPU memory limit in bytes.
   [Sync]
   MeasureApplicationLimitMemory() => (uint64 bytes);
+
+  // Returns the application CPU memory usage in bytes.
+  [Sync]
+  MeasureApplicationUsageMemory() => (uint64 bytes);
+
   // Get the amount of GPU memory used by the application, in bytes.
   [Sync]
   MeasureUsedGpuMemory() => (bool is_supported, uint64 bytes);

--- a/cobalt/browser/performance/public/mojom/performance.mojom
+++ b/cobalt/browser/performance/public/mojom/performance.mojom
@@ -24,6 +24,7 @@ struct SystemMemoryInfo {
   uint64 total_cpu_memory;
   uint64 used_pss_memory;
   uint64 application_limit_memory;
+  uint64 application_usage_memory;
   uint64? used_gpu_memory;
 };
 

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
@@ -136,7 +136,7 @@ static_library("starboard_platform_sources") {
     "//starboard/shared/gles/system_gles2.cc",
     "//starboard/shared/linux/system_get_random_data.cc",
     "//starboard/shared/linux/system_get_stack.cc",
-    "//starboard/shared/linux/system_get_used_cpu_memory.cc",
+    "system/system_get_used_cpu_memory.cc",
     "//starboard/shared/linux/system_is_debugger_attached.cc",
     "//starboard/shared/posix/log.cc",
     "//starboard/shared/posix/log_flush.cc",

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_total_cpu_memory.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_total_cpu_memory.cc
@@ -31,20 +31,54 @@
 
 #include <fcntl.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
 #include <algorithm>
+#include <string>
 
 #include "starboard/common/file.h"
 #include "starboard/common/log.h"
 #include "starboard/system.h"
 
-int64_t SbSystemGetTotalCPUMemory() {
+namespace {
 
+std::string GetMemoryCgroupPath(const char* property) {
+  std::string path;
+  starboard::ScopedFile cgroup_file("/proc/self/cgroup", O_RDONLY);
+
+  if (cgroup_file.IsValid()) {
+    const int kBufferSize = 4096;
+    char buffer[kBufferSize];
+    int bytes_read = cgroup_file.ReadAll(buffer, kBufferSize - 1);
+
+    if (bytes_read > 0) {
+      buffer[bytes_read] = '\0';
+      const char* memory_subsys = strstr(buffer, ":memory:");
+      if (memory_subsys) {
+        const char* line_end = strchr(memory_subsys, '\n');
+        const char* path_start = strchr(memory_subsys + 8, '/');
+        if (path_start && (!line_end || path_start < line_end)) {
+          if (line_end) {
+            path = std::string(path_start, line_end - path_start);
+          } else {
+            path = std::string(path_start);
+          }
+        }
+      }
+    }
+  }
+
+  return std::string("/sys/fs/cgroup/memory") + path + "/" + property;
+}
+
+}  // namespace
+
+int64_t SbSystemGetTotalCPUMemory() {
   int64_t limit_in_bytes = INT64_MAX;
 
   starboard::ScopedFile status_file(
-      "/sys/fs/cgroup/memory/memory.limit_in_bytes", O_RDONLY);
+      GetMemoryCgroupPath("memory.limit_in_bytes").c_str(), O_RDONLY);
 
   if (status_file.IsValid()) {
     const int kBufferSize = 512;

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_total_cpu_memory.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_total_cpu_memory.cc
@@ -31,19 +31,59 @@
 
 #include "starboard/system.h"
 
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
+
+#include <algorithm>
+#include <string>
 
 #include "starboard/common/file.h"
 #include "starboard/common/log.h"
-#include "starboard/common/string.h"
+
+
+namespace {
+
+std::string GetMemoryCgroupLimitPath() {
+  starboard::ScopedFile cgroup_file("/proc/self/cgroup", O_RDONLY);
+  if (!cgroup_file.IsValid()) {
+    return "/sys/fs/cgroup/memory/memory.limit_in_bytes";
+  }
+
+  const int kBufferSize = 4096;
+  char buffer[kBufferSize];
+  int bytes_read = cgroup_file.ReadAll(buffer, kBufferSize - 1);
+  if (bytes_read <= 0) {
+    return "/sys/fs/cgroup/memory/memory.limit_in_bytes";
+  }
+  buffer[bytes_read] = '\0';
+
+  const char* memory_subsys = strstr(buffer, ":memory:");
+  if (memory_subsys) {
+    const char* line_end = strchr(memory_subsys, '\n');
+    const char* path_start = strchr(memory_subsys + 8, '/');
+    if (path_start && (!line_end || path_start < line_end)) {
+      std::string path;
+      if (line_end) {
+        path = std::string(path_start, line_end - path_start);
+      } else {
+        path = std::string(path_start);
+      }
+      return "/sys/fs/cgroup/memory" + path + "/memory.limit_in_bytes";
+    }
+  }
+
+  return "/sys/fs/cgroup/memory/memory.limit_in_bytes";
+}
+
+}  // namespace
 
 int64_t SbSystemGetTotalCPUMemory() {
 
   int64_t limit_in_bytes = INT64_MAX;
 
-  starboard::ScopedFile status_file(
-    "/sys/fs/cgroup/memory/memory.limit_in_bytes",
-    O_RDONLY);
+  starboard::ScopedFile status_file(GetMemoryCgroupLimitPath().c_str(), O_RDONLY);
 
   if (status_file.IsValid()) {
     const int kBufferSize = 512;

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_total_cpu_memory.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_total_cpu_memory.cc
@@ -29,61 +29,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "starboard/system.h"
-
 #include <fcntl.h>
 #include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
 
 #include <algorithm>
-#include <string>
 
 #include "starboard/common/file.h"
 #include "starboard/common/log.h"
-
-
-namespace {
-
-std::string GetMemoryCgroupLimitPath() {
-  starboard::ScopedFile cgroup_file("/proc/self/cgroup", O_RDONLY);
-  if (!cgroup_file.IsValid()) {
-    return "/sys/fs/cgroup/memory/memory.limit_in_bytes";
-  }
-
-  const int kBufferSize = 4096;
-  char buffer[kBufferSize];
-  int bytes_read = cgroup_file.ReadAll(buffer, kBufferSize - 1);
-  if (bytes_read <= 0) {
-    return "/sys/fs/cgroup/memory/memory.limit_in_bytes";
-  }
-  buffer[bytes_read] = '\0';
-
-  const char* memory_subsys = strstr(buffer, ":memory:");
-  if (memory_subsys) {
-    const char* line_end = strchr(memory_subsys, '\n');
-    const char* path_start = strchr(memory_subsys + 8, '/');
-    if (path_start && (!line_end || path_start < line_end)) {
-      std::string path;
-      if (line_end) {
-        path = std::string(path_start, line_end - path_start);
-      } else {
-        path = std::string(path_start);
-      }
-      return "/sys/fs/cgroup/memory" + path + "/memory.limit_in_bytes";
-    }
-  }
-
-  return "/sys/fs/cgroup/memory/memory.limit_in_bytes";
-}
-
-}  // namespace
+#include "starboard/system.h"
 
 int64_t SbSystemGetTotalCPUMemory() {
 
   int64_t limit_in_bytes = INT64_MAX;
 
-  starboard::ScopedFile status_file(GetMemoryCgroupLimitPath().c_str(), O_RDONLY);
+  starboard::ScopedFile status_file(
+      "/sys/fs/cgroup/memory/memory.limit_in_bytes", O_RDONLY);
 
   if (status_file.IsValid()) {
     const int kBufferSize = 512;

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_used_cpu_memory.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_used_cpu_memory.cc
@@ -1,0 +1,77 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// clang-format off
+#include "starboard/system.h"
+// clang-format on
+
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "starboard/common/file.h"
+#include "starboard/common/log.h"
+#include "starboard/common/string.h"
+
+namespace {
+
+int64_t SearchForMemoryValue(const char* search_key, const char* buffer) {
+  const char* found = strstr(buffer, search_key);
+  if (!found) {
+    SB_LOG(ERROR) << "Could not find '" << search_key << "' in smaps_rollup.";
+    return 0;
+  }
+
+  const char* digits = strpbrk(found + strlen(search_key), "0123456789");
+  if (!digits) {
+    SB_LOG(ERROR) << "Could not find any digits for '" << search_key
+                  << "' in smaps_rollup.";
+    return 0;
+  }
+
+  int64_t memory_value_in_kilobytes = 0;
+  if (sscanf(digits, "%" PRId64, &memory_value_in_kilobytes) != 1) {
+    SB_LOG(ERROR) << "Could not parse integer value for '" << search_key
+                  << "' in smaps_rollup.";
+    return 0;
+  }
+
+  return memory_value_in_kilobytes * 1024;
+}
+
+}  // namespace
+
+int64_t SbSystemGetUsedCPUMemory() {
+  // On RDK devices, /proc/self/smaps_rollup is optimized to provide accurate
+  // memory footprint calculations avoiding double counting UMA GPU memory buffers
+  // that can be misreported by /proc/self/status VmRSS.
+  starboard::ScopedFile status_file("/proc/self/smaps_rollup", O_RDONLY);
+  if (!status_file.IsValid()) {
+    SB_LOG(ERROR)
+        << "Error opening /proc/self/smaps_rollup in order to query self memory usage.";
+    return 0;
+  }
+
+  const int kBufferSize = 4096;
+  char buffer[kBufferSize];
+  int bytes_read = status_file.ReadAll(buffer, kBufferSize - 1);
+  if (bytes_read < 0) {
+    bytes_read = 0;
+  }
+  buffer[bytes_read] = '\0';
+
+  // Use Rss footprint from smaps_rollup which is robust on RDK.
+  return SearchForMemoryValue("Rss:", buffer);
+}

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_used_cpu_memory.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_used_cpu_memory.cc
@@ -12,19 +12,54 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// clang-format off
-#include "starboard/system.h"
-// clang-format on
-
 #include <fcntl.h>
 #include <stdlib.h>
+#include <string.h>
+
+#include <string>
 
 #include "starboard/common/file.h"
 #include "starboard/common/log.h"
+#include "starboard/common/string.h"
+#include "starboard/system.h"
+
+namespace {
+
+std::string GetMemoryCgroupPath(const char* property) {
+  std::string path;
+  starboard::ScopedFile cgroup_file("/proc/self/cgroup", O_RDONLY);
+
+  if (cgroup_file.IsValid()) {
+    const int kBufferSize = 4096;
+    char buffer[kBufferSize];
+    int bytes_read = cgroup_file.ReadAll(buffer, kBufferSize - 1);
+
+    if (bytes_read > 0) {
+      buffer[bytes_read] = '\0';
+      const char* memory_subsys = strstr(buffer, ":memory:");
+      if (memory_subsys) {
+        const char* line_end = strchr(memory_subsys, '\n');
+        const char* path_start = strchr(memory_subsys + 8, '/');
+        if (path_start && (!line_end || path_start < line_end)) {
+          if (line_end) {
+            path = std::string(path_start, line_end - path_start);
+          } else {
+            path = std::string(path_start);
+          }
+        }
+      }
+    }
+  }
+
+  return std::string("/sys/fs/cgroup/memory") + path + "/" + property;
+}
+
+}  // namespace
 
 int64_t SbSystemGetUsedCPUMemory() {
   starboard::ScopedFile status_file(
-      "/sys/fs/cgroup/memory/memory.usage_in_bytes", O_RDONLY);
+      GetMemoryCgroupPath("memory.usage_in_bytes").c_str(), O_RDONLY);
+
   if (status_file.IsValid()) {
     const int kBufferSize = 512;
     char buffer[kBufferSize];
@@ -32,12 +67,10 @@ int64_t SbSystemGetUsedCPUMemory() {
     if (bytes_read == kBufferSize) {
       bytes_read = kBufferSize - 1;
     }
-    if (bytes_read >= 0) {
-      buffer[bytes_read] = '\0';
-      int64_t val = strtoll(buffer, nullptr, 10);
-      if (val > 0) {
-        return val;
-      }
+    buffer[bytes_read] = '\0';
+    int64_t val = strtoll(buffer, nullptr, 10);
+    if (val > 0) {
+      return val;
     }
   }
   return 0;

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_used_cpu_memory.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_used_cpu_memory.cc
@@ -17,61 +17,28 @@
 // clang-format on
 
 #include <fcntl.h>
-#include <inttypes.h>
-#include <stdio.h>
-#include <string.h>
+#include <stdlib.h>
 
 #include "starboard/common/file.h"
 #include "starboard/common/log.h"
-#include "starboard/common/string.h"
-
-namespace {
-
-int64_t SearchForMemoryValue(const char* search_key, const char* buffer) {
-  const char* found = strstr(buffer, search_key);
-  if (!found) {
-    SB_LOG(ERROR) << "Could not find '" << search_key << "' in smaps_rollup.";
-    return 0;
-  }
-
-  const char* digits = strpbrk(found + strlen(search_key), "0123456789");
-  if (!digits) {
-    SB_LOG(ERROR) << "Could not find any digits for '" << search_key
-                  << "' in smaps_rollup.";
-    return 0;
-  }
-
-  int64_t memory_value_in_kilobytes = 0;
-  if (sscanf(digits, "%" PRId64, &memory_value_in_kilobytes) != 1) {
-    SB_LOG(ERROR) << "Could not parse integer value for '" << search_key
-                  << "' in smaps_rollup.";
-    return 0;
-  }
-
-  return memory_value_in_kilobytes * 1024;
-}
-
-}  // namespace
 
 int64_t SbSystemGetUsedCPUMemory() {
-  // On RDK devices, /proc/self/smaps_rollup is optimized to provide accurate
-  // memory footprint calculations avoiding double counting UMA GPU memory buffers
-  // that can be misreported by /proc/self/status VmRSS.
-  starboard::ScopedFile status_file("/proc/self/smaps_rollup", O_RDONLY);
-  if (!status_file.IsValid()) {
-    SB_LOG(ERROR)
-        << "Error opening /proc/self/smaps_rollup in order to query self memory usage.";
-    return 0;
+  starboard::ScopedFile status_file(
+      "/sys/fs/cgroup/memory/memory.usage_in_bytes", O_RDONLY);
+  if (status_file.IsValid()) {
+    const int kBufferSize = 512;
+    char buffer[kBufferSize];
+    int bytes_read = status_file.ReadAll(buffer, kBufferSize);
+    if (bytes_read == kBufferSize) {
+      bytes_read = kBufferSize - 1;
+    }
+    if (bytes_read >= 0) {
+      buffer[bytes_read] = '\0';
+      int64_t val = strtoll(buffer, nullptr, 10);
+      if (val > 0) {
+        return val;
+      }
+    }
   }
-
-  const int kBufferSize = 4096;
-  char buffer[kBufferSize];
-  int bytes_read = status_file.ReadAll(buffer, kBufferSize - 1);
-  if (bytes_read < 0) {
-    bytes_read = 0;
-  }
-  buffer[bytes_read] = '\0';
-
-  // Use Rss footprint from smaps_rollup which is robust on RDK.
-  return SearchForMemoryValue("Rss:", buffer);
+  return 0;
 }

--- a/third_party/blink/renderer/core/cobalt/performance/performance_extensions.cc
+++ b/third_party/blink/renderer/core/cobalt/performance/performance_extensions.cc
@@ -173,6 +173,15 @@ uint64_t PerformanceExtensions::measureApplicationLimitMemory(
   return app_limit_memory;
 }
 
+uint64_t PerformanceExtensions::measureApplicationUsageMemory(
+    ScriptState* script_state,
+    const Performance&) {
+  uint64_t usage_memory = 0;
+  BindRemotePerformance(script_state)
+      ->MeasureApplicationUsageMemory(&usage_memory);
+  return usage_memory;
+}
+
 uint64_t PerformanceExtensions::measureUsedGpuMemory(
     ScriptState* script_state,
     const Performance&,

--- a/third_party/blink/renderer/core/cobalt/performance/performance_extensions.cc
+++ b/third_party/blink/renderer/core/cobalt/performance/performance_extensions.cc
@@ -63,6 +63,7 @@ SystemMemoryInfo* PerformanceExtensions::measureSystemMemoryInfo(
     result->setTotalCpuMemory(info->total_cpu_memory);
     result->setUsedPssMemory(info->used_pss_memory);
     result->setApplicationLimitMemory(info->application_limit_memory);
+    result->setApplicationUsageMemory(info->application_usage_memory);
     if (info->used_gpu_memory.has_value()) {
       result->setUsedGpuMemory(info->used_gpu_memory.value());
     }

--- a/third_party/blink/renderer/core/cobalt/performance/performance_extensions.h
+++ b/third_party/blink/renderer/core/cobalt/performance/performance_extensions.h
@@ -49,6 +49,8 @@ class CORE_EXPORT PerformanceExtensions final {
   static uint64_t measureUsedPssMemory(ScriptState*, const Performance&);
   static uint64_t measureApplicationLimitMemory(ScriptState*,
                                                 const Performance&);
+  static uint64_t measureApplicationUsageMemory(ScriptState*,
+                                                const Performance&);
   static uint64_t measureUsedGpuMemory(ScriptState*,
                                        const Performance&,
                                        ExceptionState&);

--- a/third_party/blink/renderer/core/cobalt/performance/performance_extensions.idl
+++ b/third_party/blink/renderer/core/cobalt/performance/performance_extensions.idl
@@ -39,6 +39,10 @@
 
     // Returns the application CPU memory limit in bytes.
     [CallWith=ScriptState] unsigned long long measureApplicationLimitMemory();
+
+    // Returns the application CPU memory usage in bytes
+    [CallWith=ScriptState] unsigned long long measureApplicationUsageMemory();
+
     // Returns the amount of GPU memory used by the Cobalt process in bytes.
     [CallWith=ScriptState, RaisesException] unsigned long long measureUsedGpuMemory();
 

--- a/third_party/blink/renderer/core/cobalt/performance/system_memory_info.idl
+++ b/third_party/blink/renderer/core/cobalt/performance/system_memory_info.idl
@@ -42,6 +42,9 @@ dictionary SystemMemoryInfo {
     // Maximum memory limit allocated to Cobalt by Starboard.
     unsigned long long applicationLimitMemory;
 
+    // The application CPU memory usage in bytes.
+    unsigned long long applicationUsageMemory;
+
     // GPU memory used by the process, or null if unsupported on the platform.
     unsigned long long? usedGpuMemory = null;
 


### PR DESCRIPTION
performance: Fix app memory APIs and limits on RDK

- Adds measureApplicationUsageMemory() mapped to SbSystemGetUsedCPUMemory
  to capture device-specific allocations like UMA pools.
- Updates SbSystemGetTotalCPUMemory to respect the active cgroup
  limit rather than the system maximum, preventing integer overflow
  limits in measureApplicationLimitMemory().

Bug: 549371287
Bug: 552272859
Bug: 555849706