### PR TITLE
Partial revert "Disable E2E tests on all platforms"

### DIFF
--- a/.github/config/android-arm.json
+++ b/.github/config/android-arm.json
@@ -7,7 +7,7 @@
   "test_on_host": true,
   "test_on_device": true,
   "test_device_family": "android",
-  "test_e2e": false,
+  "test_e2e": true,
   "test_yts": true,
   "test_yts_playback": true,
   "comment_test_browser": "test_browser controls desktop browser tests on host. Set to false for Android because browser tests run on physical devices via test_on_device.",

--- a/.github/config/android-arm64.json
+++ b/.github/config/android-arm64.json
@@ -7,7 +7,7 @@
   "test_on_host": true,
   "test_on_device": true,
   "test_device_family": "android",
-  "test_e2e": false,
+  "test_e2e": true,
   "test_yts": true,
   "test_root_target": "//cobalt/android:cobalt_apk",
   "test_dimensions": {

--- a/.github/config/evergreen-arm-hardfp-rdk.json
+++ b/.github/config/evergreen-arm-hardfp-rdk.json
@@ -6,7 +6,7 @@
   "test_package": true,
   "test_on_device": true,
   "test_device_family": "rdk",
-  "test_e2e": true,
+  "test_e2e": false,
   "test_root_target": "//cobalt:gn_all",
   "test_dimensions": {
     "device_type": "rdk",

--- a/.github/config/evergreen-arm-hardfp-rdk.json
+++ b/.github/config/evergreen-arm-hardfp-rdk.json
@@ -6,7 +6,7 @@
   "test_package": true,
   "test_on_device": true,
   "test_device_family": "rdk",
-  "test_e2e": false,
+  "test_e2e": true,
   "test_root_target": "//cobalt:gn_all",
   "test_dimensions": {
     "device_type": "rdk",


### PR DESCRIPTION
Keeping e2e tests disabled on RDK due to a different breakage.

Reverts youtube/cobalt#12061:

"Disabling E2E tests on all platforms due to MobileHarness infra error: NoSuchMethodError in WebReleaseCodeClientPlugin."

Bug: 548690970

