### PR TITLE
Enable RDK profiling for non-release builds

### DIFF
--- a/cobalt/build/gn.py
+++ b/cobalt/build/gn.py
@@ -77,10 +77,27 @@ _COBALT_TVOS_PLATFORMS = [
     'tvos-arm64-simulator',
 ]
 
+_PLATFORM_BUILD_TYPES = {
+    'evergreen-arm-hardfp-rdk': {
+        'debug': {
+            'arm_use_thumb': 'false',
+            'enable_profiling': 'true',
+        },
+        'devel': {
+            'arm_use_thumb': 'false',
+            'enable_profiling': 'true',
+        },
+        'qa': {
+            'arm_use_thumb': 'false',
+            'enable_profiling': 'true',
+        },
+    },
+}
+
 
 # pylint: disable=too-many-positional-arguments
-def write_build_args(build_args_path, platform_args_path, build_type, use_rbe,
-                     use_coverage, use_sccache):
+def write_build_args(build_args_path, platform, platform_args_path, build_type,
+                     use_rbe, use_coverage, use_sccache):
   """ Write args file, modifying settings for config"""
   gen_comment = '# Set by gn.py'
   with open(build_args_path, 'w', encoding='utf-8') as f:
@@ -91,6 +108,9 @@ def write_build_args(build_args_path, platform_args_path, build_type, use_rbe,
       f.write(f'cc_wrapper = "sccache" {gen_comment}\n')
     f.write(f'build_type = "{build_type}" {gen_comment}\n')
     for key, value in _BUILD_TYPES[build_type].items():
+      f.write(f'{key} = {value} {gen_comment}\n')
+    platform_build_types = _PLATFORM_BUILD_TYPES.get(platform, {})
+    for key, value in platform_build_types.get(build_type, {}).items():
       f.write(f'{key} = {value} {gen_comment}\n')
     f.write(f'import("//{platform_args_path}")\n')
     if use_coverage:
@@ -112,8 +132,14 @@ def configure_out_directory(out_directory: str, platform: str, build_type: str,
     print('WARNING: Existing args.gn was overwritten. '
           'Old file was copied to stale_args.gn.')
 
-  write_build_args(dst_args_gn_file, src_args_gn_file, build_type, use_rbe,
-                   use_coverage, use_sccache)
+  write_build_args(
+      dst_args_gn_file,
+      platform,
+      src_args_gn_file,
+      build_type,
+      use_rbe,
+      use_coverage=use_coverage,
+      use_sccache=use_sccache)
 
   gn_command = ['gn', 'gen', out_directory] + gn_gen_args
   print('Running', ' '.join(gn_command))

--- a/cobalt/build/gn.py
+++ b/cobalt/build/gn.py
@@ -77,27 +77,28 @@ _COBALT_TVOS_PLATFORMS = [
     'tvos-arm64-simulator',
 ]
 
+_RDK_NON_RELEASE_DEFAULTS = {
+    'arm_use_thumb': 'false',
+    'enable_profiling': 'true',
+}
+
 _PLATFORM_BUILD_TYPES = {
     'evergreen-arm-hardfp-rdk': {
-        'debug': {
-            'arm_use_thumb': 'false',
-            'enable_profiling': 'true',
-        },
-        'devel': {
-            'arm_use_thumb': 'false',
-            'enable_profiling': 'true',
-        },
-        'qa': {
-            'arm_use_thumb': 'false',
-            'enable_profiling': 'true',
-        },
+        'debug': _RDK_NON_RELEASE_DEFAULTS,
+        'devel': _RDK_NON_RELEASE_DEFAULTS,
+        'qa': _RDK_NON_RELEASE_DEFAULTS,
     },
 }
 
 
 # pylint: disable=too-many-positional-arguments
-def write_build_args(build_args_path, platform, platform_args_path, build_type,
-                     use_rbe, use_coverage, use_sccache):
+def write_build_args(build_args_path,
+                     platform_args_path,
+                     build_type,
+                     use_rbe,
+                     use_coverage,
+                     use_sccache,
+                     platform=None):
   """ Write args file, modifying settings for config"""
   gen_comment = '# Set by gn.py'
   with open(build_args_path, 'w', encoding='utf-8') as f:
@@ -109,9 +110,10 @@ def write_build_args(build_args_path, platform, platform_args_path, build_type,
     f.write(f'build_type = "{build_type}" {gen_comment}\n')
     for key, value in _BUILD_TYPES[build_type].items():
       f.write(f'{key} = {value} {gen_comment}\n')
-    platform_build_types = _PLATFORM_BUILD_TYPES.get(platform, {})
-    for key, value in platform_build_types.get(build_type, {}).items():
-      f.write(f'{key} = {value} {gen_comment}\n')
+    if platform:
+      platform_build_types = _PLATFORM_BUILD_TYPES.get(platform, {})
+      for key, value in platform_build_types.get(build_type, {}).items():
+        f.write(f'{key} = {value} {gen_comment}\n')
     f.write(f'import("//{platform_args_path}")\n')
     if use_coverage:
       f.write(f'import("//cobalt/build/configs/coverage.gn") {gen_comment}\n')
@@ -134,12 +136,12 @@ def configure_out_directory(out_directory: str, platform: str, build_type: str,
 
   write_build_args(
       dst_args_gn_file,
-      platform,
       src_args_gn_file,
       build_type,
       use_rbe,
       use_coverage=use_coverage,
-      use_sccache=use_sccache)
+      use_sccache=use_sccache,
+      platform=platform)
 
   gn_command = ['gn', 'gen', out_directory] + gn_gen_args
   print('Running', ' '.join(gn_command))

--- a/cobalt/build/test_gn.py
+++ b/cobalt/build/test_gn.py
@@ -50,9 +50,8 @@ class GnTest(unittest.TestCase):
     build_type = 'devel'
     expected_out_dir = f'out/{platform}_{build_type}'
     expected_args_content_part = (
-        'use_siso = false # Set by gn.py\n'
         'use_remoteexec = true # Set by gn.py\n'
-        'rbe_cfg_dir = rebase_path("//cobalt/reclient_cfgs") # Set by gn.py\n'
+        'use_siso = true # Set by gn.py\n'
         'build_type = "devel" # Set by gn.py\n'
         'symbol_level = 1 # Set by gn.py\n'
         'is_debug = false # Set by gn.py\n'
@@ -87,6 +86,65 @@ class GnTest(unittest.TestCase):
         expected_out_dir,
         '--check',
     ])
+
+  @mock.patch('pathlib.Path.mkdir')
+  @mock.patch('os.path.exists', return_value=False)
+  @mock.patch('os.rename')
+  @mock.patch('builtins.open', new_callable=mock.mock_open)
+  @mock.patch('subprocess.check_call')
+  def test_rdk_platform_build_types(  # pylint: disable=too-many-positional-arguments
+      self, mock_check_call, mock_open, mock_rename, mock_exists, mock_mkdir):
+    del mock_rename, mock_exists  # unused
+    platform = 'evergreen-arm-hardfp-rdk'
+    build_type = 'qa'
+    expected_out_dir = f'out/{platform}_{build_type}'
+    expected_args_content_part = (
+        'build_type = "qa" # Set by gn.py\n'
+        'symbol_level = 1 # Set by gn.py\n'
+        'is_official_build = true # Set by gn.py\n'
+        'exclude_unwind_tables = false # Set by gn.py\n'
+        'arm_use_thumb = false # Set by gn.py\n'
+        'enable_profiling = true # Set by gn.py\n'
+        'import("//cobalt/build/configs/evergreen-arm-hardfp-rdk/args.gn")\n')
+
+    sys.argv = [
+        'gn.py',
+        '-p',
+        platform,
+        '-c',
+        build_type,
+    ]
+
+    gn.main()
+
+    mock_mkdir.assert_called_once_with(parents=True, exist_ok=True)
+    mock_open.assert_called_once()
+    handle = mock_open()
+    actual_content = "".join(
+        [call.args[0] for call in handle.write.call_args_list])
+    self.assertIn(expected_args_content_part, actual_content)
+
+    mock_check_call.assert_called_once_with([
+        'gn',
+        'gen',
+        expected_out_dir,
+        '--check',
+    ])
+
+  @mock.patch('builtins.open', new_callable=mock.mock_open)
+  def test_write_build_args_backward_compatibility(self, mock_open):
+    # Verify write_build_args can be called positionally without platform
+    # argument.
+    gn.write_build_args('/tmp/args.gn',
+                        'cobalt/build/configs/android-x86/args.gn', 'devel',
+                        True, False, False)
+    handle = mock_open()
+    actual_content = "".join(
+        [call.args[0] for call in handle.write.call_args_list])
+    self.assertIn('use_remoteexec = true # Set by gn.py\n', actual_content)
+    self.assertIn('build_type = "devel" # Set by gn.py\n', actual_content)
+    self.assertIn('import("//cobalt/build/configs/android-x86/args.gn")\n',
+                  actual_content)
 
   @mock.patch('pathlib.Path.mkdir')
   @mock.patch('os.path.exists', return_value=False)

--- a/starboard/build/config/modular/BUILD.gn
+++ b/starboard/build/config/modular/BUILD.gn
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import("//build/config/compiler/compiler.gni")
 import("//starboard/build/config/sanitizers.gni")
 
 config("modular") {
@@ -90,12 +89,6 @@ config("modular") {
       #         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
       "-Wno-sign-compare",
     ]
-
-    if (!cobalt_is_release_build || can_unwind_with_frame_pointers) {
-      cflags += [ "-fno-omit-frame-pointer" ]
-    } else {
-      cflags += [ "-fomit-frame-pointer" ]
-    }
   }
 
   if (use_asan) {

--- a/starboard/build/config/modular/arm/BUILD.gn
+++ b/starboard/build/config/modular/arm/BUILD.gn
@@ -26,9 +26,4 @@ config("arm") {
     # Force char to be signed.
     "-fsigned-char",
   ]
-
-  # Force ARM 32-bit mode (-marm) instead of Thumb-2 mode for non-release builds.
-  if (!cobalt_is_release_build) {
-    cflags += [ "-marm" ]
-  }
 }


### PR DESCRIPTION
Relocate platform-specific build configurations from modular GN files to
gn.py. This explicitly sets arm_use_thumb to false and
enable_profiling to true for RDK non-release builds (debug, devel, and
qa). This ensures that frame pointer profiling and the heap profiler
work as expected on RDK by providing consistent configuration in the
main build script.

Test: run this script to check if the heap profiler is enabled correctly: https://paste.googleplex.com/6337159620067328

Bug: 537412550
