### PR TITLE
[autoroll] Configure max_commits per branch in autoroll_main workflow

### DIFF
--- a/.github/workflows/autoroll_main.yaml
+++ b/.github/workflows/autoroll_main.yaml
@@ -8,7 +8,6 @@ on:
       max_commits:
         description: 'Max number of commits to include on a single PR'
         type: number
-        default: 10
 
 permissions:
   contents: read
@@ -31,8 +30,8 @@ jobs:
       fail-fast: false
       matrix:
         branch: [
-          {source: main, target: 27.lts, autoroll: .github/AUTOROLL},
-          {source: main, target: staging, autoroll: .github/AUTOROLL},
+          {source: main, target: 27.lts, autoroll: .github/AUTOROLL, max_commits: 10},
+          {source: main, target: staging, autoroll: .github/AUTOROLL, max_commits: 50},
         ]
     steps:
       - name: Checkout code
@@ -84,7 +83,7 @@ jobs:
       - name: Cherry Pick Merged PRs
         id: autoroll
         env:
-          MAX_COMMITS: ${{ inputs.max_commits || 10 }}
+          MAX_COMMITS: ${{ inputs.max_commits || matrix.branch.max_commits }}
           SOURCE_BRANCH: ${{ matrix.branch.source }}
           TARGET_BRANCH: ${{ matrix.branch.target }}
           AUTOROLL_FILE: ${{ matrix.branch.autoroll }}


### PR DESCRIPTION
## Summary
- Remove default value for max_commits in workflow_dispatch inputs
- Configure max_commits per branch in matrix: 10 for 27.lts, 50 for staging
- Allow workflow_dispatch max_commits input to override matrix branch values