### PR TITLE
Replace new CHROMIUM_MILESTONE_LE_138 checks with 150 ones

### DIFF
--- a/services/network/network_context.cc
+++ b/services/network/network_context.cc
@@ -46,11 +46,11 @@
 #include "build/chromecast_buildflags.h"
 #include "components/cookie_config/cookie_store_util.h"
 #include "components/domain_reliability/monitor.h"
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_150
 #include "components/ip_protection/common/ip_protection_core_host_remote.h"  // nogncheck
 #include "components/ip_protection/common/ip_protection_core_impl_mojo.h"    // nogncheck
 #include "components/ip_protection/common/ip_protection_proxy_delegate.h"   // nogncheck
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_150
 #include "components/network_session_configurator/browser/network_session_configurator.h"
 #include "components/network_session_configurator/common/network_switches.h"
 #include "components/os_crypt/async/common/encryptor.h"
@@ -1247,12 +1247,12 @@ void NetworkContext::SetBlockTrustTokens(bool block) {
 
 void NetworkContext::SetTrackingProtectionContentSetting(
     const ContentSettingsForOneType& settings) {
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_150
   if (!ip_protection_core_) {
     return;
   }
   ip_protection_core_->SetTrackingProtectionContentSetting(settings);
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_150
 }
 
 void NetworkContext::OnProxyLookupComplete(
@@ -2715,7 +2715,7 @@ URLRequestContextOwner NetworkContext::MakeURLRequestContext(
   // case for any given NetworkContext: either PrefetchProxy, handling its
   // custom proxy configs, or IpProtection, using the proxy allowlist.
   bool requires_ipp_proxy_delegate = false;
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_150
   auto* mdl_manager = network_service_->masked_domain_list_manager();
   auto* prt_registry = network_service_->probabilistic_reveal_token_registry();
   requires_ipp_proxy_delegate =
@@ -2741,7 +2741,7 @@ URLRequestContextOwner NetworkContext::MakeURLRequestContext(
             ip_protection_core_impl.get()));
     ip_protection_core_ = std::move(ip_protection_core_impl);
   }
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_150
   if (!requires_ipp_proxy_delegate &&
       (params_->initial_custom_proxy_config ||
        params_->custom_proxy_config_client_receiver)) {

--- a/services/network/network_context.h
+++ b/services/network/network_context.h
@@ -26,9 +26,9 @@
 #include "base/types/pass_key.h"
 #include "base/unguessable_token.h"
 #include "build/build_config.h"
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_150
 #include "components/ip_protection/common/ip_protection_core.h"  // nogncheck
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_150
 #include "mojo/public/cpp/base/big_buffer.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
 #include "mojo/public/cpp/bindings/pending_remote.h"
@@ -209,11 +209,11 @@ class COMPONENT_EXPORT(NETWORK_SERVICE) NetworkContext
 
   CookieManager* cookie_manager() { return cookie_manager_.get(); }
 
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_150
   ip_protection::IpProtectionCore* ip_protection_core() {
     return ip_protection_core_.get();
   }
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_150
 
   const base::flat_set<std::string>* cors_exempt_header_list() const {
     return &cors_exempt_header_list_;
@@ -861,12 +861,12 @@ class COMPONENT_EXPORT(NETWORK_SERVICE) NetworkContext
 
   std::unique_ptr<ResourceScheduler> resource_scheduler_;
 
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_150
   // The IpProtectionCore for this context, used to coordinate proxying
   // protected requests. `url_request_context_owner_` indirectly holds
   // a pointer to and must be defined after `ip_protection_core_`.
   std::unique_ptr<ip_protection::IpProtectionCore> ip_protection_core_;
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_150
 
   // Used only when network::features::kCompressionDictionaryTransportBackend is
   // enabled.

--- a/services/network/network_service.cc
+++ b/services/network/network_service.cc
@@ -40,12 +40,12 @@
 #include "base/values.h"
 #include "build/build_config.h"
 #include "build/chromecast_buildflags.h"
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_150
 #include "components/ip_protection/common/ip_protection_telemetry.h"            // nogncheck
 #include "components/ip_protection/common/masked_domain_list_manager.h"        // nogncheck
 #include "components/ip_protection/common/probabilistic_reveal_token_registry.h"// nogncheck
 #include "components/privacy_sandbox/masked_domain_list/masked_domain_list.pb.h"
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_150
 #include "components/network_session_configurator/common/network_features.h"
 #include "components/os_crypt/sync/os_crypt.h"
 #include "mojo/public/cpp/base/proto_wrapper.h"
@@ -504,14 +504,14 @@ void NetworkService::Initialize(mojom::NetworkServiceParamsPtr params,
 
   tpcd_metadata_manager_ = std::make_unique<network::tpcd::metadata::Manager>();
 
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_150
   masked_domain_list_manager_ =
       std::make_unique<ip_protection::MaskedDomainListManager>(
           params->ip_protection_proxy_bypass_policy);
 
   probabilistic_reveal_token_registry_ =
       std::make_unique<ip_protection::ProbabilisticRevealTokenRegistry>();
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_150
 
 #if BUILDFLAG(IS_CT_SUPPORTED)
   constexpr size_t kMaxSCTAuditingCacheEntries = 1024;
@@ -1004,14 +1004,14 @@ void NetworkService::UpdateMaskedDomainList(
     mojo_base::ProtoWrapper masked_domain_list,
     const std::vector<std::string>& exclusion_list) {
   const base::Time start_time = base::Time::Now();
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_150
   auto mdl = masked_domain_list.As<masked_domain_list::MaskedDomainList>();
   if (mdl.has_value()) {
     ip_protection::Telemetry().MdlSize(mdl->ByteSizeLong());
     masked_domain_list_manager_->UpdateMaskedDomainList(mdl.value(),
                                                         exclusion_list);
   }
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_150
 
   base::UmaHistogramTimes(
       "NetworkService.IpProtection.ProxyAllowList.UpdateProcessTime",
@@ -1023,22 +1023,22 @@ void NetworkService::UpdateMaskedDomainListFlatbuffer(
     uint64_t default_file_size,
     base::File regular_browsing_file,
     uint64_t regular_browsing_file_size) {
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_150
   if (masked_domain_list_manager_) {
     masked_domain_list_manager_->UpdateMaskedDomainListFlatbuffer(
         std::move(default_file), default_file_size,
         std::move(regular_browsing_file), regular_browsing_file_size);
   }
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_150
 }
 
 void NetworkService::UpdateProbabilisticRevealTokenRegistry(
     base::Value::Dict registry) {
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_150
   if (probabilistic_reveal_token_registry_) {
     probabilistic_reveal_token_registry_->UpdateRegistry(std::move(registry));
   }
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_150
 }
 
 #if BUILDFLAG(IS_ANDROID)

--- a/services/network/network_service.h
+++ b/services/network/network_service.h
@@ -26,11 +26,11 @@
 #include "base/time/time.h"
 #include "base/timer/timer.h"
 #include "build/build_config.h"
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_150
 #include "components/ip_protection/common/masked_domain_list_manager.h"        // nogncheck
 #include "components/ip_protection/common/probabilistic_reveal_token_registry.h"// nogncheck
 #include "components/privacy_sandbox/masked_domain_list/masked_domain_list.pb.h"
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_150
 #include "mojo/public/cpp/bindings/pending_receiver.h"
 #include "mojo/public/cpp/bindings/pending_remote.h"
 #include "mojo/public/cpp/bindings/receiver.h"
@@ -337,7 +337,7 @@ class COMPONENT_EXPORT(NETWORK_SERVICE) NetworkService
     return tpcd_metadata_manager_.get();
   }
 
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_150
   ip_protection::MaskedDomainListManager* masked_domain_list_manager() const {
     return masked_domain_list_manager_.get();
   }
@@ -346,7 +346,7 @@ class COMPONENT_EXPORT(NETWORK_SERVICE) NetworkService
   probabilistic_reveal_token_registry() const {
     return probabilistic_reveal_token_registry_.get();
   }
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_150
 
   void set_host_resolver_factory_for_testing(
       std::unique_ptr<net::HostResolver::Factory> host_resolver_factory) {
@@ -518,7 +518,7 @@ class COMPONENT_EXPORT(NETWORK_SERVICE) NetworkService
   // this with |owned_network_contexts_|.
   std::set<raw_ptr<NetworkContext, SetExperimental>> network_contexts_;
 
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_150
   std::unique_ptr<ip_protection::MaskedDomainListManager>
       masked_domain_list_manager_;
 
@@ -526,7 +526,7 @@ class COMPONENT_EXPORT(NETWORK_SERVICE) NetworkService
   // Reveal Tokens.
   std::unique_ptr<ip_protection::ProbabilisticRevealTokenRegistry>
       probabilistic_reveal_token_registry_;
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_150
 
   // A per-process_id map of origins that are white-listed to allow
   // them to request raw headers for resources they request.


### PR DESCRIPTION
All the checks for M138 in the tree had been replaced by CHROMIUM_MILESTONE_LE_150 ones in #11689, and the 138 define was actually removed.

The #11507 cherry-pick in #11716, however, introduced new checks for 138 that were essentially always evaluating to false. Fix them too.

Bug: 522987128
Bug: 463991461