### PR TITLE
loader_app: Fix drain file expiry bypass by future timestamps

### DIFF
--- a/components/update_client/url_fetcher_downloader.cc
+++ b/components/update_client/url_fetcher_downloader.cc
@@ -271,7 +271,7 @@ void UrlFetcherDownloader::StartURLFetch(const GURL& url) {
       base::BindRepeating(&UrlFetcherDownloader::OnDownloadProgress, this),
       base::BindOnce(&UrlFetcherDownloader::OnNetworkFetcherComplete, this));
 #else
-  file_path_ = download_dir_.AppendASCII(url.ExtractFileName());
+  file_path_ = download_dir_.AppendASCII("update.crx");
   LOG(INFO) << "UrlFetcherDownloader::StartURLFetch, file_path_ =" << file_path_.value().c_str();
   network_fetcher_->DownloadToFile(
       url, file_path_,

--- a/starboard/loader_app/drain_file.cc
+++ b/starboard/loader_app/drain_file.cc
@@ -72,8 +72,12 @@ int64_t ExtractTimestamp(const std::string& str) {
 
 bool IsExpired(const std::string& filename) {
   const int64_t timestamp = ExtractTimestamp(filename);
-  return timestamp + kDrainFileMaximumAgeUsec <
-         PosixTimeToWindowsTime(CurrentPosixTime());
+  const int64_t current_time = PosixTimeToWindowsTime(CurrentPosixTime());
+  // A drain file is considered expired if it is older than the max age,
+  // or if its timestamp has been artificially placed far in the future
+  // (e.g. more than the max age later than the current timestamp).
+  return timestamp < current_time - kDrainFileMaximumAgeUsec ||
+         timestamp > current_time + kDrainFileMaximumAgeUsec;
 }
 
 std::vector<std::string> FindAllWithPrefix(const std::string& dir,


### PR DESCRIPTION
loader_app: Fix drain file expiry bypass by future timestamps

An attacker can exploit the fact that a spoofed Omaha response causes
UrlFetcherDownloader to create a drain file in the installation slot with
a server-chosen filename. An attacker can choose a filename with a timestamp
far in the future, rendering the slot permanently unavailable for future updates.

This commit implements the following fixes:
1. Updates IsExpired() in drain_file.cc to explicitly handle timestamps far
   in the future, treating them as instantly expired. It also protects against
   signed integer overflow when analyzing huge attacker-provided timestamps.
2. Directly overrides the server-chosen filename by renaming any downloaded
   CRX payload to "update.crx" within the Starboard-specific branch of
   UrlFetcherDownloader, preventing it from ever matching the drain file
   prefix ("d_").

Bug: 545796260
TAG=agy
