### PR TITLE
Fix staging build after #12126, #12123, #12114

### DIFF
--- a/base/threading/hang_watcher_unittest.cc
+++ b/base/threading/hang_watcher_unittest.cc
@@ -1879,9 +1879,8 @@ TEST_F(HangWatcherLongHangTest, MultipleThreadsOverlappingHangLogsOnce) {
   testing::StrictMock<MockHangWatcherDelegate> mock_delegate;
   auto unregister_thread_a = StartAndRegister(mock_delegate);
 
-  base::WaitableEvent unblock_thread_b;
-  BlockingThread thread_b(&unblock_thread_b, base::Seconds(1));
-  thread_b.StartAndWaitForScopeEntered();
+  BlockedThread thread_b(HangWatcher::ThreadType::kMainThread,
+                         base::Seconds(1));
 
   auto hang_scope_a = std::make_unique<WatchHangsInScope>(base::Seconds(1));
 
@@ -1908,8 +1907,8 @@ TEST_F(HangWatcherLongHangTest, MultipleThreadsOverlappingHangLogsOnce) {
   histogram_tester.ExpectUniqueSample("HangWatcher.LongHang.Detected", true, 1);
 
   // Recover thread B.
-  unblock_thread_b.Signal();
-  thread_b.Join();
+  thread_b.Unblock();
+  thread_b.WaitDone();
   EXPECT_CALL(mock_delegate, RecordHangRecovered(testing::_)).Times(1);
   TriggerMonitorAndWait();
 
@@ -1954,9 +1953,8 @@ TEST_F(HangWatcherLongHangTest, ActionableHangFollowedByIgnoredHang) {
   testing::StrictMock<MockHangWatcherDelegate> mock_delegate;
   auto unregister_thread_a = StartAndRegister(mock_delegate);
 
-  base::WaitableEvent unblock_thread_b;
-  BlockingThread thread_b(&unblock_thread_b, base::Seconds(1));
-  thread_b.StartAndWaitForScopeEntered();
+  BlockedThread thread_b(HangWatcher::ThreadType::kMainThread,
+                         base::Seconds(1));
 
   auto hang_scope_a = std::make_unique<WatchHangsInScope>(base::Seconds(1));
 
@@ -1973,8 +1971,8 @@ TEST_F(HangWatcherLongHangTest, ActionableHangFollowedByIgnoredHang) {
 
   // Recover thread B. Thread A remains hung but ignored.
   EXPECT_CALL(mock_delegate, RecordHangRecovered(testing::_)).Times(1);
-  unblock_thread_b.Signal();
-  thread_b.Join();
+  thread_b.Unblock();
+  thread_b.WaitDone();
   TriggerMonitorAndWait();
 
   // Fast forward past the long hang timeout.
@@ -2026,18 +2024,15 @@ TEST_F(HangWatcherCobaltTest, AlternatingHangsSingleUuid) {
   // Keep the main thread registered so watch_states_ is never empty,
   // ensuring Monitor() is always invoked when triggered.
 
-  base::WaitableEvent unblock_thread_a;
-  base::WaitableEvent unblock_thread_b;
-  BlockingThread thread_a(&unblock_thread_a, kTimeout);
-  BlockingThread thread_b(&unblock_thread_b, kTimeout);
+  BlockedThread thread_a(HangWatcher::ThreadType::kMainThread, kTimeout);
 
-  thread_a.StartAndWaitForScopeEntered();
   monitor_event_.Reset();
 
   // Advance time so thread A and thread B have different deadlines.
   task_environment_.FastForwardBy(kTimeout / 2);
 
-  thread_b.StartAndWaitForScopeEntered();
+  BlockedThread thread_b(HangWatcher::ThreadType::kMainThread, kTimeout);
+
   monitor_event_.Reset();
 
   // Thread A hangs.
@@ -2047,8 +2042,8 @@ TEST_F(HangWatcherCobaltTest, AlternatingHangsSingleUuid) {
   ASSERT_FALSE(captured_uuid.empty());
 
   // Thread A recovers.
-  unblock_thread_a.Signal();
-  thread_a.Join();
+  thread_a.Unblock();
+  thread_a.WaitDone();
 
   // Thread B hangs.
   task_environment_.FastForwardBy(kTimeout / 2);
@@ -2059,8 +2054,8 @@ TEST_F(HangWatcherCobaltTest, AlternatingHangsSingleUuid) {
   TriggerMonitorAndWait();
 
   // Thread B recovers.
-  unblock_thread_b.Signal();
-  thread_b.Join();
+  thread_b.Unblock();
+  thread_b.WaitDone();
 
   // Monitor runs. IsActionable() is false because no threads are hung.
   // CheckHangState() runs, sees no threads are hung, clears the incident state,
@@ -2077,10 +2072,8 @@ TEST_F(HangWatcherCobaltTest, ThreadUnregistersWhileHungRecordsRecovery) {
   auto unregister_thread_closure =
       StartAndRegisterWithUuidCapture(mock_delegate, &captured_uuid);
 
-  base::WaitableEvent unblock_thread_a;
-  BlockingThread thread_a(&unblock_thread_a, kTimeout);
+  BlockedThread thread_a(HangWatcher::ThreadType::kMainThread, kTimeout);
 
-  thread_a.StartAndWaitForScopeEntered();
   monitor_event_.Reset();
 
   // Thread A hangs.
@@ -2095,8 +2088,8 @@ TEST_F(HangWatcherCobaltTest, ThreadUnregistersWhileHungRecordsRecovery) {
   EXPECT_CALL(mock_delegate, RecordHangRecovered(captured_uuid)).Times(1);
 
   // Thread A unblocks and unregisters
-  unblock_thread_a.Signal();
-  thread_a.Join();
+  thread_a.Unblock();
+  thread_a.WaitDone();
 
   TriggerMonitorAndWait();
 

--- a/cobalt/browser/performance/performance_impl.cc
+++ b/cobalt/browser/performance/performance_impl.cc
@@ -16,7 +16,7 @@
 
 #include <utility>
 
-#include "base/notreached.h"
+#include "base/notimplemented.h"
 #include "base/process/process_handle.h"
 #include "base/process/process_metrics.h"
 #include "base/system/sys_info.h"

--- a/third_party/blink/renderer/core/inspector/cobalt/inspector_dom_agent_stub.cc
+++ b/third_party/blink/renderer/core/inspector/cobalt/inspector_dom_agent_stub.cc
@@ -16,6 +16,7 @@
 
 namespace blink {
 
+void InspectorDOMAgent::WillHidePopover(HTMLElement*, bool*) {}
 void InspectorDOMAgent::DomContentLoadedEventFired(LocalFrame*) {}
 void InspectorDOMAgent::DidCommitLoad(LocalFrame*, DocumentLoader*) {}
 void InspectorDOMAgent::DidRestoreFromBackForwardCache(LocalFrame*) {}

--- a/third_party/blink/renderer/core/inspector/cobalt/inspector_dom_debugger_agent_stub.cc
+++ b/third_party/blink/renderer/core/inspector/cobalt/inspector_dom_debugger_agent_stub.cc
@@ -33,6 +33,6 @@ void InspectorDOMDebuggerAgent::DidInvalidateStyleAttr(Node*) {}
 void InspectorDOMDebuggerAgent::EventListenersInfoForTarget(
     v8::Isolate*,
     v8::Local<v8::Value>,
-    Vector<V8EventListenerInfo, 0u, WTF::PartitionAllocator>*) {}
+    V8EventListenerInfoList*) {}
 
 }  // namespace blink

--- a/third_party/blink/renderer/core/inspector/cobalt/inspector_emulation_agent_stub.cc
+++ b/third_party/blink/renderer/core/inspector/cobalt/inspector_emulation_agent_stub.cc
@@ -17,6 +17,7 @@
 namespace blink {
 
 void InspectorEmulationAgent::ApplyAcceptLanguageOverride(String*) {}
+void InspectorEmulationAgent::ApplyDataSaverOverride(bool&) {}
 void InspectorEmulationAgent::ApplyHardwareConcurrencyOverride(unsigned int&) {}
 void InspectorEmulationAgent::ApplyUserAgentOverride(String*) {}
 void InspectorEmulationAgent::ApplyUserAgentMetadataOverride(

--- a/third_party/blink/renderer/core/inspector/cobalt/inspector_page_agent_stub.cc
+++ b/third_party/blink/renderer/core/inspector/cobalt/inspector_page_agent_stub.cc
@@ -29,7 +29,7 @@ void InspectorPageAgent::DomContentLoadedEventFired(LocalFrame*) {}
 void InspectorPageAgent::LoadEventFired(LocalFrame*) {}
 void InspectorPageAgent::FrameAttachedToParent(
     LocalFrame*,
-    const Vector<AdScriptIdentifier, 0u, WTF::PartitionAllocator>&) {}
+    const AdTracker::AdScriptAncestry&) {}
 void InspectorPageAgent::FrameDetachedFromParent(LocalFrame*, FrameDetachType) {
 }
 void InspectorPageAgent::FrameSubtreeWillBeDetached(Frame*) {}


### PR DESCRIPTION
The cherry-pick from #12126 was broken, as `hang_watcher_unittest.cc` changed significantly with the recent rolls.

This commit makes the same changes from #12008 and adapts the new code to:

* https://crrev.com/c/6588028
* https://crrev.com/c/6583574
* https://crrev.com/c/6581049

The #12123 cherry-pick broke the build because the signatures of some functions differ from M138.
    
Specifically, adapt to https://crrev.com/c/6598776 and some change to WTF that changed the Vector signature used in `InspectorDOMDebuggerAgent::EventListenersInfoForTarget()`.
    
Co-authored-by: Gyuyoung Kim <gyuyoung@igalia.com> (@Gyuyoung)

The #12114 cherry-pick broke the build because `NOTIMPLEMENTED()` needs `base/notimplemented.h`, not `base/notreached.h`, at least in the staging branch (a lot of files in `cobalt/` needed the same fix in a previous roll).

Bug: 546124857
Bug: 525402992
Bug: 544828898