### PR TITLE
cobalt: Implement zero-copy in-process image transfer path

### DIFF
--- a/base/features.cc
+++ b/base/features.cc
@@ -38,6 +38,14 @@ namespace base::features {
 
 // Alphabetical:
 
+#if BUILDFLAG(IS_COBALT)
+// When enabled, image transfer cache entries bypass serialization and transfer
+// images directly to the GPU service thread in-process.
+BASE_FEATURE(kCobaltInProcessImageTransferCache,
+             "CobaltInProcessImageTransferCache",
+             FEATURE_DISABLED_BY_DEFAULT);
+#endif  // BUILDFLAG(IS_COBALT)
+
 // Controls caching within BASE_FEATURE_PARAM(). This is feature-controlled
 // so that ScopedFeatureList can disable it to turn off caching.
 BASE_FEATURE(kFeatureParamWithCache,

--- a/base/features.h
+++ b/base/features.h
@@ -15,6 +15,12 @@ namespace base::features {
 // alongside the definition of their values in the .cc file.
 
 // Alphabetical:
+#if BUILDFLAG(IS_COBALT)
+// When enabled, image transfer cache entries bypass serialization and transfer
+// images directly to the GPU service thread in-process.
+BASE_EXPORT BASE_DECLARE_FEATURE(kCobaltInProcessImageTransferCache);
+#endif  // BUILDFLAG(IS_COBALT)
+
 BASE_EXPORT BASE_DECLARE_FEATURE(kFeatureParamWithCache);
 
 BASE_EXPORT BASE_DECLARE_FEATURE(kFastFilePathIsParent);

--- a/cc/paint/image_transfer_cache_entry.cc
+++ b/cc/paint/image_transfer_cache_entry.cc
@@ -6,17 +6,25 @@
 
 #include <algorithm>
 #include <array>
+#include <cstring>
 #include <type_traits>
 #include <utility>
 
 #include "base/compiler_specific.h"
+#include "base/containers/circular_deque.h"
+#include "base/feature_list.h"
+#include "base/features.h"
 #include "base/functional/callback_helpers.h"
 #include "base/logging.h"
+#include "base/no_destructor.h"
 #include "base/notreached.h"
 #include "base/numerics/checked_math.h"
 #include "base/numerics/safe_conversions.h"
+#include "base/synchronization/lock.h"
+#include "build/build_config.h"
 #include "cc/paint/paint_op_reader.h"
 #include "cc/paint/paint_op_writer.h"
+
 #include "third_party/skia/include/core/SkColorSpace.h"
 #include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/core/SkPixmap.h"
@@ -33,6 +41,79 @@
 
 namespace cc {
 namespace {
+
+#if BUILDFLAG(IS_COBALT)
+struct InProcessImageTransferCachePayload {
+  sk_sp<SkImage> image;
+  std::vector<sk_sp<SkImage>> yuv_planes;
+  std::optional<SkYUVAInfo> yuva_info;
+  sk_sp<SkColorSpace> yuv_color_space;
+
+  sk_sp<SkImage> gainmap_image;
+  std::optional<SkGainmapInfo> gainmap_info;
+  std::optional<gfx::HDRMetadata> hdr_metadata;
+  sk_sp<SkColorSpace> target_color_space;
+  bool needs_mips = false;
+
+  // Unref underlying decoded image on destruction.
+  base::ScopedClosureRunner unref_runner;
+};
+
+class InProcessImageTransferCachePayloadRegistry {
+ public:
+  static InProcessImageTransferCachePayloadRegistry& GetInstance() {
+    static base::NoDestructor<InProcessImageTransferCachePayloadRegistry>
+        instance;
+    return *instance;
+  }
+
+  InProcessImageTransferCachePayloadRegistry(
+      const InProcessImageTransferCachePayloadRegistry&) = delete;
+  InProcessImageTransferCachePayloadRegistry& operator=(
+      const InProcessImageTransferCachePayloadRegistry&) = delete;
+
+  void Register(InProcessImageTransferCachePayload* payload) {
+    base::AutoLock lock(lock_);
+    entries_.push_back(payload);
+  }
+
+  bool Take(InProcessImageTransferCachePayload* payload) {
+    base::AutoLock lock(lock_);
+    auto it = std::find(entries_.begin(), entries_.end(), payload);
+    if (it != entries_.end()) {
+      entries_.erase(it);
+      return true;
+    }
+    return false;
+  }
+
+  void Clear() {
+    base::circular_deque<InProcessImageTransferCachePayload*> to_clear;
+    {
+      base::AutoLock lock(lock_);
+      to_clear.swap(entries_);
+    }
+    for (auto* payload : to_clear) {
+      delete payload;
+    }
+  }
+
+ private:
+  friend class base::NoDestructor<InProcessImageTransferCachePayloadRegistry>;
+
+  InProcessImageTransferCachePayloadRegistry() = default;
+  ~InProcessImageTransferCachePayloadRegistry() = default;
+
+  base::Lock lock_;
+  // Uses circular_deque because transfer cache entries are predominantly
+  // created and deserialized in FIFO order as the GPU process parses sequential
+  // command buffer streams, allowing O(1) push and pop without memory shifting.
+  // A fallback search handles any out-of-order interleaving from concurrent
+  // worker threads.
+  base::circular_deque<InProcessImageTransferCachePayload*> entries_
+      GUARDED_BY(lock_);
+};
+#endif  // BUILDFLAG(IS_COBALT)
 
 struct Context {
   const std::vector<sk_sp<SkImage>> sk_planes_;
@@ -526,6 +607,59 @@ uint32_t ClientImageTransferCacheEntry::Id() const {
   return id_;
 }
 
+#if BUILDFLAG(IS_COBALT)
+uint32_t ClientImageTransferCacheEntry::SerializedSizeInProcess() const {
+  return sizeof(InProcessImageTransferCachePayload*);
+}
+
+bool ClientImageTransferCacheEntry::SerializeInProcess(
+    base::span<uint8_t> data,
+    base::ScopedClosureRunner unref_runner) const {
+  auto* payload = new InProcessImageTransferCachePayload();
+  if (IsYuv()) {
+    const int num_pixmaps = NumPixmapsForYUVConfig(image_.yuv_plane_config);
+    for (int i = 0; i < num_pixmaps; ++i) {
+      if (image_.pixmaps[i]) {
+        payload->yuv_planes.push_back(
+            SkImages::RasterFromPixmap(*image_.pixmaps[i], nullptr, nullptr));
+      }
+    }
+    if (!payload->yuv_planes.empty() && image_.pixmaps[0]) {
+      payload->yuva_info = SkYUVAInfo(
+          image_.pixmaps[0]->dimensions(), image_.yuv_plane_config,
+          image_.yuv_subsampling, image_.yuv_color_space);
+    }
+    if (image_.color_space) {
+      payload->yuv_color_space = sk_ref_sp(image_.color_space.get());
+    }
+  } else {
+    if (image_.pixmaps[0]) {
+      payload->image =
+          SkImages::RasterFromPixmap(*image_.pixmaps[0], nullptr, nullptr);
+    }
+  }
+  if (gainmap_image_.has_value() && gainmap_image_->pixmaps[0]) {
+    payload->gainmap_image =
+        SkImages::RasterFromPixmap(*gainmap_image_->pixmaps[0], nullptr, nullptr);
+    payload->gainmap_info = gainmap_info_;
+  }
+  payload->needs_mips = needs_mips_;
+  payload->hdr_metadata = hdr_metadata_;
+  payload->target_color_space = target_color_space_;
+  payload->unref_runner = std::move(unref_runner);
+
+  InProcessImageTransferCachePayloadRegistry::GetInstance().Register(payload);
+
+  UNSAFE_BUFFERS(std::memcpy(data.data(), &payload, sizeof(payload)));
+  return true;
+}
+
+// static
+void ClientImageTransferCacheEntry::ClearInProcessRegistry() {
+  InProcessImageTransferCachePayloadRegistry::GetInstance().Clear();
+}
+#endif  // BUILDFLAG(IS_COBALT)
+
 bool ClientImageTransferCacheEntry::Serialize(base::span<uint8_t> data) const {
   DCHECK_GE(data.size(), SerializedSize());
   // We don't need to populate the SerializeOptions here since the writer is
@@ -654,6 +788,17 @@ bool ServiceImageTransferCacheEntry::Deserialize(
   gr_context_ = gr_context;
   graphite_recorder_ = graphite_recorder;
 
+#if BUILDFLAG(IS_COBALT)
+  // Standard serialized images require at least ~64 bytes for headers and
+  // metadata, so a size equal to sizeof(InProcessImageTransferCachePayload*) (8 bytes) uniquely
+  // identifies an in-process direct payload pointer.
+  if (base::FeatureList::IsEnabled(
+          base::features::kCobaltInProcessImageTransferCache) &&
+      data.size() == sizeof(InProcessImageTransferCachePayload*)) {
+    return DeserializeInProcess(gr_context, data);
+  }
+#endif  // BUILDFLAG(IS_COBALT)
+
   // We don't need to populate the DeSerializeOptions here since the reader is
   // only used for de-serializing primitives.
   std::vector<uint8_t> scratch_buffer;
@@ -781,6 +926,117 @@ bool ServiceImageTransferCacheEntry::Deserialize(
   }
   return true;
 }
+
+#if BUILDFLAG(IS_COBALT)
+bool ServiceImageTransferCacheEntry::DeserializeInProcess(
+    GrDirectContext* gr_context,
+    base::span<const uint8_t> data) {
+  DCHECK_EQ(data.size(), sizeof(InProcessImageTransferCachePayload*));
+  if (data.size() != sizeof(InProcessImageTransferCachePayload*)) {
+    return false;
+  }
+  InProcessImageTransferCachePayload* raw_payload = nullptr;
+  UNSAFE_BUFFERS(std::memcpy(&raw_payload, data.data(), sizeof(raw_payload)));
+  if (!raw_payload ||
+      !InProcessImageTransferCachePayloadRegistry::GetInstance().Take(
+          raw_payload)) {
+    return false;
+  }
+  std::unique_ptr<InProcessImageTransferCachePayload> payload(raw_payload);
+
+  has_gainmap_ = payload->gainmap_image != nullptr;
+  hdr_metadata_ = payload->hdr_metadata;
+  const bool mip_mapped_for_upload =
+      payload->needs_mips && !payload->target_color_space;
+
+  // In Cobalt, all rasterization is GPU-driven and image dimensions are
+  // bounded within hardware texture limits by GpuImageDecodeCache.
+  // SkImages::TextureFromImage internally validates against maxTextureSize and
+  // returns nullptr on failure, so explicit max size checks and CPU-backed
+  // fallback copies are skipped.
+  if (payload->yuva_info.has_value()) {
+    std::vector<sk_sp<SkImage>> uploaded_planes;
+    for (auto& plane : payload->yuv_planes) {
+      sk_sp<SkImage> uploaded_plane =
+          UploadImageInProcess(gr_context, plane, mip_mapped_for_upload);
+      if (!uploaded_plane) {
+        DLOG(ERROR) << "Failed to upload in-process YUV plane";
+        return false;
+      }
+      uploaded_planes.push_back(std::move(uploaded_plane));
+    }
+    image_ = MakeYUVImageFromUploadedPlanes(
+        gr_context, /*graphite_recorder=*/nullptr, uploaded_planes,
+        payload->yuva_info.value(), payload->yuv_color_space);
+    if (!image_) {
+      DLOG(ERROR) << "Failed to make YUV image from uploaded planes";
+      return false;
+    }
+  } else {
+    image_ = UploadImageInProcess(gr_context, payload->image,
+                                  mip_mapped_for_upload);
+    if (!image_) {
+      DLOG(ERROR) << "Failed to upload in-process image to texture";
+      return false;
+    }
+  }
+
+  if (has_gainmap_) {
+    gainmap_image_ = UploadImageInProcess(gr_context, payload->gainmap_image,
+                                          mip_mapped_for_upload);
+    if (!gainmap_image_) {
+      return false;
+    }
+    if (payload->gainmap_info.has_value()) {
+      gainmap_info_ = payload->gainmap_info.value();
+    }
+  }
+
+  // Determine if this image will be tone mapped.
+  const bool is_tone_mapped =
+      has_gainmap_ ||
+      ToneMapUtil::UseGlobalToneMapFilter(image_->colorSpace());
+
+  // Perform color conversion (if no tone mapping is needed).
+  if (payload->target_color_space && !is_tone_mapped) {
+    image_ = image_->makeColorSpace(gr_context, payload->target_color_space);
+    if (payload->needs_mips && gr_context && image_ &&
+        image_->isTextureBacked()) {
+      image_ = SkImages::TextureFromImage(
+          gr_context, image_, skgpu::Mipmapped::kYes, skgpu::Budgeted::kNo);
+    }
+    if (!image_) {
+      DLOG(ERROR) << "Failed image color conversion.";
+      return false;
+    }
+  }
+
+  size_ = image_->textureSize();
+  if (gainmap_image_) {
+    size_ += gainmap_image_->textureSize();
+  }
+
+  return true;
+}
+
+// Uploads a single in-process raster-backed SkImage to a GPU texture.
+// Note: This currently only supports RGBA images.
+sk_sp<SkImage> ServiceImageTransferCacheEntry::UploadImageInProcess(
+    GrDirectContext* gr_context,
+    sk_sp<SkImage> img,
+    bool mip_mapped_for_upload) {
+  if (!img) {
+    return nullptr;
+  }
+  if (gr_context) {
+    img = SkImages::TextureFromImage(
+        gr_context, img,
+        mip_mapped_for_upload ? skgpu::Mipmapped::kYes : skgpu::Mipmapped::kNo,
+        skgpu::Budgeted::kNo);
+  }
+  return img;
+}
+#endif  // BUILDFLAG(IS_COBALT)
 
 const sk_sp<SkImage>& ServiceImageTransferCacheEntry::GetPlaneImage(
     size_t index) const {

--- a/cc/paint/image_transfer_cache_entry.h
+++ b/cc/paint/image_transfer_cache_entry.h
@@ -13,7 +13,10 @@
 
 #include "base/atomic_sequence_num.h"
 #include "base/containers/span.h"
+#include "base/functional/callback_helpers.h"
 #include "base/memory/raw_ptr.h"
+#include "base/memory/ref_counted.h"
+#include "build/build_config.h"
 #include "cc/paint/tone_map_util.h"
 #include "cc/paint/transfer_cache_entry.h"
 #include "third_party/skia/include/core/SkImageInfo.h"
@@ -96,6 +99,18 @@ class CC_PAINT_EXPORT ClientImageTransferCacheEntry final
   // ClientTransferCacheEntry implementation:
   uint32_t SerializedSize() const final;
   bool Serialize(base::span<uint8_t> data) const final;
+#if BUILDFLAG(IS_COBALT)
+  uint32_t SerializedSizeInProcess() const;
+  bool SerializeInProcess(
+      base::span<uint8_t> data,
+      base::ScopedClosureRunner unref_runner =
+          base::ScopedClosureRunner()) const;
+
+  // Clears all in-flight in-process image transfer payloads and runs their
+  // unref_runner runners to unref decoded images, typically called during
+  // cache clear or context loss cleanup.
+  static void ClearInProcessRegistry();
+#endif  // BUILDFLAG(IS_COBALT)
 
   static uint32_t GetNextId() { return s_next_id_.GetNext(); }
   bool IsYuv() const {
@@ -159,6 +174,13 @@ class CC_PAINT_EXPORT ServiceImageTransferCacheEntry final
   bool Deserialize(GrDirectContext* gr_context,
                    skgpu::graphite::Recorder* graphite_recorder,
                    base::span<const uint8_t> data) final;
+#if BUILDFLAG(IS_COBALT)
+  bool DeserializeInProcess(GrDirectContext* gr_context,
+                            base::span<const uint8_t> data);
+  sk_sp<SkImage> UploadImageInProcess(GrDirectContext* gr_context,
+                                      sk_sp<SkImage> img,
+                                      bool mip_mapped_for_upload);
+#endif  // BUILDFLAG(IS_COBALT)
 
   const sk_sp<SkImage>& image() const { return image_; }
 

--- a/cc/tiles/gpu_image_decode_cache.cc
+++ b/cc/tiles/gpu_image_decode_cache.cc
@@ -16,7 +16,9 @@
 #include "base/containers/span.h"
 #include "base/debug/alias.h"
 #include "base/feature_list.h"
+#include "base/features.h"
 #include "base/functional/bind.h"
+#include "base/functional/callback_helpers.h"
 #include "base/hash/hash.h"
 #include "base/logging.h"
 #include "base/memory/discardable_memory_allocator.h"
@@ -28,8 +30,9 @@
 #include "base/strings/stringprintf.h"
 #if BUILDFLAG(IS_COBALT)
 #include "base/strings/string_number_conversions.h"
-#endif
+#endif  // BUILDFLAG(IS_COBALT)
 #include "base/synchronization/lock.h"
+#include "base/task/bind_post_task.h"
 #include "base/task/single_thread_task_runner.h"
 #include "base/time/tick_clock.h"
 #include "base/time/time.h"
@@ -1230,7 +1233,7 @@ GpuImageDecodeCache::GpuImageDecodeCache(
 #if BUILDFLAG(IS_COBALT)
     size_t max_persistent_cache_items,
     size_t max_persistent_cache_memory_size,
-#endif
+#endif  // BUILDFLAG(IS_COBALT)
     RasterDarkModeFilter* const dark_mode_filter)
     : color_type_(color_type),
       use_transfer_cache_(use_transfer_cache),
@@ -1248,11 +1251,14 @@ GpuImageDecodeCache::GpuImageDecodeCache(
           max_persistent_cache_items,
           static_cast<size_t>(kNormalMaxItemsInCacheForGpu))),
       max_persistent_cache_memory_size_(max_persistent_cache_memory_size),
-#endif
+#endif  // BUILDFLAG(IS_COBALT)
       dark_mode_filter_(dark_mode_filter) {
   if (base::SequencedTaskRunner::HasCurrentDefault()) {
     task_runner_ = base::SequencedTaskRunner::GetCurrentDefault();
   }
+#if BUILDFLAG(IS_COBALT)
+  weak_ptr_ = weak_ptr_factory_.GetWeakPtr();
+#endif  // BUILDFLAG(IS_COBALT)
 
   DCHECK_NE(generator_client_id_, PaintImage::kDefaultGeneratorClientId);
   // Note that to compute |allow_accelerated_jpeg_decodes_| and
@@ -2193,6 +2199,21 @@ void GpuImageDecodeCache::UnrefImageDecode(const DrawImage& draw_image,
   }
 }
 
+#if BUILDFLAG(IS_COBALT)
+void GpuImageDecodeCache::RefImageDecode(ImageData* image_data) {
+  DCHECK(image_data);
+  ++image_data->decode.ref_count;
+  OwnershipChanged(image_data);
+}
+
+void GpuImageDecodeCache::UnrefImageDecode(ImageData* image_data) {
+  DCHECK(image_data);
+  DCHECK_GT(image_data->decode.ref_count, 0u);
+  --image_data->decode.ref_count;
+  OwnershipChanged(image_data);
+}
+#endif  // BUILDFLAG(IS_COBALT)
+
 void GpuImageDecodeCache::RefImage(const DrawImage& draw_image,
                                    const InUseCacheKey& cache_key) {
   TRACE_EVENT0(TRACE_DISABLED_BY_DEFAULT("cc.debug"),
@@ -2328,6 +2349,105 @@ void GpuImageDecodeCache::OwnershipChanged(const DrawImage& draw_image,
 #endif
 }
 
+#if BUILDFLAG(IS_COBALT)
+void GpuImageDecodeCache::OwnershipChanged(ImageData* image_data) {
+  bool has_any_refs =
+      image_data->upload.ref_count > 0 || image_data->decode.ref_count > 0;
+
+  // If we have no image refs on an image, we should unbudget it.
+  if (!has_any_refs && image_data->is_budgeted) {
+    DCHECK_GE(working_set_bytes_, image_data->GetTotalSize());
+    DCHECK_GE(working_set_items_, 1u);
+    working_set_bytes_ -= image_data->GetTotalSize();
+    working_set_items_ -= 1;
+    image_data->is_budgeted = false;
+  }
+
+  // GpuImageDecodeCache::OwnershipChanged(ImageData*) is identical to the
+  // chromium version, but with the draw_image parameter removed and the code
+  // below is commented out.
+  // // Don't keep around completely empty images. This can happen if an image's
+  // // decode/upload tasks were both cancelled before completing.
+  // const bool has_cpu_data = image_data->decode.HasData() ||
+  //                           (image_data->is_bitmap_backed &&
+  //                            image_data->decode.image(0, AuxImage::kDefault));
+  // bool is_empty = !has_any_refs && !image_data->HasUploadedData() &&
+  //                 !has_cpu_data && !image_data->is_orphaned;
+  // if (is_empty || draw_image.paint_image().no_cache()) {
+  //   auto found_persistent = persistent_cache_.Peek(draw_image.frame_key());
+  //   if (found_persistent != persistent_cache_.end())
+  //     RemoveFromPersistentCache(found_persistent);
+  // }
+
+  // Don't keep discardable cpu memory for GPU backed images. The cache hit rate
+  // of the cpu fallback (in case we don't find this image in gpu memory) is
+  // too low to cache this data.
+  if (image_data->decode.ref_count == 0 &&
+      image_data->mode != DecodedDataMode::kCpu &&
+      image_data->HasUploadedData()) {
+    image_data->decode.ResetData();
+    image_data->speculative_decode_usage_stats_.reset();
+  }
+
+  // If we have no refs on an uploaded image, it should be unlocked. Do this
+  // before any attempts to delete the image.
+  if (image_data->IsGpuOrTransferCache() && image_data->upload.ref_count == 0 &&
+      image_data->upload.is_locked()) {
+    UnlockImage(image_data);
+  }
+
+  // Don't keep around orphaned images.
+  if (image_data->is_orphaned && !has_any_refs) {
+    DeleteImage(image_data);
+  }
+
+  // Don't keep CPU images if they are unused, these images can be recreated by
+  // re-locking discardable (rather than requiring a full upload like GPU
+  // images).
+  if (image_data->mode == DecodedDataMode::kCpu && !has_any_refs) {
+    DeleteImage(image_data);
+  }
+
+  // If we have image that could be budgeted, but isn't, budget it now.
+  if (has_any_refs && !image_data->is_budgeted &&
+      CanFitInWorkingSet(image_data->GetTotalSize())) {
+    working_set_bytes_ += image_data->GetTotalSize();
+    working_set_items_ += 1;
+    image_data->is_budgeted = true;
+  }
+
+  // We should unlock the decoded image memory for the image in two cases:
+  // 1) The image is no longer being used (no decode or upload refs).
+  // 2) This is a non-CPU image that has already been uploaded and we have
+  //    no remaining decode refs.
+  bool should_unlock_decode = !has_any_refs || (image_data->HasUploadedData() &&
+                                                !image_data->decode.ref_count);
+
+  if (should_unlock_decode && image_data->decode.is_locked()) {
+    if (image_data->is_bitmap_backed) {
+      DCHECK(!image_data->decode.HasData());
+      image_data->decode.ResetBitmapImage();
+    } else {
+      DCHECK(image_data->decode.HasData());
+      image_data->decode.Unlock();
+    }
+  }
+
+  // EnsureCapacity to make sure we are under our cache limits.
+  EnsureCapacity(0);
+
+#if DCHECK_IS_ON()
+  // Sanity check the above logic.
+  if (image_data->HasUploadedData()) {
+    if (image_data->mode == DecodedDataMode::kCpu)
+      DCHECK(image_data->decode.is_locked());
+  } else {
+    DCHECK(!image_data->is_budgeted || has_any_refs);
+  }
+#endif
+}
+#endif  // BUILDFLAG(IS_COBALT)
+
 // Checks whether we can fit a new image of size |required_size| in our
 // working set. Also frees unreferenced entries to keep us below our preferred
 // items limit.
@@ -2386,11 +2506,37 @@ void GpuImageDecodeCache::InsertTransferCacheEntry(
     ImageData* image_data) {
   DCHECK(image_data);
   uint32_t size = image_entry.SerializedSize();
+
+#if BUILDFLAG(IS_COBALT)
+  bool use_in_process_transfer = false;
+  if (base::FeatureList::IsEnabled(
+          base::features::kCobaltInProcessImageTransferCache) &&
+      task_runner_) {
+    use_in_process_transfer = true;
+    size = image_entry.SerializedSizeInProcess();
+  }
+#endif  // BUILDFLAG(IS_COBALT)
+
   void* data = context_->ContextSupport()->MapTransferCacheEntry(size);
   if (data) {
     // TODO(crbug.com/40285824): Have MapTransferCacheEntry() return a span.
-    bool succeeded = image_entry.Serialize(
-        UNSAFE_TODO(base::span(static_cast<uint8_t*>(data), size)));
+    bool succeeded = false;
+#if BUILDFLAG(IS_COBALT)
+    if (use_in_process_transfer) {
+      RefImageDecode(image_data);
+      succeeded = image_entry.SerializeInProcess(
+          UNSAFE_TODO(base::span(static_cast<uint8_t*>(data), size)),
+          base::ScopedClosureRunner(base::BindPostTask(
+              task_runner_,
+              base::BindOnce(
+                  &GpuImageDecodeCache::OnInProcessImageTransferCompleted,
+                  weak_ptr_, base::WrapRefCounted(image_data)))));
+    } else
+#endif  // BUILDFLAG(IS_COBALT)
+    {
+      succeeded = image_entry.Serialize(
+          UNSAFE_TODO(base::span(static_cast<uint8_t*>(data), size)));
+    }
     DCHECK(succeeded);
     context_->ContextSupport()->UnmapAndCreateTransferCacheEntry(
         image_entry.UnsafeType(), image_entry.Id());
@@ -2403,6 +2549,14 @@ void GpuImageDecodeCache::InsertTransferCacheEntry(
     image_data->decode.decode_failure = true;
   }
 }
+
+#if BUILDFLAG(IS_COBALT)
+void GpuImageDecodeCache::OnInProcessImageTransferCompleted(
+    scoped_refptr<ImageData> image_data) {
+  base::AutoLock lock(lock_);
+  UnrefImageDecode(image_data.get());
+}
+#endif  // BUILDFLAG(IS_COBALT)
 
 bool GpuImageDecodeCache::NeedsDarkModeFilter(const DrawImage& draw_image,
                                               ImageData* image_data) {

--- a/cc/tiles/gpu_image_decode_cache.h
+++ b/cc/tiles/gpu_image_decode_cache.h
@@ -155,7 +155,7 @@ class CC_EXPORT GpuImageDecodeCache
 #if BUILDFLAG(IS_COBALT)
                                size_t max_persistent_cache_items,
                                size_t max_persistent_cache_memory_size,
-#endif
+#endif  // BUILDFLAG(IS_COBALT)
                                RasterDarkModeFilter* const dark_mode_filter);
   ~GpuImageDecodeCache() override;
 
@@ -746,6 +746,13 @@ class CC_EXPORT GpuImageDecodeCache
   void UnrefImageDecode(const DrawImage& draw_image,
                         const InUseCacheKey& cache_key)
       EXCLUSIVE_LOCKS_REQUIRED(lock_);
+#if BUILDFLAG(IS_COBALT)
+  // Ref-counting helpers for in-process image transfer caching where only
+  // `ImageData*` is available, keeping the underlying decoded memory pinned
+  // until texture upload completes on the GPU thread.
+  void RefImageDecode(ImageData* image_data) EXCLUSIVE_LOCKS_REQUIRED(lock_);
+  void UnrefImageDecode(ImageData* image_data) EXCLUSIVE_LOCKS_REQUIRED(lock_);
+#endif  // BUILDFLAG(IS_COBALT)
   void RefImage(const DrawImage& draw_image, const InUseCacheKey& cache_key)
       EXCLUSIVE_LOCKS_REQUIRED(lock_);
   void UnrefImageInternal(const DrawImage& draw_image,
@@ -756,6 +763,10 @@ class CC_EXPORT GpuImageDecodeCache
   // to ref-count or to orphaned status.
   void OwnershipChanged(const DrawImage& draw_image, ImageData* image_data)
       EXCLUSIVE_LOCKS_REQUIRED(lock_);
+#if BUILDFLAG(IS_COBALT)
+  void OwnershipChanged(ImageData* image_data)
+      EXCLUSIVE_LOCKS_REQUIRED(lock_);
+#endif  // BUILDFLAG(IS_COBALT)
 
   // Ensures that the working set can hold an element of |required_size|,
   // freeing unreferenced cache entries to make room.
@@ -767,6 +778,10 @@ class CC_EXPORT GpuImageDecodeCache
   void InsertTransferCacheEntry(
       const ClientImageTransferCacheEntry& image_entry,
       ImageData* image_data) EXCLUSIVE_LOCKS_REQUIRED(lock_);
+#if BUILDFLAG(IS_COBALT)
+  void OnInProcessImageTransferCompleted(
+      scoped_refptr<ImageData> image_data);
+#endif  // BUILDFLAG(IS_COBALT)
   bool NeedsDarkModeFilter(const DrawImage& draw_image, ImageData* image_data);
   void DecodeImageAndGenerateDarkModeFilterIfNecessary(
       const DrawImage& draw_image,
@@ -991,7 +1006,7 @@ class CC_EXPORT GpuImageDecodeCache
 #if BUILDFLAG(IS_COBALT)
   const size_t max_persistent_cache_items_;
   const size_t max_persistent_cache_memory_size_;
-#endif
+#endif  // BUILDFLAG(IS_COBALT)
 
   // This field is not a raw_ptr<> because of incompatibilities with tracing
   // (TRACE_EVENT*), perfetto::TracedDictionary::Add and gmock/EXPECT_THAT.
@@ -1014,6 +1029,14 @@ class CC_EXPORT GpuImageDecodeCache
   std::vector<uint32_t> ids_pending_deletion_;
 
   std::unique_ptr<base::MemoryPressureListener> memory_pressure_listener_;
+#if BUILDFLAG(IS_COBALT)
+  // `weak_ptr_factory_.GetWeakPtr()` must be called on the sequence that
+  // created the factory (the compositor thread) to avoid sequence checker
+  // assertions. Pre-creating `weak_ptr_` in the constructor allows worker
+  // threads to safely copy and pass it to in-process image transfer completion
+  // callbacks.
+  base::WeakPtr<GpuImageDecodeCache> weak_ptr_;
+#endif  // BUILDFLAG(IS_COBALT)
   base::WeakPtrFactory<GpuImageDecodeCache> weak_ptr_factory_{this};
 };
 

--- a/gpu/command_buffer/client/raster_implementation.cc
+++ b/gpu/command_buffer/client/raster_implementation.cc
@@ -44,6 +44,9 @@
 #include "cc/paint/skottie_serialization_history.h"
 #include "cc/paint/transfer_cache_entry.h"
 #include "cc/paint/transfer_cache_serialize_helper.h"
+#if BUILDFLAG(IS_COBALT)
+#include "cc/paint/image_transfer_cache_entry.h"
+#endif  // BUILDFLAG(IS_COBALT)
 #include "components/miracle_parameter/common/public/miracle_parameter.h"
 #include "gpu/command_buffer/client/gpu_control.h"
 #include "gpu/command_buffer/client/image_decode_accelerator_interface.h"
@@ -609,6 +612,10 @@ RasterImplementation::~RasterImplementation() {
 
   // Make sure the commands make it the service.
   WaitForCmd();
+
+#if BUILDFLAG(IS_COBALT)
+  cc::ClientImageTransferCacheEntry::ClearInProcessRegistry();
+#endif  // BUILDFLAG(IS_COBALT)
 }
 
 RasterCmdHelper* RasterImplementation::helper() const {

--- a/gpu/command_buffer/client/shared_memory_limits.h
+++ b/gpu/command_buffer/client/shared_memory_limits.h
@@ -7,9 +7,14 @@
 
 #include <stddef.h>
 
+#include "base/feature_list.h"
 #include "base/system/sys_info.h"
 #include "build/build_config.h"
 #include "ui/gfx/geometry/size.h"
+
+#if BUILDFLAG(IS_COBALT)
+#include "base/features.h"
+#endif
 
 namespace gpu {
 
@@ -32,6 +37,17 @@ struct SharedMemoryLimits {
       start_transfer_buffer_size = 32 * 1024;
       min_transfer_buffer_size = 32 * 1024;
       mapped_memory_chunk_size = 256 * 1024;
+    }
+#endif
+
+#if BUILDFLAG(IS_COBALT)
+    // When in-process image transfer is enabled, decoded images bypass
+    // transfer cache serialization and no longer use MappedMemoryManager.
+    // MappedMemoryManager is therefore only used for lightweight operations.
+    // Reducing the chunk size to 64KB avoids wasting shared memory.
+    if (base::FeatureList::IsEnabled(
+            base::features::kCobaltInProcessImageTransferCache)) {
+      mapped_memory_chunk_size = 64 * 1024;
     }
 #endif
   }


### PR DESCRIPTION
Introduce an in-process path for transferring decoded images from the
client to the GPU service.

By bypassing the serialization and deserialization of pixel data when
running in a single-process environment, this optimization reduces
CPU overhead and memory bandwidth. The implementation ensures that
decoded image memory is preserved through the transfer using a closure
runner until the GPU texture upload is finalized.

Bug: 545866687