### PR TITLE
evergreen: Port forward ELF load time histograms

### DIFF
--- a/cobalt/browser/loader_app_metrics.cc
+++ b/cobalt/browser/loader_app_metrics.cc
@@ -47,12 +47,34 @@ const StarboardExtensionLoaderAppMetricsApi* GetLoaderAppMetricsExtension() {
 
 void RecordLoaderAppTimeMetrics(
     const StarboardExtensionLoaderAppMetricsApi* metrics_extension) {
+  int64_t elf_load_duration_us =
+      metrics_extension->GetElfLoadDurationMicroseconds();
+  if (elf_load_duration_us < 0) {
+    LOG(ERROR) << "LoaderAppMetrics: ELF Load duration is negative, "
+                  "not logging.";
+    return;
+  }
+
+  base::UmaHistogramTimes("Cobalt.LoaderApp.ElfLoadDuration",
+                          base::Microseconds(elf_load_duration_us));
+  LOG(INFO) << "LoaderAppMetrics: Logging ELF Load Duration: "
+            << elf_load_duration_us << " us";
+
   int64_t elf_decompression_duration_us =
       metrics_extension->GetElfDecompressionDurationMicroseconds();
-
   if (elf_decompression_duration_us < 0) {
-    LOG(ERROR) << "LoaderAppMetrics: Decompression duration is negative, "
-                  "not logging.";
+    // This value is expected to not be set for libcobalt.zst installations,
+    // although this will be reconsidered in b/537769651.
+    LOG(INFO) << "LoaderAppMetrics: Diagnostic submetrics for ELF Load "
+                 "duration not provided.";
+    return;
+  }
+
+  if (elf_decompression_duration_us > elf_load_duration_us) {
+    LOG(ERROR) << "LoaderAppMetrics: Decompression duration ("
+               << elf_decompression_duration_us
+               << " us) exceeds load duration (" << elf_load_duration_us
+               << " us). Not logging diagnostic submetrics.";
     return;
   }
 
@@ -60,6 +82,13 @@ void RecordLoaderAppTimeMetrics(
                           base::Microseconds(elf_decompression_duration_us));
   LOG(INFO) << "LoaderAppMetrics: Logging ELF Decompression Duration: "
             << elf_decompression_duration_us << " us";
+
+  int64_t unexplained_duration_us =
+      elf_load_duration_us - elf_decompression_duration_us;
+  base::UmaHistogramTimes("Cobalt.LoaderApp.ElfLoadUnexplainedDuration",
+                          base::Microseconds(unexplained_duration_us));
+  LOG(INFO) << "LoaderAppMetrics: Logging ELF Load Unexplained Duration: "
+            << unexplained_duration_us << " us";
 }
 
 void RecordLoaderAppSpaceMetrics(
@@ -102,8 +131,10 @@ void RecordLoaderAppMetrics() {
   }
 
   if (!metrics_extension->GetElfLibraryStoredCompressed()) {
+    // We're only interested in load performance when the ELF library is stored
+    // compressed and must therefore be decompressed at load time.
     LOG(INFO) << "LoaderAppMetrics: ELF was not stored compressed. Skipping "
-                 "decompression metric.";
+                 "decompression performance metrics.";
     return;
   }
 

--- a/tools/metrics/histograms/metadata/cobalt/histograms.xml
+++ b/tools/metrics/histograms/metadata/cobalt/histograms.xml
@@ -200,12 +200,45 @@ Always run the pretty print utility on this file after editing:
 
 <histogram name="Cobalt.LoaderApp.ElfDecompressionDuration" units="ms"
     expires_after="never">
+<!-- expires-never: Needed for long-term tracking of ELF load performance. -->
+<!-- TODO(b/537769651): Consider recording this metric for libcobalt.zst
+     installations. -->
+
   <owner>hwarriner@google.com</owner>
   <owner>cobalt-team@google.com</owner>
   <summary>
-    The time it takes for the ELF dynamic shared library, stored as a compressed
-    file, to be decompressed. This metric is only recorded when the shared
-    library is stored as a compressed file.
+    The time it takes for the ELF dynamic shared library, stored as an LZ4
+    compressed file, to be decompressed. This metric is only recorded when the
+    shared library is stored as an LZ4 compressed file.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.LoaderApp.ElfLoadDuration" units="ms"
+    expires_after="never">
+<!-- expires-never: Needed for long-term tracking of ELF load performance. -->
+
+  <owner>hwarriner@google.com</owner>
+  <owner>cobalt-team@google.com</owner>
+  <summary>
+    The time it takes for Cobalt's ELF Loader to load the dynamic shared
+    library, which under normal operation is the Cobalt Core library. This
+    metric is only recorded when the shared library is stored as a compressed
+    file, and this metric includes decompression time.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.LoaderApp.ElfLoadUnexplainedDuration" units="ms"
+    expires_after="never">
+<!-- expires-never: Needed for long-term tracking of ELF load performance. -->
+<!-- TODO(b/537769651): Consider recording this metric for libcobalt.zst
+     installations. -->
+
+  <owner>hwarriner@google.com</owner>
+  <owner>cobalt-team@google.com</owner>
+  <summary>
+    Cobalt.LoaderApp.ElfLoadDuration minus
+    Cobalt.LoaderApp.ElfDecompressionDuration. This metric is only recorded when
+    the shared library is stored as an LZ4 compressed file.
   </summary>
 </histogram>
 


### PR DESCRIPTION
We originally added ElfLoadDuration as a summation metric, with ElfDecompressionDuration and ElfLoadUnexplainedDuration as diagnostic submetrics (see docs/speed/diagnostic_metrics.md for best practices). But only ElfDecompressionDuration had so far been ported forward to chrobalt.

This change adds back ElfLoadDuration and ElfLoadUnexplainedDuration, and records them both for libcobalt.lz4 installations.

ElfLoadDuration is identified as a P0 metric in
go/zstd-test-experiment-design, and this change populates this top-level duration metric for libcobalt.zst installations. It would be nice to also record the diagnostic submetrics for libcobalt.zst installations but this since it's not trivial and also not critical, we can discuss in the attached bug and consider doing so at a later time.

As with #12071, these changes have been manually tested e2e. The unit tests will be added back soon.

Issue: 537769651