### PR TITLE
fix(shell): ensure views widget and host are shown on startup

### DIFF
--- a/cobalt/shell/browser/shell_platform_delegate_views.cc
+++ b/cobalt/shell/browser/shell_platform_delegate_views.cc
@@ -465,8 +465,13 @@ void ShellPlatformDelegate::DidCreateOrAttachWebContents(
   ShellData& shell_data = it->second;
   if (shell_data.window_widget) {
     // Safely map native views window Show and Restore on initial startup!
+    if (shell_data.window_widget->GetNativeWindow() &&
+        shell_data.window_widget->GetNativeWindow()->GetHost()) {
+      shell_data.window_widget->GetNativeWindow()->GetHost()->Show();
+    }
     shell_data.window_widget->GetNativeWindow()->Show();
     shell_data.window_widget->Restore();
+    shell_data.window_widget->Show();
   }
 }
 void ShellPlatformDelegate::RevealShell(Shell* shell) {
@@ -507,8 +512,12 @@ void ShellPlatformDelegate::MapWindowShell(Shell* shell) {
       native_window->GetHost()->compositor()->SetVisible(true);
     }
     if (native_window) {
+      if (native_window->GetHost()) {
+        native_window->GetHost()->Show();
+      }
       native_window->Show();
       shell_data.window_widget->Restore();
+      shell_data.window_widget->Show();
       shell_data.window_widget->LayoutRootViewIfNecessary();
     }
   }


### PR DESCRIPTION
When the splash screen is disabled (e.g. via `--disable-splash-screen`), `LoadSplashScreenContents()` is bypassed, which previously was the only place calling `GetHost()->Show()` and `widget->Show()` on the `views::Widget` and its `WindowTreeHost`.

As a result, the `views::Widget` remained in an un-shown/inactive state, preventing native remote control key events received from Starboard/Ozone from being dispatched to the `WebView` and `RenderWidgetHostView`.

This change ensures that `DidCreateOrAttachWebContents()` and `MapWindowShell()` explicitly call `GetHost()->Show()` and `widget->Show()` when mapping windows.

Bug: 542226450