### PR TITLE
starboard/android: Fix JavaRef local-reference DCHECK for surface_view

### DIFF
--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -195,6 +195,20 @@ const DrmSystem::Callbacks kStubDrmSystemCallbacks = {
     StubDrmSessionUpdateRequestFunc, StubDrmSessionUpdatedFunc,
     StubDrmSessionKeyStatusesChangedFunc};
 
+// Makes a global ref out of `surface_view`, which callers hand us as a raw
+// jobject that is usually a global ref. jni_zero only accepts local refs when
+// wrapping a raw jobject, so go through NewLocalRef() first.
+jni_zero::ScopedJavaGlobalRef<jobject> SurfaceViewToGlobalRef(
+    void* surface_view) {
+  if (!surface_view) {
+    return jni_zero::ScopedJavaGlobalRef<jobject>();
+  }
+  JNIEnv* env = AttachCurrentThread();
+  return jni_zero::ScopedJavaGlobalRef<jobject>(
+      env, jni_zero::ScopedJavaLocalRef<jobject>::Adopt(
+               env, env->NewLocalRef(static_cast<jobject>(surface_view))));
+}
+
 }  // namespace
 
 // TODO: Merge this with VideoFrameTracker, maybe?
@@ -346,14 +360,7 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
       tunnel_mode_audio_session_id_(tunnel_mode_config.audio_session_id),
       max_video_input_size_(pipeline_config.max_input_size),
       use_dual_threads_(pipeline_config.use_dual_threads),
-      surface_view_(
-          stream_config.surface_view
-              ? jni_zero::ScopedJavaGlobalRef<jobject>(
-                    jni_zero::AttachCurrentThread(),
-                    jni_zero::JavaRef<jobject>::CreateLeaky(
-                        jni_zero::AttachCurrentThread(),
-                        static_cast<jobject>(stream_config.surface_view)))
-              : nullptr),
+      surface_view_(SurfaceViewToGlobalRef(stream_config.surface_view)),
       enable_flush_during_seek_(pipeline_config.enable_flush_during_seek),
       reset_delay_usec_(android_get_device_api_level() < 34
                             ? platform_options.reset_delay_usec


### PR DESCRIPTION
While rebasing Cobalt against 140.7318, a regression was introduced in the starboard_platform_tests on Android CI [1].
The issue was caused by [starboard/android, cobalt/shell/android: Adapt to jni_zero JavaRef-only Reset()/constructor API](https://github.com/youtube/cobalt/pull/12155/changes/bbc5bd689176a6a71e427aee6fa5c266bdc27d15), which passed a global ref to a function that only handled local refs. This PR fixes the issue.

[1] https://github.com/youtube/cobalt/actions/runs/32749361834/job/97520626432?pr=12140

Bug: 549407115
