### PR TITLE
cobalt: Add Finch fallbacks for HangWatcher

### DIFF
--- a/base/threading/hang_watcher.cc
+++ b/base/threading/hang_watcher.cc
@@ -63,17 +63,19 @@ std::atomic<LoggingLevel> g_main_thread_log_level{LoggingLevel::kNone};
 std::atomic<LoggingLevel> g_compositor_thread_log_level{LoggingLevel::kNone};
 
 #if BUILDFLAG(IS_COBALT)
-std::atomic<LoggingLevel> g_browser_process_renderer_thread_log_level{LoggingLevel::kNone};
+std::atomic<bool> g_hang_reporting_enabled{true};
 
 std::atomic<int64_t> g_hang_watch_time_us{
     WatchHangsInScope::kDefaultHangWatchTime.InMicroseconds()};
 std::atomic<int64_t> g_hang_watch_monitoring_period_us{
     base::Seconds(10).InMicroseconds()};
 
-std::atomic<bool> g_hang_reporting_enabled{true};
 std::atomic<bool> g_enable_long_hang_detection{false};
 std::atomic<bool> g_enable_long_hang_kill{false};
 std::atomic<int> g_long_hang_timeout_seconds{20};
+
+std::atomic<LoggingLevel> g_browser_process_renderer_thread_log_level{
+    LoggingLevel::kNone};
 
 static std::atomic<HangWatcher::Delegate*> g_hang_watcher_delegate{nullptr};
 #endif
@@ -341,11 +343,6 @@ constexpr const char* kThreadName = "HangWatcher";
 // HangWatcher.IsThreadHung need to be updated.
 constexpr auto kMonitoringPeriod = base::Seconds(10);
 
-#if BUILDFLAG(IS_COBALT)
-// The period after which continuous hang is considered and reported as "long"
-constexpr auto kDefaultLongHangTimeout = base::Seconds(20);
-#endif
-
 WatchHangsInScope::WatchHangsInScope(TimeDelta timeout) {
 #if BUILDFLAG(IS_COBALT)
   // Only override the timeout with the global configuration if the caller
@@ -457,7 +454,12 @@ WatchHangsInScope::~WatchHangsInScope() {
 }
 
 #if BUILDFLAG(IS_COBALT)
-// static
+LoggingLevel GetConfiguredLoggingLevel(HangWatcher::Delegate* delegate,
+                                       HangWatcher::ThreadType thread_type) {
+  return delegate->IsThreadDumpingEnabled(thread_type)
+             ? LoggingLevel::kUmaAndCrash
+             : LoggingLevel::kNone;
+}
 
 void HangWatcher::UpdateConfiguration() {
   auto* delegate = g_hang_watcher_delegate.load(std::memory_order_relaxed);
@@ -465,77 +467,44 @@ void HangWatcher::UpdateConfiguration() {
     return;
   }
 
-  if (auto configured_timeout = delegate->GetHangWatchTime()) {
-    g_hang_watch_time_us.store(configured_timeout->InMicroseconds(),
-                               std::memory_order_relaxed);
-  } else {
-    g_hang_watch_time_us.store(
-        WatchHangsInScope::kDefaultHangWatchTime.InMicroseconds(),
-        std::memory_order_relaxed);
-  }
-
-  if (auto configured_period = delegate->GetHangWatchMonitoringPeriod()) {
-    g_hang_watch_monitoring_period_us.store(configured_period->InMicroseconds(),
-                                            std::memory_order_relaxed);
-  } else {
-    g_hang_watch_monitoring_period_us.store(kMonitoringPeriod.InMicroseconds(),
-                                            std::memory_order_relaxed);
-  }
-
   g_hang_reporting_enabled.store(delegate->IsHangReportingEnabled(),
                                  std::memory_order_relaxed);
 
-  if (auto detection_enabled = delegate->IsLongHangDetectionEnabled()) {
-    g_enable_long_hang_detection.store(*detection_enabled,
-                                       std::memory_order_relaxed);
-  } else {
-    g_enable_long_hang_detection.store(false, std::memory_order_relaxed);
-  }
+  g_hang_watch_time_us.store(delegate->GetHangWatchTime().InMicroseconds(),
+                             std::memory_order_relaxed);
 
-  if (auto kill_enabled = delegate->IsLongHangKillEnabled()) {
-    g_enable_long_hang_kill.store(*kill_enabled, std::memory_order_relaxed);
-  } else {
-    g_enable_long_hang_kill.store(false, std::memory_order_relaxed);
-  }
-
-  if (auto configured_long_timeout = delegate->GetLongHangTimeout()) {
-    g_long_hang_timeout_seconds.store(
-        static_cast<int>(configured_long_timeout->InSeconds()),
-        std::memory_order_relaxed);
-  } else {
-    g_long_hang_timeout_seconds.store(kDefaultLongHangTimeout.InSeconds(),
-                                      std::memory_order_relaxed);
-  }
+  g_hang_watch_monitoring_period_us.store(
+      delegate->GetHangWatchMonitoringPeriod().InMicroseconds(),
+      std::memory_order_relaxed);
 
   // Update logging levels for thread scopes.
-  if (auto io_enabled = delegate->IsThreadDumpingEnabled(
-          HangWatcher::ThreadType::kIOThread)) {
-    LoggingLevel io_level =
-        *io_enabled ? LoggingLevel::kUmaAndCrash : LoggingLevel::kNone;
-    g_io_thread_log_level.store(io_level, std::memory_order_relaxed);
-  }
+  g_main_thread_log_level.store(
+      GetConfiguredLoggingLevel(delegate, HangWatcher::ThreadType::kMainThread),
+      std::memory_order_relaxed);
 
-  if (auto main_enabled = delegate->IsThreadDumpingEnabled(
-          HangWatcher::ThreadType::kMainThread)) {
-    LoggingLevel main_level =
-        *main_enabled ? LoggingLevel::kUmaAndCrash : LoggingLevel::kNone;
-    g_main_thread_log_level.store(main_level, std::memory_order_relaxed);
-  }
+  g_io_thread_log_level.store(
+      GetConfiguredLoggingLevel(delegate, HangWatcher::ThreadType::kIOThread),
+      std::memory_order_relaxed);
 
-  if (auto pool_enabled = delegate->IsThreadDumpingEnabled(
-          HangWatcher::ThreadType::kThreadPoolThread)) {
-    LoggingLevel pool_level =
-        *pool_enabled ? LoggingLevel::kUmaAndCrash : LoggingLevel::kNone;
-    g_threadpool_log_level.store(pool_level, std::memory_order_relaxed);
-  }
+  g_threadpool_log_level.store(
+      GetConfiguredLoggingLevel(delegate,
+                                HangWatcher::ThreadType::kThreadPoolThread),
+      std::memory_order_relaxed);
 
-  if (auto renderer_enabled = delegate->IsThreadDumpingEnabled(
-          HangWatcher::ThreadType::kRendererThread)) {
-    LoggingLevel renderer_level =
-        *renderer_enabled ? LoggingLevel::kUmaAndCrash : LoggingLevel::kNone;
-    g_browser_process_renderer_thread_log_level.store(
-        renderer_level, std::memory_order_relaxed);
-  }
+  g_browser_process_renderer_thread_log_level.store(
+      GetConfiguredLoggingLevel(delegate,
+                                HangWatcher::ThreadType::kRendererThread),
+      std::memory_order_relaxed);
+
+  g_enable_long_hang_detection.store(delegate->IsLongHangDetectionEnabled(),
+                                     std::memory_order_relaxed);
+
+  g_enable_long_hang_kill.store(delegate->IsLongHangKillEnabled(),
+                                std::memory_order_relaxed);
+
+  g_long_hang_timeout_seconds.store(
+      static_cast<int>(delegate->GetLongHangTimeout().InSeconds()),
+      std::memory_order_relaxed);
 }
 #endif
 
@@ -642,9 +611,17 @@ void HangWatcher::InitializeOnMainThread(ProcessType process_type,
 void HangWatcher::UninitializeOnMainThreadForTesting() {
 #if BUILDFLAG(IS_COBALT)
   g_hang_reporting_enabled.store(true, std::memory_order_relaxed);
+  g_hang_watch_time_us.store(
+      WatchHangsInScope::kDefaultHangWatchTime.InMicroseconds(),
+      std::memory_order_relaxed);
+  g_hang_watch_monitoring_period_us.store(kMonitoringPeriod.InMicroseconds(),
+                                          std::memory_order_relaxed);
   g_enable_long_hang_detection.store(false, std::memory_order_relaxed);
   g_enable_long_hang_kill.store(false, std::memory_order_relaxed);
   g_long_hang_timeout_seconds.store(20, std::memory_order_relaxed);
+
+  g_browser_process_renderer_thread_log_level.store(LoggingLevel::kNone,
+                                                    std::memory_order_relaxed);
 #endif
   g_use_hang_watcher.store(false, std::memory_order_relaxed);
   g_threadpool_log_level.store(LoggingLevel::kNone, std::memory_order_relaxed);
@@ -653,10 +630,6 @@ void HangWatcher::UninitializeOnMainThreadForTesting() {
   g_compositor_thread_log_level.store(LoggingLevel::kNone,
                                       std::memory_order_relaxed);
   g_shutting_down.store(false, std::memory_order_relaxed);
-#if BUILDFLAG(IS_COBALT)
-  g_browser_process_renderer_thread_log_level.store(LoggingLevel::kNone,
-                                                    std::memory_order_relaxed);
-#endif
 }
 
 // static

--- a/base/threading/hang_watcher.h
+++ b/base/threading/hang_watcher.h
@@ -149,24 +149,18 @@ class BASE_EXPORT HangWatcher : public DelegateSimpleThread::Delegate {
     // Returns true if hang reporting should be enabled
     // potentially overriding default settings.
     virtual bool IsHangReportingEnabled() = 0;
-    // Returns a custom timeout for hang watching, or std::nullopt to use
-    // default.
-    virtual std::optional<base::TimeDelta> GetHangWatchTime() = 0;
-    // Returns a custom monitoring period, or std::nullopt to use default.
-    virtual std::optional<base::TimeDelta> GetHangWatchMonitoringPeriod() = 0;
+    // Returns the timeout for hang watching.
+    virtual base::TimeDelta GetHangWatchTime() = 0;
+    // Returns the monitoring period.
+    virtual base::TimeDelta GetHangWatchMonitoringPeriod() = 0;
     // Returns whether crash dumps are enabled for a specific thread type.
-    // Returns std::nullopt if the embedder has no specific override.
-    virtual std::optional<bool> IsThreadDumpingEnabled(
-        ThreadType thread_type) = 0;
-    // Returns whether long hang detection is enabled. Returns std::nullopt
-    // if the embedder has no specific override.
-    virtual std::optional<bool> IsLongHangDetectionEnabled() = 0;
-    // Returns whether force kill is enabled on long hang. Returns std::nullopt
-    // if the embedder has no specific override.
-    virtual std::optional<bool> IsLongHangKillEnabled() = 0;
-    // Returns the threshold duration for a long hang. Returns std::nullopt
-    // if the embedder has no specific override.
-    virtual std::optional<base::TimeDelta> GetLongHangTimeout() = 0;
+    virtual bool IsThreadDumpingEnabled(ThreadType thread_type) = 0;
+    // Returns whether long hang detection is enabled.
+    virtual bool IsLongHangDetectionEnabled() = 0;
+    // Returns whether force kill is enabled on long hang.
+    virtual bool IsLongHangKillEnabled() = 0;
+    // Returns the threshold duration for a long hang.
+    virtual base::TimeDelta GetLongHangTimeout() = 0;
   };
 #endif
 

--- a/base/threading/hang_watcher_unittest.cc
+++ b/base/threading/hang_watcher_unittest.cc
@@ -1177,23 +1177,17 @@ TEST_F(WatchHangsInScopeBlockingTest, MAYBE_NewScopeDoesNotBlockDuringCapture) {
 class MockHangWatcherDelegate : public HangWatcher::Delegate {
  public:
   MOCK_METHOD(bool, IsHangReportingEnabled, (), (override));
-  MOCK_METHOD(void, RecordHangStarted, (const std::string&), (override));
-  MOCK_METHOD(void, RecordHangRecovered, (const std::string&), (override));
-  MOCK_METHOD(std::optional<base::TimeDelta>, GetHangWatchTime, (), (override));
-  MOCK_METHOD(std::optional<base::TimeDelta>,
-              GetHangWatchMonitoringPeriod,
-              (),
-              (override));
-  MOCK_METHOD(std::optional<bool>,
+  MOCK_METHOD(base::TimeDelta, GetHangWatchTime, (), (override));
+  MOCK_METHOD(base::TimeDelta, GetHangWatchMonitoringPeriod, (), (override));
+  MOCK_METHOD(bool,
               IsThreadDumpingEnabled,
               (base::HangWatcher::ThreadType),
               (override));
-  MOCK_METHOD(std::optional<bool>, IsLongHangDetectionEnabled, (), (override));
-  MOCK_METHOD(std::optional<bool>, IsLongHangKillEnabled, (), (override));
-  MOCK_METHOD(std::optional<base::TimeDelta>,
-              GetLongHangTimeout,
-              (),
-              (override));
+  MOCK_METHOD(bool, IsLongHangDetectionEnabled, (), (override));
+  MOCK_METHOD(bool, IsLongHangKillEnabled, (), (override));
+  MOCK_METHOD(base::TimeDelta, GetLongHangTimeout, (), (override));
+  MOCK_METHOD(void, RecordHangStarted, (const std::string&), (override));
+  MOCK_METHOD(void, RecordHangRecovered, (const std::string&), (override));
 };
 
 class HangWatcherCobaltTest : public testing::Test {
@@ -1234,17 +1228,17 @@ class HangWatcherCobaltTest : public testing::Test {
     EXPECT_CALL(mock_delegate, IsHangReportingEnabled())
         .WillRepeatedly(testing::Return(reporting_enabled));
     EXPECT_CALL(mock_delegate, GetHangWatchTime())
-        .WillRepeatedly(testing::Return(std::nullopt));
+        .WillRepeatedly(testing::Return(base::Seconds(10)));
     EXPECT_CALL(mock_delegate, GetHangWatchMonitoringPeriod())
         .WillRepeatedly(testing::Return(kVeryLongDelta));
     EXPECT_CALL(mock_delegate, IsThreadDumpingEnabled(testing::_))
-        .WillRepeatedly(testing::Return(std::nullopt));
+        .WillRepeatedly(testing::Return(true));
     EXPECT_CALL(mock_delegate, IsLongHangDetectionEnabled())
-        .WillRepeatedly(testing::Return(std::nullopt));
+        .WillRepeatedly(testing::Return(false));
     EXPECT_CALL(mock_delegate, IsLongHangKillEnabled())
-        .WillRepeatedly(testing::Return(std::nullopt));
+        .WillRepeatedly(testing::Return(false));
     EXPECT_CALL(mock_delegate, GetLongHangTimeout())
-        .WillRepeatedly(testing::Return(std::nullopt));
+        .WillRepeatedly(testing::Return(base::Seconds(20)));
   }
 
   void TriggerMonitorAndWait() {
@@ -1529,11 +1523,11 @@ TEST_F(HangWatcherCobaltTest, OverlappingHangsSingleUuid) {
   EXPECT_CALL(mock_delegate, IsHangReportingEnabled())
       .WillRepeatedly(testing::Return(true));
   EXPECT_CALL(mock_delegate, GetHangWatchTime())
-      .WillRepeatedly(testing::Return(std::nullopt));
+      .WillRepeatedly(testing::Return(base::Seconds(10)));
   EXPECT_CALL(mock_delegate, GetHangWatchMonitoringPeriod())
-      .WillRepeatedly(testing::Return(std::nullopt));
+      .WillRepeatedly(testing::Return(base::Seconds(10)));
   EXPECT_CALL(mock_delegate, IsThreadDumpingEnabled(testing::_))
-      .WillRepeatedly(testing::Return(std::nullopt));
+      .WillRepeatedly(testing::Return(true));
 
   // --- Thread B Recovers ---
   EXPECT_CALL(mock_delegate, RecordHangRecovered(captured_uuid)).Times(1);

--- a/cobalt/browser/features.cc
+++ b/cobalt/browser/features.cc
@@ -43,6 +43,39 @@ BASE_FEATURE(kHangReporting,
              "HangReporting",
              base::FEATURE_DISABLED_BY_DEFAULT);
 
+const base::FeatureParam<int> kHangWatchTimeSeconds{&kHangReporting,
+                                                    "HangWatchTimeSeconds", 10};
+
+const base::FeatureParam<int> kHangWatchMonitoringPeriodSeconds{
+    &kHangReporting, "HangWatchMonitoringPeriodSeconds", 10};
+
+BASE_FEATURE(kHangWatchMainThreadDump,
+             "HangWatchMainThreadDump",
+             base::FEATURE_DISABLED_BY_DEFAULT);
+
+BASE_FEATURE(kHangWatchIOThreadDump,
+             "HangWatchIOThreadDump",
+             base::FEATURE_DISABLED_BY_DEFAULT);
+
+BASE_FEATURE(kHangWatchThreadPoolDump,
+             "HangWatchThreadPoolDump",
+             base::FEATURE_DISABLED_BY_DEFAULT);
+
+BASE_FEATURE(kHangWatchRendererThreadDump,
+             "HangWatchRendererThreadDump",
+             base::FEATURE_ENABLED_BY_DEFAULT);
+
+BASE_FEATURE(kHangWatcherLongHangDetection,
+             "HangWatcherLongHangDetection",
+             base::FEATURE_DISABLED_BY_DEFAULT);
+
+BASE_FEATURE(kHangWatcherLongHangKill,
+             "HangWatcherLongHangKill",
+             base::FEATURE_DISABLED_BY_DEFAULT);
+
+const base::FeatureParam<int> kLongHangTimeoutSeconds{
+    &kHangWatcherLongHangDetection, "LongHangTimeoutSeconds", 20};
+
 BASE_FEATURE(kCobaltMetricsIntervalFeature,
              "CobaltMetricsInterval",
              base::FEATURE_DISABLED_BY_DEFAULT);

--- a/cobalt/browser/features.h
+++ b/cobalt/browser/features.h
@@ -43,6 +43,33 @@ extern const base::FeatureParam<std::string> kUserAgentFinchTokenParam;
 // Enables native hang reporting via Crashpad.
 extern const base::Feature kHangReporting;
 
+// Sets the timeout in seconds for hang watching.
+extern const base::FeatureParam<int> kHangWatchTimeSeconds;
+
+// Sets the monitoring period in seconds for hang watching.
+extern const base::FeatureParam<int> kHangWatchMonitoringPeriodSeconds;
+
+// Enables thread dump on hang for the main thread.
+extern const base::Feature kHangWatchMainThreadDump;
+
+// Enables thread dump on hang for the IO thread.
+extern const base::Feature kHangWatchIOThreadDump;
+
+// Enables thread dump on hang for the thread pool threads.
+extern const base::Feature kHangWatchThreadPoolDump;
+
+// Enables thread dump on hang for the renderer thread.
+extern const base::Feature kHangWatchRendererThreadDump;
+
+// Enables detecting severe hangs (long hangs) via UMA without terminating.
+extern const base::Feature kHangWatcherLongHangDetection;
+
+// Enables native abort (LOG(FATAL)) when a long hang is detected.
+extern const base::Feature kHangWatcherLongHangKill;
+
+// Sets the timeout in seconds for a hang to be considered a long hang.
+extern const base::FeatureParam<int> kLongHangTimeoutSeconds;
+
 // Enables overriding the default metrics collection interval with a fixed
 // value.
 extern const base::Feature kCobaltMetricsIntervalFeature;

--- a/cobalt/browser/hang_watcher_delegate_impl.cc
+++ b/cobalt/browser/hang_watcher_delegate_impl.cc
@@ -85,12 +85,14 @@ std::optional<int64_t> CobaltHangWatcherDelegate::GetIntSetting(
 }
 
 bool CobaltHangWatcherDelegate::IsHangReportingEnabled() {
-  // First, check 'GlobalFeatures', which is a process-wide settings dictionary
-  // typically populated by the embedder via the JS H5VCC API.
-  // We prioritize this to allow embedders to enable hang reporting
-  // until the proper Finch bridge is fully functional. If the setting isn't
-  // explicitly provided, we fallback to the standard Chromium 'FeatureList'
-  // which is backed by Finch.
+  // Check 'GlobalFeatures', which is populated by the embedder via the JS H5VCC
+  // API. We prioritize this to allow embedders runtime override control until
+  // the Finch bridge is fully functional. If omitted, we fallback to Finch
+  // ('base::FeatureList').
+  // Note: GlobalFeatures and Finch are treated as mutually exclusive. If an
+  // embedder explicitly sets a key, that intent is honored: invalid or
+  // non-positive values fall back directly to compiled defaults rather than
+  // silently activating an unintended Finch experiment group.
   auto val = GetIntSetting("EnableHangReporting");
   if (val.has_value()) {
     bool enabled = *val != 0;
@@ -102,77 +104,137 @@ bool CobaltHangWatcherDelegate::IsHangReportingEnabled() {
   return base::FeatureList::IsEnabled(cobalt::features::kHangReporting);
 }
 
-std::optional<base::TimeDelta> CobaltHangWatcherDelegate::GetHangWatchTime() {
+base::TimeDelta CobaltHangWatcherDelegate::GetHangWatchTime() {
   auto val = GetIntSetting("HangWatchTimeSeconds");
-  if (!val.has_value() || *val <= 0) {
-    return std::nullopt;
+  if (val.has_value()) {
+    if (*val <= 0) {
+      DLOG(INFO) << "CobaltHangWatcherDelegate: HangWatchTimeSeconds: " << *val
+                 << " is non-positive, using default";
+      return base::WatchHangsInScope::kDefaultHangWatchTime;
+    }
+    DLOG(INFO) << "CobaltHangWatcherDelegate: HangWatchTimeSeconds: " << *val;
+    return base::Seconds(*val);
   }
-  return base::Seconds(*val);
+
+  DLOG(INFO) << "CobaltHangWatcherDelegate: HangWatchTimeSeconds: using Finch";
+  int timeout_seconds = cobalt::features::kHangWatchTimeSeconds.Get();
+  if (timeout_seconds <= 0) {
+    return base::WatchHangsInScope::kDefaultHangWatchTime;
+  }
+  return base::Seconds(timeout_seconds);
 }
 
-std::optional<base::TimeDelta>
-CobaltHangWatcherDelegate::GetHangWatchMonitoringPeriod() {
+base::TimeDelta CobaltHangWatcherDelegate::GetHangWatchMonitoringPeriod() {
   auto val = GetIntSetting("HangWatchMonitoringPeriodSeconds");
-  if (!val.has_value() || *val <= 0) {
-    return std::nullopt;
+  if (val.has_value()) {
+    if (*val <= 0) {
+      DLOG(INFO) << "CobaltHangWatcherDelegate: "
+                    "HangWatchMonitoringPeriodSeconds: "
+                 << *val << " is non-positive, using default";
+      return base::Seconds(
+          cobalt::features::kHangWatchMonitoringPeriodSeconds.default_value);
+    }
+    DLOG(INFO) << "CobaltHangWatcherDelegate: "
+                  "HangWatchMonitoringPeriodSeconds: "
+               << *val;
+    return base::Seconds(*val);
   }
-  return base::Seconds(*val);
+
+  DLOG(INFO) << "CobaltHangWatcherDelegate: "
+                "HangWatchMonitoringPeriodSeconds: using Finch";
+  int period_seconds =
+      cobalt::features::kHangWatchMonitoringPeriodSeconds.Get();
+  if (period_seconds <= 0) {
+    return base::Seconds(
+        cobalt::features::kHangWatchMonitoringPeriodSeconds.default_value);
+  }
+  return base::Seconds(period_seconds);
 }
 
-std::optional<bool> CobaltHangWatcherDelegate::IsThreadDumpingEnabled(
+bool CobaltHangWatcherDelegate::IsThreadDumpingEnabled(
     base::HangWatcher::ThreadType thread_type) {
   std::string_view key;
+  const base::Feature* feature = nullptr;
   switch (thread_type) {
     case base::HangWatcher::ThreadType::kMainThread:
       key = "EnableHangWatchMainThreadDump";
+      feature = &cobalt::features::kHangWatchMainThreadDump;
       break;
     case base::HangWatcher::ThreadType::kIOThread:
       key = "EnableHangWatchIOThreadDump";
+      feature = &cobalt::features::kHangWatchIOThreadDump;
       break;
     case base::HangWatcher::ThreadType::kThreadPoolThread:
       key = "EnableHangWatchThreadPoolDump";
+      feature = &cobalt::features::kHangWatchThreadPoolDump;
       break;
     case base::HangWatcher::ThreadType::kRendererThread:
       key = "EnableHangWatchRendererThreadDump";
+      feature = &cobalt::features::kHangWatchRendererThreadDump;
       break;
     default:
-      return std::nullopt;
-  }
-
-  if (key.empty()) {
-    return std::nullopt;
+      return false;
   }
 
   auto val = GetIntSetting(key);
   if (val.has_value()) {
-    return *val != 0;
+    bool enabled = *val != 0;
+    DLOG(INFO) << "CobaltHangWatcherDelegate: " << key << ": " << enabled;
+    return enabled;
   }
 
-  return std::nullopt;
+  DLOG(INFO) << "CobaltHangWatcherDelegate: " << key << ": using Finch";
+  return base::FeatureList::IsEnabled(*feature);
 }
 
-std::optional<bool> CobaltHangWatcherDelegate::IsLongHangDetectionEnabled() {
+bool CobaltHangWatcherDelegate::IsLongHangDetectionEnabled() {
   auto val = GetIntSetting("EnableHangWatcherLongHangDetection");
   if (val.has_value()) {
+    DLOG(INFO)
+        << "CobaltHangWatcherDelegate: EnableHangWatcherLongHangDetection: "
+        << (*val != 0);
     return *val != 0;
   }
-  return std::nullopt;
+  DLOG(INFO) << "CobaltHangWatcherDelegate: "
+                "EnableHangWatcherLongHangDetection: using Finch";
+  return base::FeatureList::IsEnabled(
+      cobalt::features::kHangWatcherLongHangDetection);
 }
 
-std::optional<bool> CobaltHangWatcherDelegate::IsLongHangKillEnabled() {
+bool CobaltHangWatcherDelegate::IsLongHangKillEnabled() {
   auto val = GetIntSetting("EnableHangWatcherLongHangKill");
   if (val.has_value()) {
+    DLOG(INFO) << "CobaltHangWatcherDelegate: EnableHangWatcherLongHangKill: "
+               << (*val != 0);
     return *val != 0;
   }
-  return std::nullopt;
+  DLOG(INFO) << "CobaltHangWatcherDelegate: EnableHangWatcherLongHangKill: "
+                "using Finch";
+  return base::FeatureList::IsEnabled(
+      cobalt::features::kHangWatcherLongHangKill);
 }
 
-std::optional<base::TimeDelta> CobaltHangWatcherDelegate::GetLongHangTimeout() {
+base::TimeDelta CobaltHangWatcherDelegate::GetLongHangTimeout() {
   auto val = GetIntSetting("LongHangTimeoutSeconds");
-  if (!val.has_value() || *val <= 0) {
-    return std::nullopt;
+  if (val.has_value()) {
+    if (*val <= 0) {
+      DLOG(INFO) << "CobaltHangWatcherDelegate: LongHangTimeoutSeconds: "
+                 << *val << " is non-positive, using default";
+      return base::Seconds(
+          cobalt::features::kLongHangTimeoutSeconds.default_value);
+    }
+    DLOG(INFO) << "CobaltHangWatcherDelegate: LongHangTimeoutSeconds: " << *val;
+    return base::Seconds(*val);
   }
-  return base::Seconds(*val);
+
+  DLOG(INFO)
+      << "CobaltHangWatcherDelegate: LongHangTimeoutSeconds: using Finch";
+  int timeout_seconds = cobalt::features::kLongHangTimeoutSeconds.Get();
+  if (timeout_seconds <= 0) {
+    return base::Seconds(
+        cobalt::features::kLongHangTimeoutSeconds.default_value);
+  }
+  return base::Seconds(timeout_seconds);
 }
 
 void CobaltHangWatcherDelegate::RecordHangStarted(

--- a/cobalt/browser/hang_watcher_delegate_impl.h
+++ b/cobalt/browser/hang_watcher_delegate_impl.h
@@ -32,14 +32,28 @@ class CobaltHangWatcherDelegate : public base::HangWatcher::Delegate {
 
   static void Initialize();
 
+  // Configuration is resolved across three tiers:
+  //   1. Dynamic JavaScript runtime settings (GlobalFeatures / H5VCC)
+  //   2. Server-side Finch feature flags and parameters (cobalt::features)
+  //   3. Hardcoded compiled defaults (base::WatchHangsInScope,
+  //   cobalt::features)
+  //
+  // GlobalFeatures (H5VCC) and Finch are treated as mutually exclusive
+  // configuration paths. If an embedder explicitly provides a setting via
+  // GlobalFeatures, that configuration is authoritative. If the provided
+  // setting is invalid, the system logs a message and falls back directly to
+  // the safe compiled default rather than silently switching to a Finch value
+  // (which the embedder may not have configured or intended to use). Fallback
+  // to Finch is reserved strictly for when GlobalFeatures settings are omitted
+  // entirely.
   bool IsHangReportingEnabled() override;
-  std::optional<base::TimeDelta> GetHangWatchTime() override;
-  std::optional<base::TimeDelta> GetHangWatchMonitoringPeriod() override;
-  std::optional<bool> IsThreadDumpingEnabled(
+  base::TimeDelta GetHangWatchTime() override;
+  base::TimeDelta GetHangWatchMonitoringPeriod() override;
+  bool IsThreadDumpingEnabled(
       base::HangWatcher::ThreadType thread_type) override;
-  std::optional<bool> IsLongHangDetectionEnabled() override;
-  std::optional<bool> IsLongHangKillEnabled() override;
-  std::optional<base::TimeDelta> GetLongHangTimeout() override;
+  bool IsLongHangDetectionEnabled() override;
+  bool IsLongHangKillEnabled() override;
+  base::TimeDelta GetLongHangTimeout() override;
   void RecordHangStarted(const std::string& hang_uuid) override;
   void RecordHangRecovered(const std::string& hang_uuid) override;
 

--- a/cobalt/browser/hang_watcher_delegate_impl_unittest.cc
+++ b/cobalt/browser/hang_watcher_delegate_impl_unittest.cc
@@ -19,9 +19,11 @@
 
 #include "base/files/scoped_temp_dir.h"
 #include "base/path_service.h"
+#include "base/test/scoped_feature_list.h"
 #include "base/test/scoped_path_override.h"
 #include "base/test/task_environment.h"
 #include "base/time/time.h"
+#include "cobalt/browser/features.h"
 #include "cobalt/browser/global_features.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -46,6 +48,9 @@ class HangWatcherDelegateImplTest : public testing::Test {
     instance_->ClearSetting("EnableHangWatchIOThreadDump");
     instance_->ClearSetting("EnableHangWatchThreadPoolDump");
     instance_->ClearSetting("EnableHangWatchRendererThreadDump");
+    instance_->ClearSetting("EnableHangWatcherLongHangDetection");
+    instance_->ClearSetting("EnableHangWatcherLongHangKill");
+    instance_->ClearSetting("LongHangTimeoutSeconds");
   }
 
   base::test::TaskEnvironment task_environment_{
@@ -58,57 +63,446 @@ class HangWatcherDelegateImplTest : public testing::Test {
   std::unique_ptr<CobaltHangWatcherDelegate> delegate_;
 };
 
-TEST_F(HangWatcherDelegateImplTest, IsHangReportingEnabled_Default) {
-  // Should default to base::FeatureList value (which we can't easily mock here,
-  // but it shouldn't crash).
-  delegate_->IsHangReportingEnabled();
+TEST_F(HangWatcherDelegateImplTest, IsHangReportingEnabled_DefaultsWhenUnset) {
+  // When unconfigured by H5VCC, defaults to Finch kHangReporting defined in
+  // cobalt/browser/features.cc.
+  EXPECT_FALSE(delegate_->IsHangReportingEnabled());
 }
 
-TEST_F(HangWatcherDelegateImplTest,
-       IsHangReportingEnabledReturnsValueFromGlobalSettings) {
-  instance_->SetSettings("EnableHangReporting", int64_t(1));
+TEST_F(HangWatcherDelegateImplTest, IsHangReportingEnabled_FallbackToFinch) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeature(cobalt::features::kHangReporting);
+
+  // Settings not set, should fallback to Finch (true)
   EXPECT_TRUE(delegate_->IsHangReportingEnabled());
 
+  // If we set settings to 0, they should override Finch enabled
   instance_->SetSettings("EnableHangReporting", int64_t(0));
   EXPECT_FALSE(delegate_->IsHangReportingEnabled());
 }
 
 TEST_F(HangWatcherDelegateImplTest,
-       GetHangWatchTimeReturnsValueFromGlobalSettings) {
+       IsHangReportingEnabled_SettingsOverrideFinchDisabled) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndDisableFeature(cobalt::features::kHangReporting);
+
+  // Settings set to 1 should override Finch disabled
+  instance_->SetSettings("EnableHangReporting", int64_t(1));
+  EXPECT_TRUE(delegate_->IsHangReportingEnabled());
+}
+
+TEST_F(HangWatcherDelegateImplTest, HangWatchTimingFlags_DefaultsWhenUnset) {
+  // Defaults when unconfigured:
+  // - HangWatchTime: from base::WatchHangsInScope::kDefaultHangWatchTime in
+  //   base/threading/hang_watcher.h or kHangWatchTimeSeconds default in
+  //   cobalt/browser/features.cc.
+  // - HangWatchMonitoringPeriod: from default value of
+  //   kHangWatchMonitoringPeriodSeconds in cobalt/browser/features.cc.
+  EXPECT_EQ(delegate_->GetHangWatchTime(), base::Seconds(10));
+  EXPECT_EQ(delegate_->GetHangWatchMonitoringPeriod(), base::Seconds(10));
+}
+
+TEST_F(HangWatcherDelegateImplTest, GetHangWatchTime_FallbackToFinch) {
+  base::test::ScopedFeatureList feature_list;
+  base::FieldTrialParams params;
+  params["HangWatchTimeSeconds"] = "25";
+  feature_list.InitAndEnableFeatureWithParameters(
+      cobalt::features::kHangReporting, params);
+
+  // Settings not set, should fallback to Finch parameter (25s)
+  EXPECT_EQ(delegate_->GetHangWatchTime().InSeconds(), 25);
+
+  // If we set settings, they should override Finch
   instance_->SetSettings("HangWatchTimeSeconds", int64_t(15));
-
-  auto timeout = delegate_->GetHangWatchTime();
-  ASSERT_TRUE(timeout.has_value());
-  EXPECT_EQ(timeout->InSeconds(), 15);
+  EXPECT_EQ(delegate_->GetHangWatchTime().InSeconds(), 15);
 }
 
 TEST_F(HangWatcherDelegateImplTest,
-       GetHangWatchMonitoringPeriodReturnsValueFromGlobalSettings) {
+       GetHangWatchTime_NonPositiveSettingsFallbackToDefault) {
+  base::test::ScopedFeatureList feature_list;
+  base::FieldTrialParams params;
+  params["HangWatchTimeSeconds"] = "25";
+  feature_list.InitAndEnableFeatureWithParameters(
+      cobalt::features::kHangReporting, params);
+
+  // Present but non-positive setting should fallback directly to compiled
+  // default (base::WatchHangsInScope::kDefaultHangWatchTime in
+  // base/threading/hang_watcher.h), NOT Finch.
+  instance_->SetSettings("HangWatchTimeSeconds", int64_t(0));
+  EXPECT_EQ(delegate_->GetHangWatchTime().InSeconds(), 10);
+
+  instance_->SetSettings("HangWatchTimeSeconds", int64_t(-5));
+  EXPECT_EQ(delegate_->GetHangWatchTime().InSeconds(), 10);
+}
+
+TEST_F(HangWatcherDelegateImplTest,
+       GetHangWatchMonitoringPeriod_FallbackToFinch) {
+  base::test::ScopedFeatureList feature_list;
+  base::FieldTrialParams params;
+  params["HangWatchMonitoringPeriodSeconds"] = "18";
+  feature_list.InitAndEnableFeatureWithParameters(
+      cobalt::features::kHangReporting, params);
+
+  // Settings not set, should fallback to Finch parameter (18s)
+  EXPECT_EQ(delegate_->GetHangWatchMonitoringPeriod().InSeconds(), 18);
+
+  // If we set settings, they should override Finch
   instance_->SetSettings("HangWatchMonitoringPeriodSeconds", int64_t(8));
-  auto period = delegate_->GetHangWatchMonitoringPeriod();
-  ASSERT_TRUE(period.has_value());
-  EXPECT_EQ(period->InSeconds(), 8);
+  EXPECT_EQ(delegate_->GetHangWatchMonitoringPeriod().InSeconds(), 8);
+}
+
+TEST_F(HangWatcherDelegateImplTest, GetHangWatchTime_H5VCCOnly) {
+  instance_->SetSettings("HangWatchTimeSeconds", int64_t(30));
+  EXPECT_EQ(delegate_->GetHangWatchTime().InSeconds(), 30);
 }
 
 TEST_F(HangWatcherDelegateImplTest,
-       IsThreadDumpingEnabledReturnsValueFromGlobalSettings) {
-  instance_->SetSettings("EnableHangWatchIOThreadDump", int64_t(1));
-  auto io_enabled = delegate_->IsThreadDumpingEnabled(
-      base::HangWatcher::ThreadType::kIOThread);
-  ASSERT_TRUE(io_enabled.has_value());
-  EXPECT_TRUE(*io_enabled);
+       GetHangWatchTime_InvalidH5VCCFallbackToDefault) {
+  // Non-positive H5VCC setting falls back directly to compiled default
+  // (base::WatchHangsInScope::kDefaultHangWatchTime in
+  // base/threading/hang_watcher.h).
+  instance_->SetSettings("HangWatchTimeSeconds", int64_t(0));
+  EXPECT_EQ(delegate_->GetHangWatchTime(), base::Seconds(10));
 
+  instance_->SetSettings("HangWatchTimeSeconds", int64_t(-1));
+  EXPECT_EQ(delegate_->GetHangWatchTime(), base::Seconds(10));
+}
+
+TEST_F(HangWatcherDelegateImplTest,
+       GetHangWatchTime_NonPositiveFinchFallbackToDefault) {
+  // Non-positive Finch parameter value falls back to compiled default
+  // (base::WatchHangsInScope::kDefaultHangWatchTime in
+  // base/threading/hang_watcher.h).
+  base::test::ScopedFeatureList feature_list;
+  base::FieldTrialParams params;
+  params["HangWatchTimeSeconds"] = "0";
+  feature_list.InitAndEnableFeatureWithParameters(
+      cobalt::features::kHangReporting, params);
+  EXPECT_EQ(delegate_->GetHangWatchTime(), base::Seconds(10));
+
+  base::test::ScopedFeatureList negative_feature_list;
+  base::FieldTrialParams negative_params;
+  negative_params["HangWatchTimeSeconds"] = "-5";
+  negative_feature_list.InitAndEnableFeatureWithParameters(
+      cobalt::features::kHangReporting, negative_params);
+  EXPECT_EQ(delegate_->GetHangWatchTime(), base::Seconds(10));
+}
+
+TEST_F(HangWatcherDelegateImplTest, GetHangWatchMonitoringPeriod_H5VCCOnly) {
+  instance_->SetSettings("HangWatchMonitoringPeriodSeconds", int64_t(12));
+  EXPECT_EQ(delegate_->GetHangWatchMonitoringPeriod().InSeconds(), 12);
+}
+
+TEST_F(HangWatcherDelegateImplTest,
+       GetHangWatchMonitoringPeriod_NonPositiveSettingsFallbackToDefault) {
+  base::test::ScopedFeatureList feature_list;
+  base::FieldTrialParams params;
+  params["HangWatchMonitoringPeriodSeconds"] = "18";
+  feature_list.InitAndEnableFeatureWithParameters(
+      cobalt::features::kHangReporting, params);
+
+  // Present but non-positive setting should fallback directly to compiled
+  // default (kHangWatchMonitoringPeriodSeconds default in
+  // cobalt/browser/features.cc), NOT Finch.
+  instance_->SetSettings("HangWatchMonitoringPeriodSeconds", int64_t(0));
+  EXPECT_EQ(delegate_->GetHangWatchMonitoringPeriod().InSeconds(), 10);
+
+  instance_->SetSettings("HangWatchMonitoringPeriodSeconds", int64_t(-5));
+  EXPECT_EQ(delegate_->GetHangWatchMonitoringPeriod().InSeconds(), 10);
+}
+
+TEST_F(HangWatcherDelegateImplTest,
+       GetHangWatchMonitoringPeriod_InvalidH5VCCFallbackToDefault) {
+  // Non-positive H5VCC setting falls back directly to compiled default
+  // (kHangWatchMonitoringPeriodSeconds default in
+  // cobalt/browser/features.cc).
+  instance_->SetSettings("HangWatchMonitoringPeriodSeconds", int64_t(0));
+  EXPECT_EQ(delegate_->GetHangWatchMonitoringPeriod(), base::Seconds(10));
+
+  instance_->SetSettings("HangWatchMonitoringPeriodSeconds", int64_t(-1));
+  EXPECT_EQ(delegate_->GetHangWatchMonitoringPeriod(), base::Seconds(10));
+}
+
+TEST_F(HangWatcherDelegateImplTest,
+       GetHangWatchMonitoringPeriod_NonPositiveFinchFallbackToDefault) {
+  // Non-positive Finch parameter value falls back to compiled default
+  // (kHangWatchMonitoringPeriodSeconds default in
+  // cobalt/browser/features.cc).
+  base::test::ScopedFeatureList feature_list;
+  base::FieldTrialParams params;
+  params["HangWatchMonitoringPeriodSeconds"] = "0";
+  feature_list.InitAndEnableFeatureWithParameters(
+      cobalt::features::kHangReporting, params);
+  EXPECT_EQ(delegate_->GetHangWatchMonitoringPeriod(), base::Seconds(10));
+
+  base::test::ScopedFeatureList negative_feature_list;
+  base::FieldTrialParams negative_params;
+  negative_params["HangWatchMonitoringPeriodSeconds"] = "-5";
+  negative_feature_list.InitAndEnableFeatureWithParameters(
+      cobalt::features::kHangReporting, negative_params);
+  EXPECT_EQ(delegate_->GetHangWatchMonitoringPeriod(), base::Seconds(10));
+}
+
+TEST_F(HangWatcherDelegateImplTest, IsThreadDumpingEnabled_DefaultsWhenUnset) {
+  // Defaults when unconfigured, from feature definitions in
+  // cobalt/browser/features.cc:
+  // - kHangWatchMainThreadDump
+  // - kHangWatchIOThreadDump
+  // - kHangWatchThreadPoolDump
+  // - kHangWatchRendererThreadDump
+  EXPECT_FALSE(delegate_->IsThreadDumpingEnabled(
+      base::HangWatcher::ThreadType::kMainThread));
+  EXPECT_FALSE(delegate_->IsThreadDumpingEnabled(
+      base::HangWatcher::ThreadType::kIOThread));
+  EXPECT_FALSE(delegate_->IsThreadDumpingEnabled(
+      base::HangWatcher::ThreadType::kThreadPoolThread));
+  EXPECT_TRUE(delegate_->IsThreadDumpingEnabled(
+      base::HangWatcher::ThreadType::kRendererThread));
+}
+
+TEST_F(HangWatcherDelegateImplTest, IsThreadDumpingEnabled_FallbackToFinch) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitWithFeatures(
+      /*enabled_features=*/{cobalt::features::kHangWatchMainThreadDump,
+                            cobalt::features::kHangWatchIOThreadDump,
+                            cobalt::features::kHangWatchThreadPoolDump},
+      /*disabled_features=*/{cobalt::features::kHangWatchRendererThreadDump});
+
+  EXPECT_TRUE(delegate_->IsThreadDumpingEnabled(
+      base::HangWatcher::ThreadType::kMainThread));
+  EXPECT_TRUE(delegate_->IsThreadDumpingEnabled(
+      base::HangWatcher::ThreadType::kIOThread));
+  EXPECT_TRUE(delegate_->IsThreadDumpingEnabled(
+      base::HangWatcher::ThreadType::kThreadPoolThread));
+  EXPECT_FALSE(delegate_->IsThreadDumpingEnabled(
+      base::HangWatcher::ThreadType::kRendererThread));
+}
+
+TEST_F(HangWatcherDelegateImplTest,
+       IsThreadDumpingEnabled_SettingsOverrideFinch) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitWithFeatures(
+      /*enabled_features=*/{cobalt::features::kHangWatchMainThreadDump,
+                            cobalt::features::kHangWatchIOThreadDump},
+      /*disabled_features=*/{cobalt::features::kHangWatchThreadPoolDump,
+                             cobalt::features::kHangWatchRendererThreadDump});
+
+  // Main thread is Finch enabled, but settings set to 0 -> should return false
+  instance_->SetSettings("EnableHangWatchMainThreadDump", int64_t(0));
+  EXPECT_FALSE(delegate_->IsThreadDumpingEnabled(
+      base::HangWatcher::ThreadType::kMainThread));
+
+  // IO thread is Finch enabled, but settings set to 0 -> should return false
   instance_->SetSettings("EnableHangWatchIOThreadDump", int64_t(0));
-  io_enabled = delegate_->IsThreadDumpingEnabled(
-      base::HangWatcher::ThreadType::kIOThread);
-  ASSERT_TRUE(io_enabled.has_value());
-  EXPECT_FALSE(*io_enabled);
+  EXPECT_FALSE(delegate_->IsThreadDumpingEnabled(
+      base::HangWatcher::ThreadType::kIOThread));
 
+  // Thread pool is Finch disabled, but settings set to 1 -> should return true
+  instance_->SetSettings("EnableHangWatchThreadPoolDump", int64_t(1));
+  EXPECT_TRUE(delegate_->IsThreadDumpingEnabled(
+      base::HangWatcher::ThreadType::kThreadPoolThread));
+
+  // Renderer thread is Finch disabled, but settings set to 1 -> should return
+  // true
   instance_->SetSettings("EnableHangWatchRendererThreadDump", int64_t(1));
-  auto renderer_enabled = delegate_->IsThreadDumpingEnabled(
-      base::HangWatcher::ThreadType::kRendererThread);
-  ASSERT_TRUE(renderer_enabled.has_value());
-  EXPECT_TRUE(*renderer_enabled);
+  EXPECT_TRUE(delegate_->IsThreadDumpingEnabled(
+      base::HangWatcher::ThreadType::kRendererThread));
+
+  // Unrecognized / unsupported thread type should return false
+  EXPECT_FALSE(delegate_->IsThreadDumpingEnabled(
+      base::HangWatcher::ThreadType::kCompositorThread));
+}
+
+TEST_F(HangWatcherDelegateImplTest, IsThreadDumpingEnabled_H5VCCOnly) {
+  instance_->SetSettings("EnableHangWatchMainThreadDump", int64_t(1));
+  instance_->SetSettings("EnableHangWatchIOThreadDump", int64_t(1));
+  instance_->SetSettings("EnableHangWatchThreadPoolDump", int64_t(1));
+  instance_->SetSettings("EnableHangWatchRendererThreadDump", int64_t(0));
+
+  EXPECT_TRUE(delegate_->IsThreadDumpingEnabled(
+      base::HangWatcher::ThreadType::kMainThread));
+  EXPECT_TRUE(delegate_->IsThreadDumpingEnabled(
+      base::HangWatcher::ThreadType::kIOThread));
+  EXPECT_TRUE(delegate_->IsThreadDumpingEnabled(
+      base::HangWatcher::ThreadType::kThreadPoolThread));
+  EXPECT_FALSE(delegate_->IsThreadDumpingEnabled(
+      base::HangWatcher::ThreadType::kRendererThread));
+}
+
+TEST_F(HangWatcherDelegateImplTest,
+       IsLongHangDetectionEnabled_FallbackToFinch) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeature(
+      cobalt::features::kHangWatcherLongHangDetection);
+
+  // Settings not set, should fallback to Finch (true)
+  EXPECT_TRUE(delegate_->IsLongHangDetectionEnabled());
+
+  // If we set settings, they should override Finch
+  instance_->SetSettings("EnableHangWatcherLongHangDetection", int64_t(0));
+  EXPECT_FALSE(delegate_->IsLongHangDetectionEnabled());
+}
+
+TEST_F(HangWatcherDelegateImplTest, IsLongHangKillEnabled_FallbackToFinch) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeature(cobalt::features::kHangWatcherLongHangKill);
+
+  // Settings not set, should fallback to Finch (true)
+  EXPECT_TRUE(delegate_->IsLongHangKillEnabled());
+
+  // If we set settings, they should override Finch
+  instance_->SetSettings("EnableHangWatcherLongHangKill", int64_t(0));
+  EXPECT_FALSE(delegate_->IsLongHangKillEnabled());
+}
+
+TEST_F(HangWatcherDelegateImplTest, GetLongHangTimeout_FallbackToFinch) {
+  base::test::ScopedFeatureList feature_list;
+  base::FieldTrialParams params;
+  params["LongHangTimeoutSeconds"] = "35";
+  feature_list.InitAndEnableFeatureWithParameters(
+      cobalt::features::kHangWatcherLongHangDetection, params);
+
+  // Settings not set, should fallback to Finch parameter
+  EXPECT_EQ(delegate_->GetLongHangTimeout().InSeconds(), 35);
+
+  // If we set settings, they should override Finch
+  instance_->SetSettings("LongHangTimeoutSeconds", int64_t(42));
+  EXPECT_EQ(delegate_->GetLongHangTimeout().InSeconds(), 42);
+}
+
+TEST_F(HangWatcherDelegateImplTest, LongHangFlags_DefaultsWhenUnset) {
+  // Defaults when unconfigured, from definitions in cobalt/browser/features.cc:
+  // - kHangWatcherLongHangDetection
+  // - kHangWatcherLongHangKill
+  // - kLongHangTimeoutSeconds
+  EXPECT_FALSE(delegate_->IsLongHangDetectionEnabled());
+  EXPECT_FALSE(delegate_->IsLongHangKillEnabled());
+  EXPECT_EQ(delegate_->GetLongHangTimeout(), base::Seconds(20));
+}
+
+TEST_F(HangWatcherDelegateImplTest,
+       IsLongHangDetectionEnabled_SettingsOverrideFinchDisabled) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndDisableFeature(
+      cobalt::features::kHangWatcherLongHangDetection);
+
+  // GlobalFeatures setting '1' should override Finch disabled state.
+  instance_->SetSettings("EnableHangWatcherLongHangDetection", int64_t(1));
+  EXPECT_TRUE(delegate_->IsLongHangDetectionEnabled());
+}
+
+TEST_F(HangWatcherDelegateImplTest,
+       IsLongHangKillEnabled_SettingsOverrideFinchDisabled) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndDisableFeature(
+      cobalt::features::kHangWatcherLongHangKill);
+
+  // GlobalFeatures setting '1' should override Finch disabled state.
+  instance_->SetSettings("EnableHangWatcherLongHangKill", int64_t(1));
+  EXPECT_TRUE(delegate_->IsLongHangKillEnabled());
+}
+
+TEST_F(HangWatcherDelegateImplTest, IsLongHangDetectionEnabled_H5VCCOnly) {
+  instance_->SetSettings("EnableHangWatcherLongHangDetection", int64_t(1));
+  EXPECT_TRUE(delegate_->IsLongHangDetectionEnabled());
+
+  instance_->SetSettings("EnableHangWatcherLongHangDetection", int64_t(0));
+  EXPECT_FALSE(delegate_->IsLongHangDetectionEnabled());
+}
+
+TEST_F(HangWatcherDelegateImplTest, IsLongHangKillEnabled_H5VCCOnly) {
+  instance_->SetSettings("EnableHangWatcherLongHangKill", int64_t(1));
+  EXPECT_TRUE(delegate_->IsLongHangKillEnabled());
+
+  instance_->SetSettings("EnableHangWatcherLongHangKill", int64_t(0));
+  EXPECT_FALSE(delegate_->IsLongHangKillEnabled());
+}
+
+TEST_F(HangWatcherDelegateImplTest, GetLongHangTimeout_H5VCCOnly) {
+  instance_->SetSettings("LongHangTimeoutSeconds", int64_t(45));
+  EXPECT_EQ(delegate_->GetLongHangTimeout().InSeconds(), 45);
+}
+
+TEST_F(HangWatcherDelegateImplTest,
+       GetLongHangTimeout_NonPositiveSettingsFallbackToDefault) {
+  base::test::ScopedFeatureList feature_list;
+  base::FieldTrialParams params;
+  params["LongHangTimeoutSeconds"] = "35";
+  feature_list.InitAndEnableFeatureWithParameters(
+      cobalt::features::kHangWatcherLongHangDetection, params);
+
+  // Present but non-positive setting should fallback directly to compiled
+  // default (kLongHangTimeoutSeconds default in
+  // cobalt/browser/features.cc), NOT Finch.
+  instance_->SetSettings("LongHangTimeoutSeconds", int64_t(0));
+  EXPECT_EQ(delegate_->GetLongHangTimeout().InSeconds(), 20);
+
+  instance_->SetSettings("LongHangTimeoutSeconds", int64_t(-10));
+  EXPECT_EQ(delegate_->GetLongHangTimeout().InSeconds(), 20);
+}
+
+TEST_F(HangWatcherDelegateImplTest,
+       GetLongHangTimeout_InvalidH5VCCFallbackToDefault) {
+  // Non-positive H5VCC setting falls back directly to compiled default
+  // (kLongHangTimeoutSeconds default in cobalt/browser/features.cc).
+  instance_->SetSettings("LongHangTimeoutSeconds", int64_t(0));
+  EXPECT_EQ(delegate_->GetLongHangTimeout(), base::Seconds(20));
+
+  instance_->SetSettings("LongHangTimeoutSeconds", int64_t(-5));
+  EXPECT_EQ(delegate_->GetLongHangTimeout(), base::Seconds(20));
+}
+
+TEST_F(HangWatcherDelegateImplTest,
+       GetLongHangTimeout_NonPositiveFinchFallbackToDefault) {
+  // Non-positive Finch parameter value falls back to compiled default
+  // (kLongHangTimeoutSeconds default in cobalt/browser/features.cc).
+  base::test::ScopedFeatureList feature_list;
+  base::FieldTrialParams params;
+  params["LongHangTimeoutSeconds"] = "0";
+  feature_list.InitAndEnableFeatureWithParameters(
+      cobalt::features::kHangWatcherLongHangDetection, params);
+  EXPECT_EQ(delegate_->GetLongHangTimeout(), base::Seconds(20));
+
+  base::test::ScopedFeatureList negative_feature_list;
+  base::FieldTrialParams negative_params;
+  negative_params["LongHangTimeoutSeconds"] = "-5";
+  negative_feature_list.InitAndEnableFeatureWithParameters(
+      cobalt::features::kHangWatcherLongHangDetection, negative_params);
+  EXPECT_EQ(delegate_->GetLongHangTimeout(), base::Seconds(20));
+}
+
+TEST_F(HangWatcherDelegateImplTest, SettingsTypeMismatch_FallsBackToFinch) {
+  base::test::ScopedFeatureList feature_list;
+  base::FieldTrialParams params;
+  params["LongHangTimeoutSeconds"] = "35";
+  feature_list.InitAndEnableFeatureWithParameters(
+      cobalt::features::kHangWatcherLongHangDetection, params);
+
+  base::test::ScopedFeatureList reporting_feature_list;
+  base::FieldTrialParams reporting_params;
+  reporting_params["HangWatchTimeSeconds"] = "22";
+  reporting_params["HangWatchMonitoringPeriodSeconds"] = "14";
+  reporting_feature_list.InitAndEnableFeatureWithParameters(
+      cobalt::features::kHangReporting, reporting_params);
+
+  // Inject string variant instead of int64_t
+  instance_->SetSettings("EnableHangWatcherLongHangDetection",
+                         std::string("true"));
+  instance_->SetSettings("LongHangTimeoutSeconds", std::string("42"));
+  instance_->SetSettings("HangWatchTimeSeconds", std::string("99"));
+  instance_->SetSettings("HangWatchMonitoringPeriodSeconds", std::string("99"));
+  instance_->SetSettings("EnableHangWatchMainThreadDump", std::string("1"));
+  instance_->SetSettings("EnableHangWatchRendererThreadDump", std::string("0"));
+
+  // Should ignore strings and fallback to Finch
+  EXPECT_TRUE(delegate_->IsLongHangDetectionEnabled());
+  EXPECT_EQ(delegate_->GetLongHangTimeout().InSeconds(), 35);
+  EXPECT_EQ(delegate_->GetHangWatchTime().InSeconds(), 22);
+  EXPECT_EQ(delegate_->GetHangWatchMonitoringPeriod().InSeconds(), 14);
+  EXPECT_FALSE(delegate_->IsThreadDumpingEnabled(
+      base::HangWatcher::ThreadType::kMainThread));
+  EXPECT_TRUE(delegate_->IsThreadDumpingEnabled(
+      base::HangWatcher::ThreadType::kRendererThread));
 }
 
 }  // namespace browser


### PR DESCRIPTION
This change integrates the Finch feature system to allow remote configuration of hang
detection parameters via Finch flags, in addition to the GlobalSettings via h5vcc API.

Supported parameters include hang watch time, monitoring periods,
and thread-specific dumping flags. The configuration hierarchy is
established to check GlobalSettings(h5vcc API) first, followed by Finch
feature parameters, and finally internal defaults. This provides
greater flexibility for tuning hang detection in production.

Bug: 517626586