### PR TITLE
Update Loader App Loading Priority for mmap in slot_management

### DIFF
--- a/starboard/loader_app/slot_management.cc
+++ b/starboard/loader_app/slot_management.cc
@@ -367,7 +367,10 @@ void* LoadSlotManagedLibrary(const std::string& app_key,
     elf_loader::CompressionType compression_type =
         elf_loader::CompressionType::kNone;
     struct stat info;
-    if (stat(lz4_compressed_lib_path.data(), &info) == 0) {
+    if (use_memory_mapped_file &&
+        stat(uncompressed_lib_path.data(), &info) == 0) {
+      lib_path = uncompressed_lib_path.data();
+    } else if (stat(lz4_compressed_lib_path.data(), &info) == 0) {
       lib_path = lz4_compressed_lib_path.data();
       compression_type = elf_loader::CompressionType::kLz4;
     } else if (stat(zstd_compressed_lib_path.data(), &info) == 0) {


### PR DESCRIPTION
If `--loader_use_mmap_file` is passed, let loader_app natively prioritize the uncompressed libcobalt.so in slot_management.cc for EG-full. Similar to PR 12116.

Bug: 537318952