### PR TITLE
Support semicolon-delimited --trace-startup in CommandLineOverrideHelper

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
@@ -158,6 +158,7 @@ public final class CommandLineOverrideHelper {
     StringJoiner enableFeatureOverrides = getDefaultEnableFeatureOverridesList();
     StringJoiner disableFeatureOverrides = getDefaultDisableFeatureOverridesList();
     StringJoiner blinkEnableFeatureOverrides = getDefaultBlinkEnableFeatureOverridesList();
+    StringJoiner traceStartupOverrides = new StringJoiner(",");
     StringJoiner enableH5vccSettings = new StringJoiner(";");
 
     if (params != null) {
@@ -185,6 +186,8 @@ public final class CommandLineOverrideHelper {
                 disableFeatureOverrides.add(v);
               } else if (key.equals("--enable-blink-features")) {
                 blinkEnableFeatureOverrides.add(v);
+              } else if (key.equals("--trace-startup")) {
+                traceStartupOverrides.add(v);
               } else if (key.equals("--enable-h5vcc-settings")) {
                 enableH5vccSettings.add(v);
               } else {
@@ -210,6 +213,11 @@ public final class CommandLineOverrideHelper {
     CommandLine.getInstance()
         .appendSwitchesAndArguments(
             new String[] {"--enable-blink-features=" + blinkEnableFeatureOverrides.toString()});
+    if (traceStartupOverrides.length() > 0) {
+      CommandLine.getInstance()
+          .appendSwitchesAndArguments(
+              new String[] {"--trace-startup=" + traceStartupOverrides.toString()});
+    }
     if (enableH5vccSettings.length() > 0) {
       CommandLine.getInstance()
           .appendSwitchesAndArguments(

--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/CommandLineOverrideHelperTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/CommandLineOverrideHelperTest.java
@@ -211,4 +211,52 @@ public class CommandLineOverrideHelperTest {
     String h5vccSettings = CommandLine.getInstance().getSwitchValue("enable-h5vcc-settings");
     Assert.assertEquals("Setting1=val1;Setting2=val2", h5vccSettings);
   }
+
+  @Test
+  public void testFlagOverrides_TraceStartup() {
+    String[] commandLineArgs = {"--trace-startup=-*;disabled-by-default-memory-infra"};
+    CommandLineOverrideHelper.CommandLineOverrideHelperParams params =
+        new CommandLineOverrideHelper.CommandLineOverrideHelperParams(true, commandLineArgs);
+    CommandLineOverrideHelper.getFlagOverrides(params);
+
+    String traceStartup = CommandLine.getInstance().getSwitchValue("trace-startup");
+    Assert.assertEquals("-*,disabled-by-default-memory-infra", traceStartup);
+  }
+
+  @Test
+  public void testFlagOverrides_TraceStartupEmpty() {
+    String[] commandLineArgs = {"--trace-startup"};
+    CommandLineOverrideHelper.CommandLineOverrideHelperParams params =
+        new CommandLineOverrideHelper.CommandLineOverrideHelperParams(true, commandLineArgs);
+    CommandLineOverrideHelper.getFlagOverrides(params);
+
+    Assert.assertTrue(CommandLine.getInstance().hasSwitch("trace-startup"));
+  }
+
+  @Test
+  public void testFlagOverrides_HeapProfilingAdbArgs() {
+    String[] commandLineArgs = {
+      "--enable-heap-profiling",
+      "--memlog=all",
+      "--memlog-stack-mode=native-with-thread-names",
+      "--trace-startup=-*;disabled-by-default-memory-infra",
+      "--trace-startup-duration=60",
+      "--trace-startup-file=/sdcard/Download/trace_atv.pftrace"
+    };
+    CommandLineOverrideHelper.CommandLineOverrideHelperParams params =
+        new CommandLineOverrideHelper.CommandLineOverrideHelperParams(true, commandLineArgs);
+    CommandLineOverrideHelper.getFlagOverrides(params);
+
+    Assert.assertTrue(CommandLine.getInstance().hasSwitch("enable-heap-profiling"));
+    Assert.assertEquals("all", CommandLine.getInstance().getSwitchValue("memlog"));
+    Assert.assertEquals(
+        "native-with-thread-names", CommandLine.getInstance().getSwitchValue("memlog-stack-mode"));
+    Assert.assertEquals(
+        "-*,disabled-by-default-memory-infra",
+        CommandLine.getInstance().getSwitchValue("trace-startup"));
+    Assert.assertEquals("60", CommandLine.getInstance().getSwitchValue("trace-startup-duration"));
+    Assert.assertEquals(
+        "/sdcard/Download/trace_atv.pftrace",
+        CommandLine.getInstance().getSwitchValue("trace-startup-file"));
+  }
 }


### PR DESCRIPTION
Enable the use of semicolon-delimited values for the --trace-startup
flag within the Android command line override utility. This ensures
that complex tracing categories can be passed through platform
overrides and correctly normalized to the comma-delimited format
required by the engine.

Bug: 550575265