### PR TITLE
build: Update junit_mini_parser to output JSON

### DIFF
--- a/.github/actions/process_test_results/action.yaml
+++ b/.github/actions/process_test_results/action.yaml
@@ -83,7 +83,15 @@ runs:
           echo "  |_| |_____|____/ |_|   |____/ |_|/_/   \_\|_|  \___/ |____/ "
           echo
 
-          python3 cobalt/tools/junit_mini_parser.py ${RESULTS_GLOB}
+          if ! python3 cobalt/tools/junit_mini_parser.py "${result_xmls[@]}" > test_failures.json; then
+            if [ -s test_failures.json ]; then
+              jq -r '
+                .failing_tests | to_entries[] |
+                .key + "\n" + ([.value[] | "  [  FAILED  ] \(.name)" + (if .message != "" then "\n" + ("    " + (.message | gsub("\n"; "\n    "))) else "" end)] | join("\n"))
+              ' test_failures.json || true
+            fi
+          fi
+          rm -f test_failures.json
 
           echo "::error::${TARGET_NAME} has ${TESTS_FAILED} failed test(s)."
           exit_code=1

--- a/.github/actions/process_test_results/action.yaml
+++ b/.github/actions/process_test_results/action.yaml
@@ -85,17 +85,15 @@ runs:
           echo
 
           if ! python3 cobalt/tools/junit_mini_parser.py "${result_xmls[@]}" > test_failures.json; then
-            if [ -s test_failures.json ]; then
-              jq -r '
-                .failing_tests | to_entries[] |
-                .key, (
-                  .value[] |
-                  "  [  FAILED  ] \(.name)",
-                  (.message | select(. != "") | split("\n")[] | "    \(.)")
-                ),
-                ""
-              ' test_failures.json || true
-            fi
+            jq -r '
+              .failing_tests | to_entries[] |
+              .key, (
+                .value[] |
+                "  [  FAILED  ] \(.name)",
+                (.message | select(. != "") | split("\n")[] | "    \(.)")
+              ),
+              ""
+            ' test_failures.json
           fi
           rm -f test_failures.json
 

--- a/.github/actions/process_test_results/action.yaml
+++ b/.github/actions/process_test_results/action.yaml
@@ -84,18 +84,20 @@ runs:
           echo "  |_| |_____|____/ |_|   |____/ |_|/_/   \_\|_|  \___/ |____/ "
           echo
 
-          if ! python3 cobalt/tools/junit_mini_parser.py "${result_xmls[@]}" > test_failures.json; then
-            jq -r '
-              .failing_tests | to_entries[] |
-              .key, (
-                .value[] |
-                "  [  FAILED  ] \(.name)",
-                (.message | select(. != "") | split("\n")[] | "    \(.)")
-              ),
-              ""
-            ' test_failures.json
+          if [[ ${#result_xmls[@]} -gt 0 && -f "${result_xmls[0]}" ]]; then
+            if ! python3 cobalt/tools/junit_mini_parser.py "${result_xmls[@]}" > test_failures.json; then
+              jq -r '
+                .failing_tests | to_entries[] |
+                .key, (
+                  .value[] |
+                  "  [  FAILED  ] \(.name)",
+                  (.message | select(. != "") | split("\n")[] | "    \(.)")
+                ),
+                ""
+              ' test_failures.json
+            fi
+            rm -f test_failures.json
           fi
-          rm -f test_failures.json
 
           echo "::error::${TARGET_NAME} has ${TESTS_FAILED} failed test(s)."
           exit_code=1

--- a/.github/actions/process_test_results/action.yaml
+++ b/.github/actions/process_test_results/action.yaml
@@ -44,8 +44,9 @@ runs:
         TARGET_NAME: ${{ inputs.target_name }}
         GTEST_SHARDS: ${{ inputs.num_gtest_shards }}
       run: |
+        set -euo pipefail
         # Check test status.
-        if [ "$RUNNER_DEBUG" == "1" ]; then
+        if [ "${RUNNER_DEBUG:-0}" = "1" ]; then
           set -x
         fi
         exit_code=0
@@ -61,8 +62,8 @@ runs:
         result_xmls=(${RESULTS_GLOB})
         result_logs=(${LOG_GLOB})
 
-        if [ ${#result_xmls[@]} -ne ${GTEST_SHARDS} ]; then
-          if [ ${#result_logs[@]} -gt ${#result_xmls[@]} ]; then
+        if [ "${#result_xmls[@]}" -ne "${GTEST_SHARDS}" ]; then
+          if [ "${#result_logs[@]}" -gt "${#result_xmls[@]}" ]; then
             # If there are more log files than test results, test shards probably crashed.
             msg="Some targets likely crashed."
           else
@@ -73,7 +74,7 @@ runs:
           exit_code=1
         fi
 
-        if [ ${TESTS_FAILED:-0} -gt 0 ]; then
+        if [ "${TESTS_FAILED:-0}" -gt 0 ]; then
           # Print failed tests.
           echo
           echo " _____ _____ ____ _____   ____ _____   _   _____ _   _  ____  "
@@ -87,7 +88,12 @@ runs:
             if [ -s test_failures.json ]; then
               jq -r '
                 .failing_tests | to_entries[] |
-                .key + "\n" + ([.value[] | "  [  FAILED  ] \(.name)" + (if .message != "" then "\n" + ("    " + (.message | gsub("\n"; "\n    "))) else "" end)] | join("\n"))
+                .key, (
+                  .value[] |
+                  "  [  FAILED  ] \(.name)",
+                  (.message | select(. != "") | split("\n")[] | "    \(.)")
+                ),
+                ""
               ' test_failures.json || true
             fi
           fi
@@ -110,10 +116,10 @@ runs:
         DD_VERSION: 'v2.18.0'
         DD_SHA256SUM: 'adbe9b3a41faaf0b1d9702ba256cf8fa9e474c0cc8216f25e5b489c53d6f0a70  datadog-ci'
       run: |
-        set -x
+        set -ex
         download_url="https://github.com/DataDog/datadog-ci/releases/download/${DD_VERSION}/datadog-ci_linux-x64"
-        curl -L --fail ${download_url} --output datadog-ci
-        echo ${DD_SHA256SUM} | sha256sum --check
+        curl -L --fail "${download_url}" --output datadog-ci
+        echo "${DD_SHA256SUM}" | sha256sum --check
         chmod +x datadog-ci
       shell: bash
 
@@ -128,11 +134,11 @@ runs:
         DD_ENV: ci
         RESULTS_GLOB: ${{ inputs.results_glob }}
       run: |
-        set -x
+        set -ex
         # Enable globstar shell option for globstar paths e.g. /**/*.xml
         # globstar is not supported on macOS default bash (3.2), so we only enable it on non-macOS platforms.
         if [[ "$OSTYPE" != "darwin"* ]]; then
           shopt -s globstar
         fi
-        ./datadog-ci junit upload --service ${DD_SERVICE} ${RESULTS_GLOB}
+        ./datadog-ci junit upload --service "${DD_SERVICE}" ${RESULTS_GLOB}
       shell: bash

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1085,13 +1085,16 @@ jobs:
           if [[ ${#xml_files[@]} -gt 0 ]]; then
             if ! python3 cobalt/tools/junit_mini_parser.py "${xml_files[@]}" > test_failures.json; then
               failed=true
-              if [ -s test_failures.json ]; then
-                echo "Failing Tests Summary:"
-                jq -r '
-                  .failing_tests | to_entries[] |
-                  .key + "\n" + ([.value[] | "  [  FAILED  ] \(.name)" + (if .message != "" then "\n" + ("    " + (.message | gsub("\n"; "\n    "))) else "" end)] | join("\n"))
-                ' test_failures.json || true
-              fi
+              echo "Failing Tests Summary:"
+              jq -r '
+                .failing_tests | to_entries[] |
+                .key, (
+                  .value[] |
+                  "  [  FAILED  ] \(.name)",
+                  (.message | select(. != "") | split("\n")[] | "    \(.)")
+                ),
+                ""
+              ' test_failures.json
             fi
             rm -f test_failures.json
           fi

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1083,9 +1083,17 @@ jobs:
           xml_files=(results/**/*.xml)
           failed=false
           if [[ ${#xml_files[@]} -gt 0 ]]; then
-            if ! python3 cobalt/tools/junit_mini_parser.py "${xml_files[@]}"; then
+            if ! python3 cobalt/tools/junit_mini_parser.py "${xml_files[@]}" > test_failures.json; then
               failed=true
+              if [ -s test_failures.json ]; then
+                echo "Failing Tests Summary:"
+                jq -r '
+                  .failing_tests | to_entries[] |
+                  .key + "\n" + ([.value[] | "  [  FAILED  ] \(.name)" + (if .message != "" then "\n" + ("    " + (.message | gsub("\n"; "\n    "))) else "" end)] | join("\n"))
+                ' test_failures.json || true
+              fi
             fi
+            rm -f test_failures.json
           fi
 
           if [[ "${BUILD_RESULT}" != "success" ]]; then

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1082,7 +1082,7 @@ jobs:
           shopt -s globstar nullglob
           xml_files=(results/**/*.xml)
           failed=false
-          if [[ ${#xml_files[@]} -gt 0 ]]; then
+          if [[ ${#xml_files[@]} -gt 0 && -f "${xml_files[0]}" ]]; then
             if ! python3 cobalt/tools/junit_mini_parser.py "${xml_files[@]}" > test_failures.json; then
               failed=true
               echo "Failing Tests Summary:"

--- a/cobalt/tools/junit_mini_parser.py
+++ b/cobalt/tools/junit_mini_parser.py
@@ -1,5 +1,3 @@
-"""A simple util that prints failing tests from JUnit xml using only the Python
-standard library."""
 #!/usr/bin/env python3
 #
 # Copyright 2025 The Cobalt Authors. All Rights Reserved.
@@ -15,8 +13,11 @@ standard library."""
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""A simple util that prints failing tests from JUnit xml using only the Python
+standard library."""
 
 import collections
+import json
 import logging
 import os
 import sys
@@ -24,14 +25,15 @@ import xml.etree.ElementTree
 
 
 def find_failing_tests(
-    junit_xml_files: list[str]) -> dict[str, list[tuple[str, str]]]:
+    junit_xml_files: list[str]) -> dict[str, list[dict[str, str]]]:
   """Parses a list of JUnit XML files to find failing test cases.
 
   Args:
     junit_xml_files (list): A list of paths to JUnit XML files.
 
   Returns:
-    A map of test target -> list of (failing test name, failure message) tuples.
+    A map of test target -> list of dicts containing failing test name
+    and message.
   """
   failing_tests = collections.defaultdict(list)
   for filename in junit_xml_files:
@@ -53,7 +55,10 @@ def find_failing_tests(
               case.attrib.get('message', '').strip() + '\n' +
               (case.text or '').strip() for case in failures + errors)
           rel_path = os.path.relpath(filename)
-          failing_tests[rel_path].append((f'{suite_name}.{test_name}', message))
+          failing_tests[rel_path].append({
+              'name': f'{suite_name}.{test_name}',
+              'message': message.strip()
+          })
   return failing_tests
 
 
@@ -67,21 +72,9 @@ def main(xml_files: list[str]) -> int:
     1 if failing tests are found, 0 otherwise.
   """
   failing_tests = find_failing_tests(xml_files)
-
-  if failing_tests:
-    logging.info('Failing Tests:')
-    for target, test_status in sorted(failing_tests.items()):
-      logging.info('%s', target)
-      for test, message in sorted(test_status):
-        logging.info('[  FAILED  ] %s', test)
-        if message:
-          logging.info('%s', message)
-      logging.info('')  # Blank line between targets
-    return 1
-
-  if xml_files:
-    logging.info('No failing tests found in the test results.')
-  return 0
+  output = {'failing_tests': failing_tests}
+  print(json.dumps(output, indent=2))
+  return 1 if failing_tests else 0
 
 
 if __name__ == '__main__':

--- a/cobalt/tools/junit_mini_parser.py
+++ b/cobalt/tools/junit_mini_parser.py
@@ -18,7 +18,6 @@ standard library."""
 
 import collections
 import json
-import logging
 import os
 import sys
 import xml.etree.ElementTree
@@ -37,12 +36,7 @@ def find_failing_tests(
   """
   failing_tests = collections.defaultdict(list)
   for filename in junit_xml_files:
-    try:
-      tree = xml.etree.ElementTree.parse(filename)
-    except (xml.etree.ElementTree.ParseError, FileNotFoundError) as e:
-      logging.error('Failed to parse %s: %s', filename, e)
-      continue
-
+    tree = xml.etree.ElementTree.parse(filename)
     root = tree.getroot()
     for testsuite in root.findall('testsuite'):
       suite_name = testsuite.get('name', os.path.basename(filename))
@@ -78,11 +72,4 @@ def main(xml_files: list[str]) -> int:
 
 
 if __name__ == '__main__':
-  logging.basicConfig(level=logging.INFO, format='%(message)s')
-  if len(sys.argv) == 1:
-    logging.error('Usage: python junit_mini_parser.py '
-                  '<junit_xml_file1> <junit_xml_file2> ...')
-    logging.error('Please provide a list of JUnit XML files as command line '
-                  'arguments.')
-    sys.exit(2)
   sys.exit(main(sys.argv[1:]))

--- a/cobalt/tools/junit_mini_parser.py
+++ b/cobalt/tools/junit_mini_parser.py
@@ -18,6 +18,7 @@ standard library."""
 
 import collections
 import json
+import logging
 import os
 import sys
 import xml.etree.ElementTree
@@ -72,4 +73,11 @@ def main(xml_files: list[str]) -> int:
 
 
 if __name__ == '__main__':
+  logging.basicConfig(level=logging.INFO, format='%(message)s')
+  if len(sys.argv) == 1:
+    logging.error('Usage: python junit_mini_parser.py '
+                  '<junit_xml_file1> <junit_xml_file2> ...')
+    logging.error('Please provide a list of JUnit XML files as command line '
+                  'arguments.')
+    sys.exit(2)
   sys.exit(main(sys.argv[1:]))

--- a/cobalt/tools/junit_mini_parser_test.py
+++ b/cobalt/tools/junit_mini_parser_test.py
@@ -1,4 +1,3 @@
-"""Tests for the simple JUnit parser."""
 #!/usr/bin/env python3
 #
 # Copyright 2025 The Cobalt Authors. All Rights Reserved.
@@ -7,17 +6,20 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Tests for the simple JUnit parser."""
 
-import unittest
-from unittest.mock import mock_open, patch
+import io
+import json
 import logging
+import unittest
+from unittest.mock import MagicMock, mock_open, patch
 
 from cobalt.tools.junit_mini_parser import find_failing_tests, main
 
@@ -51,7 +53,12 @@ class TestFindFailingTests(unittest.TestCase):
     """
     with patch('builtins.open', mock_open(read_data=xml_content)):
       failing_tests = find_failing_tests(['report.xml'])
-      expected = {'report.xml': [('TestSuiteA.test_fail', 'Assertion failed')]}
+      expected = {
+          'report.xml': [{
+              'name': 'TestSuiteA.test_fail',
+              'message': 'Assertion failed\n...'
+          }]
+      }
       self.assertEqual(failing_tests, expected)
 
   def test_multiple_failing_tests_in_single_file(self):
@@ -72,9 +79,13 @@ class TestFindFailingTests(unittest.TestCase):
     with patch('builtins.open', mock_open(read_data=xml_content)):
       failing_tests = find_failing_tests(['results.xml'])
       expected = {
-          'results.xml': [('UnitTests.test_two_failed', 'Something went wrong'),
-                          ('UnitTests.test_three_errored',
-                           'An exception occurred')]
+          'results.xml': [{
+              'name': 'UnitTests.test_two_failed',
+              'message': 'Something went wrong\n...'
+          }, {
+              'name': 'UnitTests.test_three_errored',
+              'message': 'An exception occurred\n...'
+          }]
       }
       self.assertEqual(failing_tests, expected)
 
@@ -107,8 +118,14 @@ class TestFindFailingTests(unittest.TestCase):
         ]):
       failing_tests = find_failing_tests(['report1.xml', 'report2.xml'])
       expected = {
-          'report1.xml': [('ModuleA.test_beta_fail', 'Failure A')],
-          'report2.xml': [('ModuleB.test_gamma_error', 'Error B')]
+          'report1.xml': [{
+              'name': 'ModuleA.test_beta_fail',
+              'message': 'Failure A\n...'
+          }],
+          'report2.xml': [{
+              'name': 'ModuleB.test_gamma_error',
+              'message': 'Error B\n...'
+          }]
       }
       self.assertEqual(failing_tests, expected)
 
@@ -125,7 +142,10 @@ class TestFindFailingTests(unittest.TestCase):
     with patch('builtins.open', mock_open(read_data=xml_content)):
       failing_tests = find_failing_tests(['empty_name.xml'])
       expected = {
-          'empty_name.xml': [('empty_name.xml.test_one_failed', 'Fail msg')]
+          'empty_name.xml': [{
+              'name': 'empty_name.xml.test_one_failed',
+              'message': 'Fail msg\n...'
+          }]
       }
       self.assertEqual(failing_tests, expected)
 
@@ -133,24 +153,52 @@ class TestFindFailingTests(unittest.TestCase):
 class TestMain(unittest.TestCase):
   """Test cases for main function in junit_mini_parser."""
 
-  def setUp(self):
+  def setUp(self) -> None:
     logging.disable(logging.CRITICAL)
 
-  def tearDown(self):
+  def tearDown(self) -> None:
     logging.disable(logging.NOTSET)
 
   @patch('cobalt.tools.junit_mini_parser.find_failing_tests')
-  def test_main_success(self, mock_find):
+  @patch('sys.stdout', new_callable=io.StringIO)
+  def test_main_success(self, mock_stdout: io.StringIO,
+                        mock_find: MagicMock) -> None:
     mock_find.return_value = {}
-    self.assertEqual(main(['results.xml']), 0)
+    exit_code = main(['results.xml'])
+    self.assertEqual(exit_code, 0)
+
+    expected_output = {'failing_tests': {}}
+    self.assertEqual(json.loads(mock_stdout.getvalue()), expected_output)
 
   @patch('cobalt.tools.junit_mini_parser.find_failing_tests')
-  def test_main_failure(self, mock_find):
-    mock_find.return_value = {'results.xml': [('Test.fail', 'msg')]}
-    self.assertEqual(main(['results.xml']), 1)
+  @patch('sys.stdout', new_callable=io.StringIO)
+  def test_main_failure(self, mock_stdout: io.StringIO,
+                        mock_find: MagicMock) -> None:
+    mock_find.return_value = {
+        'results.xml': [{
+            'name': 'Test.fail',
+            'message': 'msg'
+        }]
+    }
+    exit_code = main(['results.xml'])
+    self.assertEqual(exit_code, 1)
 
-  def test_main_no_files(self):
-    self.assertEqual(main([]), 0)
+    expected_output = {
+        'failing_tests': {
+            'results.xml': [{
+                'name': 'Test.fail',
+                'message': 'msg'
+            }]
+        }
+    }
+    self.assertEqual(json.loads(mock_stdout.getvalue()), expected_output)
+
+  @patch('sys.stdout', new_callable=io.StringIO)
+  def test_main_no_files(self, mock_stdout: io.StringIO) -> None:
+    exit_code = main([])
+    self.assertEqual(exit_code, 0)
+    expected_output = {'failing_tests': {}}
+    self.assertEqual(json.loads(mock_stdout.getvalue()), expected_output)
 
 
 if __name__ == '__main__':

--- a/cobalt/tools/junit_mini_parser_test.py
+++ b/cobalt/tools/junit_mini_parser_test.py
@@ -17,7 +17,6 @@
 
 import io
 import json
-import logging
 import unittest
 from unittest.mock import MagicMock, mock_open, patch
 
@@ -152,12 +151,6 @@ class TestFindFailingTests(unittest.TestCase):
 
 class TestMain(unittest.TestCase):
   """Test cases for main function in junit_mini_parser."""
-
-  def setUp(self) -> None:
-    logging.disable(logging.CRITICAL)
-
-  def tearDown(self) -> None:
-    logging.disable(logging.NOTSET)
 
   @patch('cobalt.tools.junit_mini_parser.find_failing_tests')
   @patch('sys.stdout', new_callable=io.StringIO)


### PR DESCRIPTION
Update junit_mini_parser.py to output failing test results as
structured JSON instead of plain text. This change allows CI
workflows to more reliably parse and process test failure data.

GitHub Actions and workflows are updated to use jq for processing the
new output format. The parser test suite is also updated to improve
coverage and include type annotations.

Tag: agy
Conv: fb32e968-5c28-4711-9b18-47b6c44fd1d0
Bug: 546722232

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>