### PR TITLE
[tvos] Fix build undefined symbol for system_hide_splash_screen.cc to tvos BUILD.gn

### DIFF
--- a/starboard/tvos/shared/BUILD.gn
+++ b/starboard/tvos/shared/BUILD.gn
@@ -88,6 +88,7 @@ static_library("starboard_platform") {
     "//starboard/shared/stub/decode_target_get_info.cc",
     "//starboard/shared/stub/media_can_change_type.cc",
     "//starboard/shared/stub/storage_write_record.cc",
+    "//starboard/shared/stub/system_hide_splash_screen.cc",
     "//starboard/shared/stub/system_symbolize.cc",
     "accessibility_extension.cc",
     "accessibility_extension.h",


### PR DESCRIPTION
system_hide_splash_screen.cc was recently added in https://github.com/youtube/cobalt/pull/12036. Need to add this to the tvOS deps.

Bug: 552586321