### PR TITLE
media: Refactor BufferClamp to Percentage Reduction

### DIFF
--- a/media/base/demuxer_memory_limit.h
+++ b/media/base/demuxer_memory_limit.h
@@ -27,9 +27,8 @@ GetDemuxerStreamVideoMemoryLimit(DemuxerType demuxer_type,
 MEDIA_EXPORT size_t GetDemuxerMemoryLimit(DemuxerType demuxer_type);
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-MEDIA_EXPORT size_t GetVideoBufferSizeClamp();
-MEDIA_EXPORT void SetVideoBufferSizeClamp(int size_mb);
-#endif
+MEDIA_EXPORT void SetVideoBufferSizeReductionPercent(int reduction_pct);
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 namespace internal {
 

--- a/media/base/starboard/demuxer_memory_limit_starboard.cc
+++ b/media/base/starboard/demuxer_memory_limit_starboard.cc
@@ -30,10 +30,10 @@
 namespace media {
 namespace {
 
-// |g_video_buffer_size_clamp_bytes| is process-wide, and is currently set by
-// a h5vcc flag.
-std::atomic<size_t> g_video_buffer_size_clamp_bytes{
-    std::numeric_limits<size_t>::max()};
+// |g_video_buffer_size_reduction_percent| is process-wide, and is currently set
+// by h5vcc flags.
+std::atomic<std::optional<int>> g_video_buffer_size_reduction_percent{
+    std::nullopt};
 
 int GetBitsPerPixel(const VideoDecoderConfig& video_config) {
   bool is_hdr = false;
@@ -62,17 +62,10 @@ int GetBitsPerPixel(const VideoDecoderConfig& video_config) {
 
 }  // namespace
 
-size_t GetVideoBufferSizeClamp() {
-  return g_video_buffer_size_clamp_bytes.load();
-}
-
-void SetVideoBufferSizeClamp(int size_mb) {
-  // We convert the value from MBs to bytes, as the values returned by
-  // GetVideoDecoderBufferLimitBytes's return value is in bytes.
-  CHECK_GT(size_mb, 0);
-  // Prevent overflow bugs by setting the limit to 4 GiB.
-  CHECK_LT(size_mb, 4096);
-  g_video_buffer_size_clamp_bytes = static_cast<size_t>(size_mb) * 1024 * 1024;
+void SetVideoBufferSizeReductionPercent(int reduction_pct) {
+  CHECK_GT(reduction_pct, 0);
+  CHECK_LT(reduction_pct, 100);
+  g_video_buffer_size_reduction_percent = reduction_pct;
 }
 
 size_t GetDemuxerStreamAudioMemoryLimit(
@@ -93,7 +86,18 @@ size_t GetDemuxerStreamVideoMemoryLimit(
                                             GetBitsPerPixel(*video_config));
   }
 
-  return std::min(limit, g_video_buffer_size_clamp_bytes.load());
+  std::optional<int> reduction_pct =
+      g_video_buffer_size_reduction_percent.load();
+  if (!reduction_pct.has_value()) {
+    return limit;
+  }
+
+  // Multiplying limit by uint64_t remaining_pct preserves full precision and
+  // automatically promotes the calculation to 64-bit to prevent 32-bit
+  // overflow.
+  const uint64_t remaining_pct = 100 - reduction_pct.value();
+
+  return static_cast<size_t>((limit * remaining_pct) / 100);
 }
 
 size_t GetDemuxerMemoryLimit(DemuxerType demuxer_type) {

--- a/media/filters/source_buffer_stream.cc
+++ b/media/filters/source_buffer_stream.cc
@@ -1861,12 +1861,6 @@ bool SourceBufferStream::UpdateVideoConfig(const VideoDecoderConfig& config,
     DVLOG(2)
         << __func__
         << ": Skipping updating memory limit as memory limit was overridden.";
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-    if (GetVideoBufferSizeClamp() != std::numeric_limits<size_t>::max()) {
-      LOG(WARNING)
-          << "Experiment VideoBufferSizeClamp is active but ignored as memory limit was overridden.";
-    }
-#endif //  BUILDFLAG(USE_STARBOARD_MEDIA)
   } else {
     // Dynamically increase |memory_limit_| on video config changes.
     size_t new_memory_limit =

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
@@ -183,10 +183,10 @@ ScriptPromise<IDLUndefined> H5vccSettings::set(
           return true;
         });
   }
-  if (name == "Media.VideoBufferSizeClampMb") {
+  if (name == "Media.VideoBufferSizeReductionPercent") {
     return ProcessSettingAsPositiveInt(
         script_state, exception_context, name, *value, [](int int_value) {
-          ::media::SetVideoBufferSizeClamp(int_value);
+          ::media::SetVideoBufferSizeReductionPercent(int_value);
           return true;
         });
   }


### PR DESCRIPTION
This PR replaces `Media.VideoBufferSizeClampMb` and replaces it with
a percentage-based reduction mechanism. This change allows for more
general changes to all returned values of the buffer size, instead of just
clamping down on the larget value. `Media.VideoBufferSizeClampMb`
only really affected the highest playback resolutions (e.x. 4k playback).
With this change, we can evenly test reducing the clamp size across different
video resolutions.

This PR:
- Replaced `Media.VideoBufferSizeClampMb` with `Media.VideoBufferSizeReductionPercent`
- Updated the code in `demuxer_memory_limit_starboard.cc` to use this new flag instead of  `Media.VideoBufferSizeClampMb`
- Remove all other traces of  `Media.VideoBufferSizeClampMb`

Bug: 416105795