### PR TITLE
Add noise audit to memory verification

### DIFF
--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -362,12 +362,13 @@ test("cobalt_unittests") {
     "//cobalt/shell/browser/picture_in_picture/picture_in_picture_window_manager_unittest.cc",
   ]
 
-  # The symbolizer pipeline test requires launching external Python and
-  # llvm-symbolizer processes, which is not supported on Starboard and
-  # modular/Evergreen platforms due to subprocess spawning restrictions.
+  # Memory instrumentation host-side tool tests require launching external
+  # Python processes, which is not supported on Starboard and modular/Evergreen
+  # platforms due to subprocess spawning restrictions.
   if (!is_starboard && !sb_is_modular) {
     sources += [
       "//cobalt/tools/performance/memory/symbolize_in_process_heap_unittest.cc",
+      "//cobalt/tools/performance/memory/verify_memory_trace_unittest.cc",
     ]
   }
 

--- a/cobalt/tools/performance/memory/verify_memory_trace.py
+++ b/cobalt/tools/performance/memory/verify_memory_trace.py
@@ -74,6 +74,28 @@ def parse_trace_file(trace_path: str) -> Optional[List[Dict[str, Any]]]:
   return events
 
 
+# Categories that are expected in a pure memory trace.
+_ALLOWED_CATEGORIES = {
+    "disabled-by-default-memory-infra",
+    "__metadata",
+}
+
+
+def _parse_bytes_to_mb(val: Any) -> Optional[float]:
+  """Safely parses hex string or numeric bytes to Megabytes (MB)."""
+  if val is None or isinstance(val, bool):
+    return None
+  try:
+    if isinstance(val, (int, float)):
+      return float(val) / (1024 * 1024)
+    if isinstance(val, str):
+      # Chromium trace JSON formats byte values as hex strings.
+      return float(int(val, 16)) / (1024 * 1024)
+  except (ValueError, TypeError):
+    pass
+  return None
+
+
 def analyze_memory_events(events: List[Dict[str, Any]]) -> Dict[str, Any]:
   """Analyzes trace events to gather memory diagnostic metrics.
 
@@ -87,12 +109,27 @@ def analyze_memory_events(events: List[Dict[str, Any]]) -> Dict[str, Any]:
       "memory_dumps_count": 0,
       "has_heaps_v2": False,
       "has_process_mmaps": False,
-      "has_smaps": False,
+      "has_process_totals": False,
+      "latest_private_footprint_mb": None,
+      "latest_peak_rss_mb": None,
+      "has_redundant_data": False,
+      "noise_categories": set(),
   }
 
   for event in events:
     if not isinstance(event, dict):
       continue
+
+    # 1. Check for redundant CPU / timeline categories
+    cat = event.get("cat")
+    if cat and isinstance(cat, str):
+      for c in cat.split(","):
+        c_stripped = c.strip()
+        if c_stripped and c_stripped not in _ALLOWED_CATEGORIES:
+          metrics["has_redundant_data"] = True
+          metrics["noise_categories"].add(c_stripped)
+
+    # 2. Check for memory snapshot dumps
     if event.get("name") == "periodic_interval":
       metrics["memory_dumps_count"] += 1
       args = event.get("args")
@@ -113,8 +150,16 @@ def analyze_memory_events(events: List[Dict[str, Any]]) -> Dict[str, Any]:
           metrics["has_heaps_v2"] = True
         if "process_mmaps" in dumps_dict:
           metrics["has_process_mmaps"] = True
-        if "smaps" in dumps_dict:
-          metrics["has_smaps"] = True
+        if "process_totals" in dumps_dict:
+          metrics["has_process_totals"] = True
+          pt = dumps_dict["process_totals"]
+          if isinstance(pt, dict):
+            priv = _parse_bytes_to_mb(pt.get("private_footprint_bytes"))
+            rss = _parse_bytes_to_mb(pt.get("peak_resident_set_size"))
+            if priv is not None:
+              metrics["latest_private_footprint_mb"] = priv
+            if rss is not None:
+              metrics["latest_peak_rss_mb"] = rss
 
   return metrics
 
@@ -147,13 +192,25 @@ def print_scorecard(metrics: Dict[str, Any]) -> None:
         "  • VM Map (process_mmaps):  🔴 MISSING (No memory mapping lists found)"
     )
 
-  if metrics["has_smaps"]:
-    logger.info(
-        "  • PSS Categories (smaps):  🟢 PRESENT (Memory categories mapped)")
+  if metrics["has_process_totals"]:
+    priv = metrics["latest_private_footprint_mb"]
+    rss = metrics["latest_peak_rss_mb"]
+    details = []
+    if priv is not None:
+      details.append(f"Private: {priv:.1f} MB")
+    if rss is not None:
+      details.append(f"Peak RSS: {rss:.1f} MB")
+    detail_str = " (" + ", ".join(details) + ")" if details else ""
+    logger.info("  • OS Memory Totals:        🟢 PRESENT%s", detail_str)
   else:
-    logger.info(
-        "  • PSS Categories (smaps):  ⚪ NOT PRESENT (Categorized memory absent)"
-    )
+    logger.info("  • OS Memory Totals:        ⚪ NOT PRESENT")
+
+  if not metrics["has_redundant_data"]:
+    logger.info("  • Trace Redundancy:        🟢 CLEAN (No CPU timeline noise)")
+  else:
+    noise_str = ", ".join(sorted(metrics["noise_categories"]))
+    logger.info("  • Trace Redundancy:        🔴 NOISY (%s)", noise_str)
+
   logger.info("-" * 40)
 
 
@@ -162,13 +219,24 @@ def print_verdict(metrics: Dict[str, Any]) -> bool:
   dumps_count = metrics["memory_dumps_count"]
   has_heaps_v2 = metrics["has_heaps_v2"]
   has_process_mmaps = metrics["has_process_mmaps"]
+  has_redundant_data = metrics["has_redundant_data"]
 
   if dumps_count > 0 and has_heaps_v2 and has_process_mmaps:
-    logger.info("\n🎉 SUCCESS: The trace is valid and fully profileable!")
+    if not has_redundant_data:
+      logger.info("\n🎉 [SIGNAL: PROCEED] Trace is valid and clean! Ready for "
+                  "symbolization.")
+    else:
+      logger.info(
+          "\n⚠️ [SIGNAL: PROCEED_WITH_WARNING] Trace is valid but contains "
+          "redundant CPU events.")
+      logger.info("   - Tip: Pass "
+                  "--trace-startup=\"-*,disabled-by-default-memory-infra\" "
+                  "to shrink trace size by 10x-30x.")
     logger.info("=" * 60)
     return True
 
-  logger.info("\n❌ VERDICT: The trace is INCOMPLETE or INVALID for profiling!")
+  logger.info(
+      "\n❌ [SIGNAL: ABORT] Trace is INCOMPLETE or INVALID for profiling!")
   reasons = []
   if dumps_count == 0:
     reasons.append(

--- a/cobalt/tools/performance/memory/verify_memory_trace_unittest.cc
+++ b/cobalt/tools/performance/memory/verify_memory_trace_unittest.cc
@@ -1,0 +1,199 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "build/build_config.h"
+
+#if (BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_MAC)) && !BUILDFLAG(IS_STARBOARD)
+
+#include "base/command_line.h"
+#include "base/files/file_path.h"
+#include "base/files/file_util.h"
+#include "base/files/scoped_temp_dir.h"
+#include "base/path_service.h"
+#include "base/process/launch.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace cobalt {
+namespace {
+
+base::FilePath GetMemoryToolsDir() {
+  base::FilePath source_root;
+  EXPECT_TRUE(
+      base::PathService::Get(base::DIR_SRC_TEST_DATA_ROOT, &source_root));
+  return source_root.AppendASCII("cobalt")
+      .AppendASCII("tools")
+      .AppendASCII("performance")
+      .AppendASCII("memory");
+}
+
+TEST(VerifyMemoryTraceTest, RunPythonUnitTestSuite) {
+  base::FilePath script_path =
+      GetMemoryToolsDir().AppendASCII("verify_memory_trace_unittest.py");
+
+  base::CommandLine cmd(base::FilePath(FILE_PATH_LITERAL("python3")));
+  cmd.AppendArgPath(script_path);
+
+  std::string output;
+  int exit_code = -1;
+  bool success = base::GetAppOutputWithExitCode(cmd, &output, &exit_code);
+
+  EXPECT_TRUE(success) << "Failed to run verify_memory_trace_unittest.py.";
+  EXPECT_EQ(0, exit_code)
+      << "verify_memory_trace_unittest.py failed with output:\n"
+      << output;
+}
+
+TEST(VerifyMemoryTraceTest, CleanTraceProceeds) {
+  base::ScopedTempDir temp_dir;
+  ASSERT_TRUE(temp_dir.CreateUniqueTempDir());
+
+  base::FilePath trace_path =
+      temp_dir.GetPath().AppendASCII("clean_trace.json");
+  std::string trace_content = R"({
+    "traceEvents": [
+      {
+        "cat": "__metadata",
+        "name": "process_name",
+        "args": {"name": "Cobalt"}
+      },
+      {
+        "cat": "disabled-by-default-memory-infra",
+        "name": "periodic_interval",
+        "args": {
+          "dumps": {
+            "heaps_v2": {"allocators": {"malloc": {}}},
+            "process_mmaps": {"vm_regions": []},
+            "process_totals": {
+              "private_footprint_bytes": "5025000",
+              "peak_resident_set_size": "a5b6000"
+            }
+          }
+        }
+      }
+    ]
+  })";
+  ASSERT_TRUE(base::WriteFile(trace_path, trace_content));
+
+  base::FilePath script_path =
+      GetMemoryToolsDir().AppendASCII("verify_memory_trace.py");
+
+  base::CommandLine cmd(base::FilePath(FILE_PATH_LITERAL("python3")));
+  cmd.AppendArgPath(script_path);
+  cmd.AppendArgPath(trace_path);
+
+  std::string output;
+  int exit_code = -1;
+  bool success = base::GetAppOutputWithExitCode(cmd, &output, &exit_code);
+
+  EXPECT_TRUE(success) << "Failed to run verify_memory_trace.py.";
+  EXPECT_EQ(0, exit_code) << "Script failed with output:\n" << output;
+  EXPECT_NE(output.find("[SIGNAL: PROCEED]"), std::string::npos)
+      << "Expected [SIGNAL: PROCEED] in output:\n"
+      << output;
+  EXPECT_NE(output.find("Private: 80.1 MB"), std::string::npos)
+      << "Expected parsed Private Footprint in scorecard:\n"
+      << output;
+}
+
+TEST(VerifyMemoryTraceTest, NoisyTraceWarns) {
+  base::ScopedTempDir temp_dir;
+  ASSERT_TRUE(temp_dir.CreateUniqueTempDir());
+
+  base::FilePath trace_path =
+      temp_dir.GetPath().AppendASCII("noisy_trace.json");
+  std::string trace_content = R"({
+    "traceEvents": [
+      {
+        "cat": "toplevel,blink",
+        "name": "TaskQueue::RunTask"
+      },
+      {
+        "cat": "disabled-by-default-memory-infra",
+        "name": "periodic_interval",
+        "args": {
+          "dumps": {
+            "heaps_v2": {"allocators": {}},
+            "process_mmaps": {"vm_regions": []}
+          }
+        }
+      }
+    ]
+  })";
+  ASSERT_TRUE(base::WriteFile(trace_path, trace_content));
+
+  base::FilePath script_path =
+      GetMemoryToolsDir().AppendASCII("verify_memory_trace.py");
+
+  base::CommandLine cmd(base::FilePath(FILE_PATH_LITERAL("python3")));
+  cmd.AppendArgPath(script_path);
+  cmd.AppendArgPath(trace_path);
+
+  std::string output;
+  int exit_code = -1;
+  bool success = base::GetAppOutputWithExitCode(cmd, &output, &exit_code);
+
+  EXPECT_TRUE(success) << "Failed to run verify_memory_trace.py.";
+  EXPECT_EQ(0, exit_code) << "Script failed with output:\n" << output;
+  EXPECT_NE(output.find("[SIGNAL: PROCEED_WITH_WARNING]"), std::string::npos)
+      << "Expected [SIGNAL: PROCEED_WITH_WARNING] in output:\n"
+      << output;
+  EXPECT_NE(output.find("🔴 NOISY (blink, toplevel)"), std::string::npos)
+      << "Expected noise categories in scorecard:\n"
+      << output;
+}
+
+TEST(VerifyMemoryTraceTest, IncompleteTraceAborts) {
+  base::ScopedTempDir temp_dir;
+  ASSERT_TRUE(temp_dir.CreateUniqueTempDir());
+
+  base::FilePath trace_path =
+      temp_dir.GetPath().AppendASCII("incomplete_trace.json");
+  std::string trace_content = R"({
+    "traceEvents": [
+      {
+        "cat": "disabled-by-default-memory-infra",
+        "name": "periodic_interval",
+        "args": {
+          "dumps": {
+            "process_mmaps": {"vm_regions": []}
+          }
+        }
+      }
+    ]
+  })";
+  ASSERT_TRUE(base::WriteFile(trace_path, trace_content));
+
+  base::FilePath script_path =
+      GetMemoryToolsDir().AppendASCII("verify_memory_trace.py");
+
+  base::CommandLine cmd(base::FilePath(FILE_PATH_LITERAL("python3")));
+  cmd.AppendArgPath(script_path);
+  cmd.AppendArgPath(trace_path);
+
+  std::string output;
+  int exit_code = -1;
+  bool success = base::GetAppOutputWithExitCode(cmd, &output, &exit_code);
+
+  EXPECT_TRUE(success) << "Failed to run verify_memory_trace.py.";
+  EXPECT_EQ(1, exit_code) << "Expected exit code 1 for incomplete trace.";
+  EXPECT_NE(output.find("[SIGNAL: ABORT]"), std::string::npos)
+      << "Expected [SIGNAL: ABORT] in output:\n"
+      << output;
+}
+
+}  // namespace
+}  // namespace cobalt
+
+#endif  // (BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_MAC)) &&
+        // !BUILDFLAG(IS_STARBOARD)

--- a/cobalt/tools/performance/memory/verify_memory_trace_unittest.py
+++ b/cobalt/tools/performance/memory/verify_memory_trace_unittest.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Cobalt Authors. All Rights Reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+"""Unit tests for verify_memory_trace.py."""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+script_dir = os.path.dirname(os.path.realpath(__file__))
+if script_dir not in sys.path:
+  sys.path.insert(0, script_dir)
+
+# pylint: disable=wrong-import-position
+import verify_memory_trace
+
+
+class VerifyMemoryTraceTest(unittest.TestCase):
+  """Test suite for memory trace verification and noise detection."""
+
+  def setUp(self):
+    # pylint: disable=consider-using-with
+    self.temp_dir = tempfile.TemporaryDirectory()
+
+  def tearDown(self):
+    self.temp_dir.cleanup()
+
+  def test_clean_memory_trace(self):
+    """Verifies that a pure memory trace triggers the PROCEED signal."""
+    clean_events = [
+        {
+            "cat": "__metadata",
+            "name": "process_name",
+            "args": {
+                "name": "Cobalt"
+            }
+        },
+        {
+            "cat": "disabled-by-default-memory-infra",
+            "name": "periodic_interval",
+            "args": {
+                "dumps": {
+                    "heaps_v2": {
+                        "allocators": {
+                            "malloc": {}
+                        }
+                    },
+                    "process_mmaps": {
+                        "vm_regions": []
+                    },
+                }
+            },
+        },
+    ]
+    metrics = verify_memory_trace.analyze_memory_events(clean_events)
+    self.assertEqual(metrics["memory_dumps_count"], 1)
+    self.assertTrue(metrics["has_heaps_v2"])
+    self.assertTrue(metrics["has_process_mmaps"])
+    self.assertFalse(metrics["has_redundant_data"])
+    self.assertEqual(metrics["noise_categories"], set())
+    self.assertTrue(verify_memory_trace.print_verdict(metrics))
+
+  def test_clean_memory_trace_with_process_totals(self):
+    """Verifies parsing of process_totals (Private Footprint and Peak RSS)."""
+    events = [{
+        "cat": "disabled-by-default-memory-infra",
+        "name": "periodic_interval",
+        "args": {
+            "dumps": {
+                "heaps_v2": {},
+                "process_mmaps": {},
+                "process_totals": {
+                    "private_footprint_bytes": "5025000",
+                    "peak_resident_set_size": "a5b6000",
+                    "is_peak_rss_resettable": True,
+                },
+            }
+        },
+    }]
+    metrics = verify_memory_trace.analyze_memory_events(events)
+    self.assertTrue(metrics["has_process_totals"])
+    self.assertAlmostEqual(
+        metrics["latest_private_footprint_mb"], 80.14, places=1)
+    self.assertAlmostEqual(metrics["latest_peak_rss_mb"], 165.71, places=1)
+
+  def test_parse_bytes_to_mb(self):
+    """Verifies byte parsing logic and type guards."""
+    # pylint: disable=protected-access
+    self.assertIsNone(verify_memory_trace._parse_bytes_to_mb(None))
+    self.assertIsNone(verify_memory_trace._parse_bytes_to_mb(True))
+    self.assertIsNone(verify_memory_trace._parse_bytes_to_mb(False))
+    self.assertIsNone(verify_memory_trace._parse_bytes_to_mb("invalid_hex"))
+    self.assertAlmostEqual(
+        verify_memory_trace._parse_bytes_to_mb(1048576), 1.0, places=4)
+    self.assertAlmostEqual(
+        verify_memory_trace._parse_bytes_to_mb("100000"), 1.0, places=4)
+
+  def test_noisy_memory_trace(self):
+    """Verifies that CPU categories trigger PROCEED_WITH_WARNING."""
+    noisy_events = [
+        {
+            "cat": "__metadata",
+            "name": "process_name"
+        },
+        {
+            "cat": "toplevel,blink",
+            "name": "TaskQueue::RunTask"
+        },
+        {
+            "cat": "netlog",
+            "name": "URLRequest"
+        },
+        {
+            "cat": "disabled-by-default-memory-infra",
+            "name": "periodic_interval",
+            "args": {
+                "dumps": {
+                    "heaps_v2": {
+                        "allocators": {
+                            "malloc": {}
+                        }
+                    },
+                    "process_mmaps": {
+                        "vm_regions": []
+                    },
+                }
+            },
+        },
+    ]
+    metrics = verify_memory_trace.analyze_memory_events(noisy_events)
+    self.assertEqual(metrics["memory_dumps_count"], 1)
+    self.assertTrue(metrics["has_heaps_v2"])
+    self.assertTrue(metrics["has_process_mmaps"])
+    self.assertTrue(metrics["has_redundant_data"])
+    self.assertEqual(metrics["noise_categories"],
+                     {"toplevel", "blink", "netlog"})
+    # Should still return True (profileable), but flagged as noisy
+    self.assertTrue(verify_memory_trace.print_verdict(metrics))
+
+  def test_incomplete_trace_missing_heaps(self):
+    """Verifies that missing heaps_v2 triggers ABORT."""
+    incomplete_events = [{
+        "cat": "disabled-by-default-memory-infra",
+        "name": "periodic_interval",
+        "args": {
+            "dumps": {
+                "process_mmaps": {
+                    "vm_regions": []
+                }
+            }
+        },
+    }]
+    metrics = verify_memory_trace.analyze_memory_events(incomplete_events)
+    self.assertFalse(metrics["has_heaps_v2"])
+    self.assertFalse(verify_memory_trace.print_verdict(metrics))
+
+  def test_incomplete_trace_missing_mmaps(self):
+    """Verifies that missing process_mmaps triggers ABORT."""
+    incomplete_events = [{
+        "cat": "disabled-by-default-memory-infra",
+        "name": "periodic_interval",
+        "args": {
+            "dumps": {
+                "heaps_v2": {
+                    "allocators": {}
+                }
+            }
+        },
+    }]
+    metrics = verify_memory_trace.analyze_memory_events(incomplete_events)
+    self.assertFalse(metrics["has_process_mmaps"])
+    self.assertFalse(verify_memory_trace.print_verdict(metrics))
+
+  def test_parse_valid_json_file(self):
+    """Tests parsing a standard trace file."""
+    trace_path = os.path.join(self.temp_dir.name, "trace.json")
+    trace_content = {
+        "traceEvents": [{
+            "cat": "__metadata",
+            "name": "process_name"
+        }, {
+            "cat": "disabled-by-default-memory-infra",
+            "name": "periodic_interval",
+            "args": {
+                "dumps": {
+                    "heaps_v2": {},
+                    "process_mmaps": {}
+                }
+            }
+        }]
+    }
+    with open(trace_path, "w", encoding="utf-8") as f:
+      json.dump(trace_content, f)
+
+    events = verify_memory_trace.parse_trace_file(trace_path)
+    self.assertIsNotNone(events)
+    self.assertEqual(len(events), 2)
+    self.assertTrue(verify_memory_trace.verify_trace(trace_path))
+
+  def test_parse_missing_file(self):
+    """Tests parsing a non-existent file."""
+    non_existent = os.path.join(self.temp_dir.name, "missing.json")
+    self.assertIsNone(verify_memory_trace.parse_trace_file(non_existent))
+    self.assertFalse(verify_memory_trace.verify_trace(non_existent))
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
Update the trace verification tool to detect redundant CPU and
timeline categories that significantly increase trace size without
adding value to memory analysis. The script now extracts OS memory
metrics like Private Footprint and Peak RSS to provide better
diagnostic context.

These changes introduce explicit signal levels to guide the
symbolization pipeline and include comprehensive unit tests to
validate the analysis logic.

Test: https://paste.googleplex.com/5766223307603968
Bug: 528369392