### PR TITLE
cobalt: Implement zero-copy in-process direct raster path

### DIFF
--- a/cc/layers/heads_up_display_layer_impl.cc
+++ b/cc/layers/heads_up_display_layer_impl.cc
@@ -13,6 +13,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/feature_list.h"
 #include "base/logging.h"
 #include "base/memory/raw_ptr.h"
 #include "base/notreached.h"
@@ -52,6 +53,7 @@
 #include "gpu/command_buffer/common/shared_image_trace_utils.h"
 #include "gpu/command_buffer/common/shared_image_usage.h"
 #include "gpu/config/gpu_feature_info.h"
+#include "gpu/config/gpu_finch_features.h"
 #include "gpu/ipc/client/client_shared_image_interface.h"
 #include "skia/ext/legacy_display_globals.h"
 #include "third_party/skia/include/core/SkFont.h"
@@ -811,8 +813,18 @@ SkRect HeadsUpDisplayLayerImpl::DrawGpuRasterizationStatus(PaintCanvas* canvas,
   std::string status;
   SkColor color = SK_ColorRED;
   if (layer_tree_impl()->use_gpu_rasterization()) {
+#if BUILDFLAG(IS_COBALT)
+    if (base::FeatureList::IsEnabled(features::kCobaltInProcessDirectRaster)) {
+      status = "in-proc";
+      color = SK_ColorCYAN;
+    } else {
+      status = "on";
+      color = SK_ColorGREEN;
+    }
+#else
     status = "on";
     color = SK_ColorGREEN;
+#endif
   } else {
     status = "off";
     color = SK_ColorRED;

--- a/gpu/command_buffer/client/BUILD.gn
+++ b/gpu/command_buffer/client/BUILD.gn
@@ -307,6 +307,7 @@ source_set("raster_sources") {
     "//gpu/command_buffer/common:gles2",
     "//gpu/command_buffer/common:gles2_utils",
     "//gpu/command_buffer/common:raster",
+    "//gpu/config",
     "//ui/base:features",
     "//ui/gfx:color_space",
     "//ui/gfx/geometry",

--- a/gpu/command_buffer/client/raster_implementation.cc
+++ b/gpu/command_buffer/client/raster_implementation.cc
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstring>
 #include <limits>
 #include <set>
 #include <sstream>
@@ -28,6 +29,7 @@
 #include "base/bits.h"
 #include "base/compiler_specific.h"
 #include "base/functional/bind.h"
+#include "base/logging.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/stack_allocated.h"
 #include "base/metrics/histogram_macros.h"
@@ -40,7 +42,10 @@
 #include "cc/paint/decode_stashing_image_provider.h"
 #include "cc/paint/display_item_list.h"
 #include "cc/paint/paint_cache.h"
+#include "cc/paint/paint_flags.h"
+#include "cc/paint/paint_op_buffer_iterator.h"
 #include "cc/paint/paint_op_buffer_serializer.h"
+#include "cc/paint/paint_shader.h"
 #include "cc/paint/skottie_serialization_history.h"
 #include "cc/paint/transfer_cache_entry.h"
 #include "cc/paint/transfer_cache_serialize_helper.h"
@@ -54,6 +59,8 @@
 #include "gpu/command_buffer/client/raster_cmd_helper.h"
 #include "gpu/command_buffer/client/shared_memory_limits.h"
 #include "gpu/command_buffer/client/transfer_buffer.h"
+#include "gpu/command_buffer/common/in_process_raster_payload.h"
+#include "gpu/config/gpu_finch_features.h"
 #include "third_party/skia/include/core/SkColorSpace.h"
 #include "ui/gfx/color_space.h"
 #include "ui/gfx/geometry/rect.h"
@@ -175,6 +182,146 @@ class ScopedSharedMemoryPtr {
   std::optional<ScopedMappedMemoryPtr> scoped_mapped_ptr_;
   std::optional<ScopedTransferBufferPtr> scoped_transfer_ptr_;
 };
+
+#if BUILDFLAG(IS_COBALT)
+// Performs the equivalent of PaintOpWriter::Write(const DrawImage&, SkSize*)
+// and PaintOpWriter::WriteImage(): decodes/uploads the image via |provider|
+// and records its transfer_cache_entry_id.
+void ProcessPaintImage(
+    const cc::PaintImage& paint_image,
+    const SkIRect& src_rect,
+    cc::PaintFlags::FilterQuality quality,
+    cc::ImageProvider* provider,
+    base::flat_map<cc::PaintImage::Id, uint32_t>* image_to_transfer_cache_id) {
+  DCHECK(provider);
+  if (!paint_image) {
+    return;
+  }
+
+  // Dark mode is not used in Cobalt, and an identity matrix (SkM44()) decodes
+  // and uploads the image at its native 1:1 scale to the transfer cache.
+  // |current_ctm| is not needed for preprocessing because DisplayItemList
+  // retains the full CTM context, and Skia will apply all canvas
+  // transformations dynamically during rasterization.
+  cc::DrawImage draw_image(paint_image, /*use_dark_mode=*/false, src_rect,
+                           quality, SkM44());
+  auto result = provider->GetRasterContent(draw_image);
+  if (result &&
+      result.decoded_image().transfer_cache_entry_id().has_value()) {
+    (*image_to_transfer_cache_id)[paint_image.stable_id()] =
+        result.decoded_image().transfer_cache_entry_id().value();
+  }
+}
+
+// Forward declaration
+void InProcRasterPreProcess(
+    const cc::PaintOpBuffer& buffer,
+    const std::vector<size_t>* offsets,
+    cc::ImageProvider* provider,
+    base::flat_map<cc::PaintImage::Id, uint32_t>* image_to_transfer_cache_id);
+
+// Handles a single PaintOp to extract and process images.
+void InProcRasterPreProcessOp(
+    const cc::PaintOp& op,
+    cc::ImageProvider* provider,
+    base::flat_map<cc::PaintImage::Id, uint32_t>* image_to_transfer_cache_id) {
+  DCHECK(provider);
+
+  switch (op.GetType()) {
+    case cc::PaintOpType::kDrawImage: {
+      const auto& draw_image_op = static_cast<const cc::DrawImageOp&>(op);
+      ProcessPaintImage(draw_image_op.image,
+                        SkIRect::MakeWH(draw_image_op.image.width(),
+                                        draw_image_op.image.height()),
+                        draw_image_op.GetImageQuality(), provider,
+                        image_to_transfer_cache_id);
+      break;
+    }
+    case cc::PaintOpType::kDrawImageRect: {
+      const auto& draw_image_rect_op =
+          static_cast<const cc::DrawImageRectOp&>(op);
+      SkIRect int_src_rect;
+      draw_image_rect_op.src.roundOut(&int_src_rect);
+      ProcessPaintImage(draw_image_rect_op.image, int_src_rect,
+                        draw_image_rect_op.GetImageQuality(), provider,
+                        image_to_transfer_cache_id);
+      break;
+    }
+    // Recursively process all ops in the nested PaintRecord buffer.
+    case cc::PaintOpType::kDrawRecord: {
+      const auto& draw_record_op = static_cast<const cc::DrawRecordOp&>(op);
+      InProcRasterPreProcess(draw_record_op.record.buffer(), nullptr, provider,
+                            image_to_transfer_cache_id);
+      break;
+    }
+    // Recursively process all ops in the scrolling DisplayItemList buffer.
+    case cc::PaintOpType::kDrawScrollingContents: {
+      const auto& scrolling_op =
+          static_cast<const cc::DrawScrollingContentsOp&>(op);
+      if (scrolling_op.display_item_list) {
+        InProcRasterPreProcess(
+            scrolling_op.display_item_list->paint_op_buffer(), nullptr,
+            provider, image_to_transfer_cache_id);
+      }
+      break;
+    }
+    // All other drawing ops with PaintFlags serialize their flags via
+    // PaintOpWriter::Write(const PaintFlags&, ...), which checks for image
+    // shaders or nested PaintRecords. Ops without flags do nothing.
+    default:
+      if (op.IsPaintOpWithFlags()) {
+        const auto& flags_op = static_cast<const cc::PaintOpWithFlags&>(op);
+        if (flags_op.flags.HasShader()) {
+          const cc::PaintShader* shader = flags_op.flags.getShader();
+          if (shader) {
+            if (shader->shader_type() == cc::PaintShader::Type::kImage) {
+              ProcessPaintImage(
+                  shader->paint_image(),
+                  SkIRect::MakeWH(shader->paint_image().width(),
+                                  shader->paint_image().height()),
+                  flags_op.flags.getFilterQuality(), provider,
+                  image_to_transfer_cache_id);
+            } else if (shader->shader_type() ==
+                       cc::PaintShader::Type::kPaintRecord) {
+              if (shader->paint_record()) {
+                InProcRasterPreProcess(shader->paint_record()->buffer(),
+                                      nullptr, provider,
+                                      image_to_transfer_cache_id);
+              }
+            }
+          }
+        }
+      }
+      break;
+  }
+}
+
+// Recursively traverses the PaintOpBuffer (including nested PaintRecords,
+// scrolling display lists, and PaintShader images) to decode images via
+// |provider| and populate |image_to_transfer_cache_id|. This allows the
+// GPU-side raster decoder to resolve pre-uploaded transfer cache textures
+// during direct playback without serialization.
+void InProcRasterPreProcess(
+    const cc::PaintOpBuffer& buffer,
+    const std::vector<size_t>* offsets,
+    cc::ImageProvider* provider,
+    base::flat_map<cc::PaintImage::Id, uint32_t>* image_to_transfer_cache_id) {
+  if (!provider) {
+    return;
+  }
+
+  if (offsets) {
+    for (const cc::PaintOp& op :
+         cc::PaintOpBuffer::OffsetIterator(buffer, *offsets)) {
+      InProcRasterPreProcessOp(op, provider, image_to_transfer_cache_id);
+    }
+  } else {
+    for (const cc::PaintOp& op : buffer) {
+      InProcRasterPreProcessOp(op, provider, image_to_transfer_cache_id);
+    }
+  }
+}
+#endif  // BUILDFLAG(IS_COBALT)
 
 }  // namespace
 
@@ -590,7 +737,20 @@ gpu::ContextResult RasterImplementation::Initialize(
     const SharedMemoryLimits& limits) {
   TRACE_EVENT0("gpu", "RasterImplementation::Initialize");
 
-  auto result = ImplementationBase::Initialize(limits);
+  SharedMemoryLimits modified_limits = limits;
+#if BUILDFLAG(IS_COBALT)
+  // When in-process direct raster is enabled, PaintOp buffers are passed
+  // directly via pointer payload. Reduce the initial transfer buffer size to
+  // 1 KB to minimize shared memory overhead.
+  if (base::FeatureList::IsEnabled(features::kCobaltInProcessDirectRaster)) {
+    LOG(INFO) << "RasterImplementation: CobaltInProcessDirectRaster enabled, "
+                 "reducing initial transfer buffer size to "
+              << 1024 << " bytes (was " << limits.start_transfer_buffer_size
+              << " bytes)";
+    modified_limits.start_transfer_buffer_size = 1024;
+  }
+#endif  // BUILDFLAG(IS_COBALT)
+  auto result = ImplementationBase::Initialize(modified_limits);
   if (result != gpu::ContextResult::kSuccess) {
     return result;
   }
@@ -615,6 +775,7 @@ RasterImplementation::~RasterImplementation() {
 
 #if BUILDFLAG(IS_COBALT)
   cc::ClientImageTransferCacheEntry::ClearInProcessRegistry();
+  InProcessRasterPayloadRegistry::GetInstance().Clear();
 #endif  // BUILDFLAG(IS_COBALT)
 }
 
@@ -1225,6 +1386,45 @@ void RasterImplementation::UnmapRasterCHROMIUM(uint32_t raster_written_size,
   CheckGLError();
 }
 
+#if BUILDFLAG(IS_COBALT)
+void RasterImplementation::RasterCHROMIUMInProcess(
+    const cc::DisplayItemList* list,
+    cc::ImageProvider* provider,
+    const gfx::Size& content_size,
+    const gfx::Rect& full_raster_rect,
+    const gfx::Rect& playback_rect,
+    const gfx::Vector2dF& post_translate,
+    const gfx::Vector2dF& post_scale,
+    bool requires_clear,
+    const ScrollOffsetMap* raster_inducing_scroll_offsets) {
+  uint32_t size_allocated = 0;
+  void* mem =
+      MapRasterCHROMIUM(sizeof(InProcessRasterPayload*), &size_allocated);
+  if (mem) {
+    auto* payload = new InProcessRasterPayload();
+    payload->display_item_list = base::WrapRefCounted(list);
+    payload->content_size = content_size;
+    payload->full_raster_rect = full_raster_rect;
+    payload->playback_rect = playback_rect;
+    payload->post_translate = post_translate;
+    payload->post_scale = post_scale;
+    payload->requires_clear = requires_clear;
+    payload->background_color = raster_properties_->background_color;
+    if (raster_inducing_scroll_offsets) {
+      payload->raster_inducing_scroll_offsets = *raster_inducing_scroll_offsets;
+    }
+
+    InProcRasterPreProcess(list->paint_op_buffer(), &temp_raster_offsets_,
+                           provider, &payload->image_to_transfer_cache_id);
+
+    InProcessRasterPayloadRegistry::GetInstance().Register(payload);
+    std::memcpy(mem, &payload, sizeof(payload));
+    UnmapRasterCHROMIUM(sizeof(InProcessRasterPayload*),
+                        sizeof(InProcessRasterPayload*));
+  }
+}
+#endif  // BUILDFLAG(IS_COBALT)
+
 // Include the auto-generated part of this file. We split this because it means
 // we can easily edit the non-auto generated parts right here in this file
 // instead of having to edit some template or the code generator.
@@ -1417,6 +1617,15 @@ void RasterImplementation::RasterCHROMIUM(
   if (temp_raster_offsets_.empty() && !requires_clear) {
     return;
   }
+
+#if BUILDFLAG(IS_COBALT)
+  if (base::FeatureList::IsEnabled(features::kCobaltInProcessDirectRaster)) {
+    RasterCHROMIUMInProcess(list, provider, content_size, full_raster_rect,
+                            playback_rect, post_translate, post_scale,
+                            requires_clear, raster_inducing_scroll_offsets);
+    return;
+  }
+#endif  // BUILDFLAG(IS_COBALT)
 
   // TODO(enne): Tune these numbers
   static constexpr uint32_t kMinAlloc = 16 * 1024;

--- a/gpu/command_buffer/client/raster_implementation.h
+++ b/gpu/command_buffer/client/raster_implementation.h
@@ -298,6 +298,22 @@ class RASTER_EXPORT RasterImplementation : public RasterInterface,
   void UnmapRasterCHROMIUM(uint32_t raster_written_size,
                            uint32_t total_written_size);
 
+#if BUILDFLAG(IS_COBALT)
+  // Fast path for Cobalt in-process direct raster. Passes a pointer payload
+  // wrapping the finalized DisplayItemList and image transfer cache IDs to
+  // the GPU raster decoder, bypassing PaintOp serialization.
+  void RasterCHROMIUMInProcess(
+      const cc::DisplayItemList* list,
+      cc::ImageProvider* provider,
+      const gfx::Size& content_size,
+      const gfx::Rect& full_raster_rect,
+      const gfx::Rect& playback_rect,
+      const gfx::Vector2dF& post_translate,
+      const gfx::Vector2dF& post_scale,
+      bool requires_clear,
+      const ScrollOffsetMap* raster_inducing_scroll_offsets);
+#endif  // BUILDFLAG(IS_COBALT)
+
   // Returns the last error and clears it. Useful for debugging.
   const std::string& GetLastError() { return last_error_; }
 

--- a/gpu/command_buffer/common/BUILD.gn
+++ b/gpu/command_buffer/common/BUILD.gn
@@ -158,6 +158,8 @@ source_set("raster_sources") {
   visibility = [ "//gpu/*" ]
 
   sources = [
+    "in_process_raster_payload.cc",
+    "in_process_raster_payload.h",
     "raster_cmd_enums.h",
     "raster_cmd_format.cc",
     "raster_cmd_format.h",
@@ -173,6 +175,7 @@ source_set("raster_sources") {
   deps = [
     ":gles2_utils",
     "//base",
+    "//cc/paint",
     "//skia",
     "//ui/gl:gl",
   ]

--- a/gpu/command_buffer/common/in_process_raster_payload.cc
+++ b/gpu/command_buffer/common/in_process_raster_payload.cc
@@ -1,0 +1,67 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gpu/command_buffer/common/in_process_raster_payload.h"
+
+#include <algorithm>
+
+#include "base/no_destructor.h"
+
+namespace gpu {
+namespace raster {
+
+InProcessRasterPayload::InProcessRasterPayload() = default;
+InProcessRasterPayload::~InProcessRasterPayload() = default;
+InProcessRasterPayload::InProcessRasterPayload(InProcessRasterPayload&& other) =
+    default;
+InProcessRasterPayload& InProcessRasterPayload::operator=(
+    InProcessRasterPayload&& other) = default;
+
+// static
+InProcessRasterPayloadRegistry& InProcessRasterPayloadRegistry::GetInstance() {
+  static base::NoDestructor<InProcessRasterPayloadRegistry> instance;
+  return *instance;
+}
+
+InProcessRasterPayloadRegistry::InProcessRasterPayloadRegistry() = default;
+InProcessRasterPayloadRegistry::~InProcessRasterPayloadRegistry() = default;
+
+void InProcessRasterPayloadRegistry::Register(InProcessRasterPayload* payload) {
+  base::AutoLock lock(lock_);
+  entries_.push_back(payload);
+}
+
+bool InProcessRasterPayloadRegistry::Take(InProcessRasterPayload* payload) {
+  base::AutoLock lock(lock_);
+  auto it = std::find(entries_.begin(), entries_.end(), payload);
+  if (it != entries_.end()) {
+    entries_.erase(it);
+    return true;
+  }
+  return false;
+}
+
+void InProcessRasterPayloadRegistry::Clear() {
+  base::circular_deque<InProcessRasterPayload*> to_clear;
+  {
+    base::AutoLock lock(lock_);
+    to_clear.swap(entries_);
+  }
+  for (auto* payload : to_clear) {
+    delete payload;
+  }
+}
+
+}  // namespace raster
+}  // namespace gpu

--- a/gpu/command_buffer/common/in_process_raster_payload.h
+++ b/gpu/command_buffer/common/in_process_raster_payload.h
@@ -1,0 +1,97 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GPU_COMMAND_BUFFER_COMMON_IN_PROCESS_RASTER_PAYLOAD_H_
+#define GPU_COMMAND_BUFFER_COMMON_IN_PROCESS_RASTER_PAYLOAD_H_
+
+#include <stdint.h>
+#include <optional>
+
+#include "base/containers/circular_deque.h"
+#include "base/containers/flat_map.h"
+#include "base/memory/ref_counted.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/no_destructor.h"
+#include "base/synchronization/lock.h"
+#include "build/build_config.h"
+#include "cc/paint/display_item_list.h"
+#include "cc/paint/paint_image.h"
+#include "cc/paint/scroll_offset_map.h"
+#include "gpu/gpu_export.h"
+#include "third_party/skia/include/core/SkColor.h"
+#include "ui/gfx/geometry/rect.h"
+#include "ui/gfx/geometry/size.h"
+#include "ui/gfx/geometry/vector2d_f.h"
+
+namespace gpu {
+namespace raster {
+
+// Encapsulates the parameters and display list for direct in-process
+// rasterization. When running in single-process mode, this payload can be
+// passed directly from RasterImplementation (client) to RasterDecoder
+// (service), completely bypassing PaintOp serialization and deserialization.
+struct GPU_EXPORT InProcessRasterPayload {
+  InProcessRasterPayload();
+  ~InProcessRasterPayload();
+  InProcessRasterPayload(InProcessRasterPayload&& other);
+  InProcessRasterPayload& operator=(InProcessRasterPayload&& other);
+
+  // The DisplayItemList is finalized and immutable before raster, so it's safe to
+  // send it directly to the GPU thread.
+  scoped_refptr<const cc::DisplayItemList> display_item_list;
+  gfx::Size content_size;
+  gfx::Rect full_raster_rect;
+  gfx::Rect playback_rect;
+  gfx::Vector2dF post_translate;
+  gfx::Vector2dF post_scale;
+  bool requires_clear = false;
+  SkColor4f background_color = SkColors::kTransparent;
+
+  // Dynamic scroll offsets required by DrawScrollingContentsOp.
+  std::optional<cc::ScrollOffsetMap> raster_inducing_scroll_offsets;
+
+  // Maps each PaintImage to its pre-uploaded GPU transfer cache entry ID.
+  base::flat_map<cc::PaintImage::Id, uint32_t> image_to_transfer_cache_id;
+};
+
+// Thread-safe registry for in-process raster payloads. Validates ownership
+// before dereferencing on the GPU thread and safely cleans up in-flight
+// payloads during context teardown.
+class GPU_EXPORT InProcessRasterPayloadRegistry {
+ public:
+  static InProcessRasterPayloadRegistry& GetInstance();
+
+  InProcessRasterPayloadRegistry(
+      const InProcessRasterPayloadRegistry&) = delete;
+  InProcessRasterPayloadRegistry& operator=(
+      const InProcessRasterPayloadRegistry&) = delete;
+
+  void Register(InProcessRasterPayload* payload);
+  bool Take(InProcessRasterPayload* payload);
+  void Clear();
+
+ private:
+  friend class base::NoDestructor<InProcessRasterPayloadRegistry>;
+
+  InProcessRasterPayloadRegistry();
+  ~InProcessRasterPayloadRegistry();
+
+  base::Lock lock_;
+  base::circular_deque<InProcessRasterPayload*> entries_ GUARDED_BY(lock_);
+};
+
+}  // namespace raster
+}  // namespace gpu
+
+#endif  // GPU_COMMAND_BUFFER_COMMON_IN_PROCESS_RASTER_PAYLOAD_H_

--- a/gpu/command_buffer/service/raster_decoder.cc
+++ b/gpu/command_buffer/service/raster_decoder.cc
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <optional>
 #include <string>
@@ -28,6 +29,7 @@
 #include "base/feature_list.h"
 #include "base/functional/bind.h"
 #include "base/logging.h"
+#include "base/memory/ptr_util.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/ref_counted.h"
 #include "base/memory/weak_ptr.h"
@@ -36,6 +38,12 @@
 #include "base/time/time.h"
 #include "base/trace_event/trace_event.h"
 #include "build/build_config.h"
+#include "cc/paint/clear_for_opaque_raster.h"
+#include "cc/paint/display_item_list.h"
+#include "cc/paint/image_provider.h"
+#include "cc/paint/image_transfer_cache_entry.h"
+#include "gpu/command_buffer/common/in_process_raster_payload.h"
+#include "gpu/config/gpu_finch_features.h"
 #include "cc/paint/paint_cache.h"
 #include "cc/paint/paint_op.h"
 #include "cc/paint/paint_op_buffer.h"
@@ -144,6 +152,52 @@ namespace raster {
 namespace {
 
 base::AtomicSequenceNumber g_raster_decoder_id;
+
+#if BUILDFLAG(IS_COBALT)
+// An ImageProvider that resolves cc::PaintImages directly from the GPU
+// ServiceTransferCache using the transfer cache IDs collected during
+// in-process raster preprocessing.
+class GpuTransferCacheImageProvider : public cc::ImageProvider {
+ public:
+  GpuTransferCacheImageProvider(
+      int raster_decoder_id,
+      ServiceTransferCache* transfer_cache,
+      const base::flat_map<cc::PaintImage::Id, uint32_t>& image_map)
+      : raster_decoder_id_(raster_decoder_id),
+        transfer_cache_(transfer_cache),
+        image_map_(image_map) {}
+
+  ScopedResult GetRasterContent(const cc::DrawImage& draw_image) override {
+    auto it = image_map_.find(draw_image.paint_image().stable_id());
+    if (it != image_map_.end() && transfer_cache_) {
+      auto* entry = transfer_cache_->GetEntry(
+          ServiceTransferCache::EntryKey(raster_decoder_id_,
+                                         cc::TransferCacheEntryType::kImage,
+                                         it->second));
+      if (entry && entry->Type() == cc::TransferCacheEntryType::kImage) {
+        auto* image_entry =
+            static_cast<cc::ServiceImageTransferCacheEntry*>(entry);
+        if (image_entry->image()) {
+          return ScopedResult(cc::DecodedDrawImage(
+              image_entry->image(), /*dark_mode_color_filter=*/nullptr,
+              SkSize::Make(0, 0), SkSize::Make(1.f, 1.f),
+              draw_image.filter_quality(), /*is_budgeted=*/true));
+        }
+      }
+    }
+
+    return ScopedResult(cc::DecodedDrawImage(
+        draw_image.paint_image().GetSwSkImage(), nullptr,
+        SkSize::Make(0, 0), SkSize::Make(1.f, 1.f),
+        draw_image.filter_quality(), true));
+  }
+
+ private:
+  int raster_decoder_id_;
+  raw_ptr<ServiceTransferCache> transfer_cache_;
+  const base::flat_map<cc::PaintImage::Id, uint32_t>& image_map_;
+};
+#endif  // BUILDFLAG(IS_COBALT)
 
 // Controls whether we may yield during rasterization.
 BASE_FEATURE(kGpuYieldRasterization,
@@ -769,6 +823,10 @@ class RasterDecoderImpl final : public RasterDecoder,
                                 GLuint font_shm_id,
                                 GLuint font_shm_offset,
                                 GLuint font_shm_size);
+#if BUILDFLAG(IS_COBALT)
+  error::Error DoRasterCHROMIUMInProcess(
+      std::unique_ptr<InProcessRasterPayload> payload);
+#endif  // BUILDFLAG(IS_COBALT)
   void DoEndRasterCHROMIUM();
   void DoCreateTransferCacheEntryINTERNAL(GLuint entry_type,
                                           GLuint entry_id,
@@ -3050,6 +3108,21 @@ error::Error RasterDecoderImpl::DoRasterCHROMIUM(GLuint raster_shm_id,
     return error::kNoError;
   }
 
+#if BUILDFLAG(IS_COBALT)
+  if (base::FeatureList::IsEnabled(features::kCobaltInProcessDirectRaster) &&
+      raster_shm_size == sizeof(InProcessRasterPayload*)) {
+    InProcessRasterPayload* in_process_payload = nullptr;
+    std::memcpy(&in_process_payload, paint_buffer_memory,
+                sizeof(in_process_payload));
+    if (in_process_payload &&
+        InProcessRasterPayloadRegistry::GetInstance().Take(
+            in_process_payload)) {
+      return DoRasterCHROMIUMInProcess(
+          base::WrapUnique(in_process_payload));
+    }
+  }
+#endif  // BUILDFLAG(IS_COBALT)
+
   cc::PlaybackParams playback_params(nullptr, SkM44());
   TransferCacheDeserializeHelperImpl impl(raster_decoder_id_, transfer_cache());
   cc::PaintOp::DeserializeOptions options{
@@ -3140,6 +3213,89 @@ error::Error RasterDecoderImpl::DoRasterCHROMIUM(GLuint raster_shm_id,
 
   return error::kNoError;
 }
+
+#if BUILDFLAG(IS_COBALT)
+error::Error RasterDecoderImpl::DoRasterCHROMIUMInProcess(
+    std::unique_ptr<InProcessRasterPayload> payload) {
+  // |scoped_shared_image_raster_write_| is only used by RawDraw, which is not
+  // used in Cobalt. Skip the handling for it in DoRasterCHROMIUMInProcess.
+  DCHECK(!scoped_shared_image_raster_write_);
+
+  if (raster_canvas_) {
+    SkIRect raster_bounds = gfx::RectToSkIRect(payload->full_raster_rect);
+    if (!payload->playback_rect.IsEmpty() &&
+        !raster_bounds.intersect(
+            gfx::RectToSkIRect(payload->playback_rect))) {
+      return error::kNoError;
+    }
+
+    int save_count = raster_canvas_->getSaveCount();
+
+    // Replicate tile setup preamble (PaintOpBufferSerializer::SerializePreamble)
+    // directly onto the canvas, since in-process raster bypasses serialization.
+    bool is_partial_raster =
+        payload->full_raster_rect != payload->playback_rect;
+    if (!payload->requires_clear) {
+      gfx::Rect outer_rect;
+      gfx::Rect inner_rect;
+      if (cc::CalculateClearForOpaqueRasterRects(
+              payload->post_translate, payload->post_scale,
+              payload->content_size, payload->full_raster_rect,
+              payload->playback_rect, outer_rect, inner_rect)) {
+        raster_canvas_->save();
+        raster_canvas_->clipRect(gfx::RectToSkRect(outer_rect),
+                                 SkClipOp::kIntersect);
+        if (!inner_rect.IsEmpty()) {
+          raster_canvas_->clipRect(gfx::RectToSkRect(inner_rect),
+                                   SkClipOp::kDifference);
+        }
+        raster_canvas_->drawColor(payload->background_color.toSkColor(),
+                                  SkBlendMode::kSrc);
+        raster_canvas_->restore();
+      }
+    } else if (!is_partial_raster) {
+      raster_canvas_->clear(SK_ColorTRANSPARENT);
+    }
+
+    raster_canvas_->save();
+    if (!payload->full_raster_rect.OffsetFromOrigin().IsZero()) {
+      raster_canvas_->translate(-payload->full_raster_rect.x(),
+                                -payload->full_raster_rect.y());
+    }
+    raster_canvas_->clipRect(SkRect::Make(raster_bounds));
+    if (!payload->post_translate.IsZero()) {
+      raster_canvas_->translate(payload->post_translate.x(),
+                                payload->post_translate.y());
+    }
+    if (payload->post_scale.x() != 1.f || payload->post_scale.y() != 1.f) {
+      raster_canvas_->scale(payload->post_scale.x(),
+                            payload->post_scale.y());
+    }
+
+    // If a transparent tile is partially rastered, clear only the clipped
+    // dirty section that is being re-rastered.
+    if (is_partial_raster && payload->requires_clear) {
+      raster_canvas_->clear(SK_ColorTRANSPARENT);
+    }
+
+    GpuTransferCacheImageProvider gpu_image_provider(
+        raster_decoder_id_, transfer_cache(),
+        payload->image_to_transfer_cache_id);
+    cc::PlaybackParams params(&gpu_image_provider);
+    if (payload->raster_inducing_scroll_offsets.has_value()) {
+      params.raster_inducing_scroll_offsets =
+          &payload->raster_inducing_scroll_offsets.value();
+    }
+    if (payload->display_item_list) {
+      payload->display_item_list->Raster(raster_canvas_, params);
+    }
+
+    raster_canvas_->restoreToCount(save_count);
+  }
+
+  return error::kNoError;
+}
+#endif  // BUILDFLAG(IS_COBALT)
 
 error::Error RasterDecoderImpl::HandleRasterCHROMIUM(
     uint32_t immediate_data_size,

--- a/gpu/config/gpu_finch_features.cc
+++ b/gpu/config/gpu_finch_features.cc
@@ -51,6 +51,14 @@ BASE_FEATURE(kUseGles2ForOopR,
              "UseGles2ForOopR",
              base::FEATURE_DISABLED_BY_DEFAULT);
 
+#if BUILDFLAG(IS_COBALT)
+// Enables zero-copy, direct in-process rasterization for Cobalt by bypassing
+// PaintOp buffer serialization and transfer cache caching.
+BASE_FEATURE(kCobaltInProcessDirectRaster,
+             "CobaltInProcessDirectRaster",
+             base::FEATURE_DISABLED_BY_DEFAULT);
+#endif  // BUILDFLAG(IS_COBALT)
+
 // More aggressive behavior for the shader cache: increase size, and do not
 // purge as much in case of memory pressure.
 BASE_FEATURE(kAggressiveShaderCacheLimits,

--- a/gpu/config/gpu_finch_features.h
+++ b/gpu/config/gpu_finch_features.h
@@ -21,6 +21,10 @@ namespace features {
 
 GPU_EXPORT BASE_DECLARE_FEATURE(kUseGles2ForOopR);
 
+#if BUILDFLAG(IS_COBALT)
+GPU_EXPORT BASE_DECLARE_FEATURE(kCobaltInProcessDirectRaster);
+#endif  // BUILDFLAG(IS_COBALT)
+
 // All features in alphabetical order. The features should be documented
 // alongside the definition of their values in the .cc file.
 GPU_EXPORT BASE_DECLARE_FEATURE(kAggressiveShaderCacheLimits);


### PR DESCRIPTION
Introduce the kCobaltInProcessDirectRaster feature to bypass PaintOp
serialization and deserialization when Cobalt is running in single-
process mode. This reduces CPU overhead and memory usage by passing
a pointer to the DisplayItemList directly to the GPU service via
shared memory.

On the client side, RasterImplementation pre-uploads images to the
transfer cache and packages the immutable display list into a
payload. On the service side, RasterDecoderImpl performs direct
rasterization on the canvas using a specialized image provider
to resolve pre-uploaded textures.

Bug: 545866687