### PR TITLE
feat(tvos): conditionally re-sign unit test app for physical device builds

### DIFF
--- a/cobalt/devinfra/kokoro/bin/presubmit_build_mac.sh
+++ b/cobalt/devinfra/kokoro/bin/presubmit_build_mac.sh
@@ -134,31 +134,30 @@ EOF
       # --------------------------------------------------------------------------
       # Embed Provisioning Profile & Re-sign App (Internal Kokoro Device Builds Only)
       # --------------------------------------------------------------------------
-      local tvos_profile="${KOKORO_PIPER_DIR:-}/google3/googlemac/iPhone/Shared/ProvisioningProfiles/Google_Development_tvOS.mobileprovision"
+      if [[ -n "${KOKORO_PIPER_DIR:-}" ]]; then
+        local tvos_profile="${KOKORO_PIPER_DIR}/google3/googlemac/iPhone/Shared/ProvisioningProfiles/Google_Development_tvOS.mobileprovision"
+        if [[ -f "${tvos_profile}" ]]; then
+          echo "Embedding ${tvos_profile} into ${target_name}.app..."
+          cp -f "${tvos_profile}" "${out_dir}/${target_name}.app/embedded.mobileprovision"
 
-      if [[ -n "${KOKORO_PIPER_DIR:-}" ]] && [[ -f "${tvos_profile}" ]]; then
-        echo "Embedding ${tvos_profile} into ${target_name}.app..."
-        cp -f "${tvos_profile}" "${out_dir}/${target_name}.app/embedded.mobileprovision"
-
-        # Extract entitlements from the provisioning profile
-        local profile_plist="${out_dir}/${target_name}_profile.plist"
-        local entitlements_plist="${out_dir}/${target_name}_entitlements.plist"
-        if security cms -D -i "${tvos_profile}" > "${profile_plist}" 2>/dev/null; then
-          if ! plutil -extract Entitlements xml1 -o "${entitlements_plist}" "${profile_plist}" 2>/dev/null; then
+          # Extract entitlements from the provisioning profile
+          local entitlements_plist="${out_dir}/${target_name}_entitlements.plist"
+          if ! security cms -D -i "${tvos_profile}" 2>/dev/null | plutil -extract Entitlements xml1 -o "${entitlements_plist}" - 2>/dev/null; then
             rm -f "${entitlements_plist}"
           fi
-        fi
-        rm -f "${profile_plist}"
 
-        # Re-sign app bundle using Kokoro's installed development certificate
-        echo "Signing ${target_name}.app for physical lab devices..."
-        if [[ -f "${entitlements_plist}" ]]; then
-          codesign --force --deep --sign "Apple Development" --entitlements "${entitlements_plist}" "${out_dir}/${target_name}.app" || \
-          codesign --force --deep --sign "iPhone Developer" --entitlements "${entitlements_plist}" "${out_dir}/${target_name}.app"
-          rm -f "${entitlements_plist}"
+          # Re-sign app bundle using Kokoro's installed development certificate
+          echo "Signing ${target_name}.app for physical lab devices..."
+          if [[ -f "${entitlements_plist}" ]]; then
+            codesign --force --deep --sign "Apple Development" --entitlements "${entitlements_plist}" "${out_dir}/${target_name}.app" || \
+            codesign --force --deep --sign "iPhone Developer" --entitlements "${entitlements_plist}" "${out_dir}/${target_name}.app"
+            rm -f "${entitlements_plist}"
+          else
+            codesign --force --deep --sign "Apple Development" "${out_dir}/${target_name}.app" || \
+            codesign --force --deep --sign "iPhone Developer" "${out_dir}/${target_name}.app"
+          fi
         else
-          codesign --force --deep --sign "Apple Development" "${out_dir}/${target_name}.app" || \
-          codesign --force --deep --sign "iPhone Developer" "${out_dir}/${target_name}.app"
+          echo "KOKORO_PIPER_DIR is present, but provisioning profile not found at ${tvos_profile}. Skipping re-signing."
         fi
       else
         echo "Not running in internal Kokoro (KOKORO_PIPER_DIR absent). Skipping re-signing for simulator build."

--- a/cobalt/devinfra/kokoro/bin/presubmit_build_mac.sh
+++ b/cobalt/devinfra/kokoro/bin/presubmit_build_mac.sh
@@ -16,7 +16,8 @@ cd "${WORKSPACE_COBALT}"
 # Clean up workspace on exit or error.
 trap "bash ${WORKSPACE_COBALT}/cobalt/devinfra/kokoro/bin/cleanup.sh" EXIT INT TERM
 
-
+# TODO(b/538697105): Unify build_mac.sh and presubmit_build_mac.sh, and consolidate
+# tvOS app code-signing logic into the unified CI build script.
 resign_tvos_app_if_needed () {
   local target_name="$1"
   local out_dir="$2"

--- a/cobalt/devinfra/kokoro/bin/presubmit_build_mac.sh
+++ b/cobalt/devinfra/kokoro/bin/presubmit_build_mac.sh
@@ -130,6 +130,41 @@ EOF
 
     elif [[ " ${json_targets} " == *" ${target_name} "* ]] && [[ -d "${out_dir}/${target_name}.app" ]]; then
       echo "Archiving and uploading test package ${target_name}.app..."
+
+      # --------------------------------------------------------------------------
+      # Embed Provisioning Profile & Re-sign App (Internal Kokoro Device Builds Only)
+      # --------------------------------------------------------------------------
+      local tvos_profile="${KOKORO_PIPER_DIR:-}/google3/googlemac/iPhone/Shared/ProvisioningProfiles/Google_Development_tvOS.mobileprovision"
+
+      if [[ -n "${KOKORO_PIPER_DIR:-}" ]] && [[ -f "${tvos_profile}" ]]; then
+        echo "Embedding ${tvos_profile} into ${target_name}.app..."
+        cp -f "${tvos_profile}" "${out_dir}/${target_name}.app/embedded.mobileprovision"
+
+        # Extract entitlements from the provisioning profile
+        local profile_plist="${out_dir}/${target_name}_profile.plist"
+        local entitlements_plist="${out_dir}/${target_name}_entitlements.plist"
+        if security cms -D -i "${tvos_profile}" > "${profile_plist}" 2>/dev/null; then
+          if ! plutil -extract Entitlements xml1 -o "${entitlements_plist}" "${profile_plist}" 2>/dev/null; then
+            rm -f "${entitlements_plist}"
+          fi
+        fi
+        rm -f "${profile_plist}"
+
+        # Re-sign app bundle using Kokoro's installed development certificate
+        echo "Signing ${target_name}.app for physical lab devices..."
+        if [[ -f "${entitlements_plist}" ]]; then
+          codesign --force --deep --sign "Apple Development" --entitlements "${entitlements_plist}" "${out_dir}/${target_name}.app" || \
+          codesign --force --deep --sign "iPhone Developer" --entitlements "${entitlements_plist}" "${out_dir}/${target_name}.app"
+          rm -f "${entitlements_plist}"
+        else
+          codesign --force --deep --sign "Apple Development" "${out_dir}/${target_name}.app" || \
+          codesign --force --deep --sign "iPhone Developer" "${out_dir}/${target_name}.app"
+        fi
+      else
+        echo "Not running in internal Kokoro (KOKORO_PIPER_DIR absent). Skipping re-signing for simulator build."
+      fi
+      # --------------------------------------------------------------------------
+
       local archive_file="${WORKSPACE_COBALT}/package/${target_name}.tar.gz"
       mkdir -p "${WORKSPACE_COBALT}/package"
 

--- a/cobalt/devinfra/kokoro/bin/presubmit_build_mac.sh
+++ b/cobalt/devinfra/kokoro/bin/presubmit_build_mac.sh
@@ -17,6 +17,37 @@ cd "${WORKSPACE_COBALT}"
 trap "bash ${WORKSPACE_COBALT}/cobalt/devinfra/kokoro/bin/cleanup.sh" EXIT INT TERM
 
 
+resign_tvos_app_if_needed () {
+  local target_name="$1"
+  local out_dir="$2"
+
+  if [[ -z "${KOKORO_PIPER_DIR:-}" ]]; then
+    echo "Not running in internal Kokoro (KOKORO_PIPER_DIR absent). Skipping re-signing for simulator build."
+    return 0
+  fi
+
+  local tvos_profile="${KOKORO_PIPER_DIR}/google3/googlemac/iPhone/Shared/ProvisioningProfiles/YouTube/YouTube_Dev_tvOS.mobileprovision"
+  if [[ ! -f "${tvos_profile}" ]]; then
+    echo "ERROR: Provisioning profile not found at ${tvos_profile}" >&2
+    exit 1
+  fi
+
+  echo "Embedding ${tvos_profile} into ${target_name}.app..."
+  cp -f "${tvos_profile}" "${out_dir}/${target_name}.app/embedded.mobileprovision"
+
+  # Extract entitlements from the provisioning profile
+  local entitlements_plist="${out_dir}/${target_name}_entitlements.plist"
+  if ! security cms -D -i "${tvos_profile}" 2>/dev/null | plutil -extract Entitlements xml1 -o "${entitlements_plist}" - 2>/dev/null; then
+    echo "ERROR: Failed to extract entitlements from ${tvos_profile}" >&2
+    exit 1
+  fi
+
+  # Re-sign app bundle using Kokoro's installed development certificate
+  echo "Signing ${target_name}.app for physical lab devices..."
+  codesign --force --deep --sign "Apple Development" --entitlements "${entitlements_plist}" "${out_dir}/${target_name}.app"
+  rm -f "${entitlements_plist}"
+}
+
 # Mac build script.
 pipeline () {
   # Run common configuration steps.
@@ -131,42 +162,8 @@ EOF
     elif [[ " ${json_targets} " == *" ${target_name} "* ]] && [[ -d "${out_dir}/${target_name}.app" ]]; then
       echo "Archiving and uploading test package ${target_name}.app..."
 
-      # --------------------------------------------------------------------------
-      # Embed Provisioning Profile & Re-sign App (Internal Kokoro Device Builds Only)
-      # --------------------------------------------------------------------------
-      if [[ -n "${KOKORO_PIPER_DIR:-}" ]]; then
-        local tvos_profile="${KOKORO_PIPER_DIR}/google3/googlemac/iPhone/Shared/ProvisioningProfiles/YouTube/YouTube_Dev_tvOS.mobileprovision"
-        if [[ ! -f "${tvos_profile}" ]]; then
-          tvos_profile="${KOKORO_PIPER_DIR}/google3/googlemac/iPhone/Shared/ProvisioningProfiles/Google_Development_tvOS.mobileprovision"
-        fi
-
-        if [[ -f "${tvos_profile}" ]]; then
-          echo "Embedding ${tvos_profile} into ${target_name}.app..."
-          cp -f "${tvos_profile}" "${out_dir}/${target_name}.app/embedded.mobileprovision"
-
-          # Extract entitlements from the provisioning profile
-          local entitlements_plist="${out_dir}/${target_name}_entitlements.plist"
-          if ! security cms -D -i "${tvos_profile}" 2>/dev/null | plutil -extract Entitlements xml1 -o "${entitlements_plist}" - 2>/dev/null; then
-            rm -f "${entitlements_plist}"
-          fi
-
-          # Re-sign app bundle using Kokoro's installed development certificate
-          echo "Signing ${target_name}.app for physical lab devices..."
-          if [[ -f "${entitlements_plist}" ]]; then
-            codesign --force --deep --sign "Apple Development" --entitlements "${entitlements_plist}" "${out_dir}/${target_name}.app" || \
-            codesign --force --deep --sign "iPhone Developer" --entitlements "${entitlements_plist}" "${out_dir}/${target_name}.app"
-            rm -f "${entitlements_plist}"
-          else
-            codesign --force --deep --sign "Apple Development" "${out_dir}/${target_name}.app" || \
-            codesign --force --deep --sign "iPhone Developer" "${out_dir}/${target_name}.app"
-          fi
-        else
-          echo "KOKORO_PIPER_DIR is present, but provisioning profile not found at ${tvos_profile}. Skipping re-signing."
-        fi
-      else
-        echo "Not running in internal Kokoro (KOKORO_PIPER_DIR absent). Skipping re-signing for simulator build."
-      fi
-      # --------------------------------------------------------------------------
+      # Re-sign app for physical lab devices if running in internal Kokoro
+      resign_tvos_app_if_needed "${target_name}" "${out_dir}"
 
       local archive_file="${WORKSPACE_COBALT}/package/${target_name}.tar.gz"
       mkdir -p "${WORKSPACE_COBALT}/package"

--- a/cobalt/devinfra/kokoro/bin/presubmit_build_mac.sh
+++ b/cobalt/devinfra/kokoro/bin/presubmit_build_mac.sh
@@ -135,7 +135,11 @@ EOF
       # Embed Provisioning Profile & Re-sign App (Internal Kokoro Device Builds Only)
       # --------------------------------------------------------------------------
       if [[ -n "${KOKORO_PIPER_DIR:-}" ]]; then
-        local tvos_profile="${KOKORO_PIPER_DIR}/google3/googlemac/iPhone/Shared/ProvisioningProfiles/Google_Development_tvOS.mobileprovision"
+        local tvos_profile="${KOKORO_PIPER_DIR}/google3/googlemac/iPhone/Shared/ProvisioningProfiles/YouTube/YouTube_Dev_tvOS.mobileprovision"
+        if [[ ! -f "${tvos_profile}" ]]; then
+          tvos_profile="${KOKORO_PIPER_DIR}/google3/googlemac/iPhone/Shared/ProvisioningProfiles/Google_Development_tvOS.mobileprovision"
+        fi
+
         if [[ -f "${tvos_profile}" ]]; then
           echo "Embedding ${tvos_profile} into ${target_name}.app..."
           cp -f "${tvos_profile}" "${out_dir}/${target_name}.app/embedded.mobileprovision"


### PR DESCRIPTION
Re-applies tvOS unit test app signing for physical devices (b/538697105) with a check for `KOKORO_PIPER_DIR`.

### Key Changes
* Embeds `Google_Development_tvOS.mobileprovision` and re-signs `cobalt_unittests.app` **only when running inside internal Kokoro** (`KOKORO_PIPER_DIR` present).
* Safely skips signing on GitHub PR presubmit runners (simulator builds) where Piper profiles and Keychain certificates are absent, preventing presubmit pipeline breakage.

Bug: 538697105