### PR TITLE
ci(25.lts): Replace kaidokert/checkout with actions/checkout

### DIFF
--- a/.github/workflows/gradle_25.lts.1+.yaml
+++ b/.github/workflows/gradle_25.lts.1+.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: kaidokert/checkout@1bf7689f6bce800f108fa5e9f0885fbfcb14ffd6 # v3.5.999
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         timeout-minutes: 30
       - name: Set up JDK 11
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -79,7 +79,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - id: checkout
-        uses: kaidokert/checkout@1bf7689f6bce800f108fa5e9f0885fbfcb14ffd6 # v3.5.999
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         timeout-minutes: 30
         with:
           fetch-depth: 1
@@ -192,7 +192,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout files
-        uses: kaidokert/checkout@1bf7689f6bce800f108fa5e9f0885fbfcb14ffd6 # v3.5.999
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         timeout-minutes: 30
         with:
           fetch-depth: 2
@@ -345,7 +345,7 @@ jobs:
       MODULAR_BUILD: ${{ inputs.modular && 1 || 0 }}
     steps:
       - name: Checkout
-        uses: kaidokert/checkout@1bf7689f6bce800f108fa5e9f0885fbfcb14ffd6 # v3.5.999
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         timeout-minutes: 30
         with:
           fetch-depth: 1
@@ -378,7 +378,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout
-        uses: kaidokert/checkout@1bf7689f6bce800f108fa5e9f0885fbfcb14ffd6 # v3.5.999
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         timeout-minutes: 30
         with:
           fetch-depth: 1

--- a/.github/workflows/main_win.yaml
+++ b/.github/workflows/main_win.yaml
@@ -64,7 +64,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - id: Checkout
-        uses: kaidokert/checkout@1bf7689f6bce800f108fa5e9f0885fbfcb14ffd6 # v3.5.999
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -212,7 +212,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout
-        uses: kaidokert/checkout@1bf7689f6bce800f108fa5e9f0885fbfcb14ffd6 # v3.5.999
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/pytest_25.lts.1+.yaml
+++ b/.github/workflows/pytest_25.lts.1+.yaml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: kaidokert/checkout@1bf7689f6bce800f108fa5e9f0885fbfcb14ffd6 # v3.5.999
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
           persist-credentials: false


### PR DESCRIPTION
Deprecate and replace custom action `kaidokert/checkout` with default `actions/checkout` across 25.lts workflows.

Tag: agy
Conv: 903121f7-324b-4066-b90b-a2370ac4688c
Bug: 551984449