### PR TITLE
evergreen: Decouple ICU data file (icudtl.dat) from libcobalt.so

### DIFF
--- a/cobalt/build/configs/evergreen_common.gn
+++ b/cobalt/build/configs/evergreen_common.gn
@@ -1,3 +1,6 @@
 import("//cobalt/build/configs/linux_modular_common.gn")
 
 use_evergreen = true
+
+# Decouple ICU data file to reduce runtime anonymous dirty memory footprint (b/552779286).
+icu_use_data_file = true

--- a/cobalt/build/configs/evergreen_common.gn
+++ b/cobalt/build/configs/evergreen_common.gn
@@ -2,5 +2,5 @@ import("//cobalt/build/configs/linux_modular_common.gn")
 
 use_evergreen = true
 
-# Decouple ICU data file to reduce runtime anonymous dirty memory footprint (b/552779286).
+# Decouple ICU data file to reduce runtime anonymous dirty memory footprint.
 icu_use_data_file = true

--- a/cobalt/common/icu_init/init.cc
+++ b/cobalt/common/icu_init/init.cc
@@ -128,8 +128,8 @@ void InitializeIcuDatabase() {
     return;
   }
 
-  // Inform the OS that the mapped data is accessed randomly.
-  madvise(icu_data, length, MADV_RANDOM);
+  // Inform the OS that the mapped data is accessed sequentially.
+  madvise(icu_data, length, MADV_NORMAL);
 
   if (!SetIcuDataPointer(icu_data)) {
     PrintIcuNotLoadedWarning();

--- a/cobalt/common/icu_init/init.h
+++ b/cobalt/common/icu_init/init.h
@@ -15,6 +15,19 @@
 #ifndef COBALT_COMMON_ICU_INIT_INIT_H_
 #define COBALT_COMMON_ICU_INIT_INIT_H_
 
+// These macro definitions are cloned natively from Chromium's
+// base/i18n/icu_util.h. They are strictly required because the C-preprocessor
+// silently evaluates any undefined macros as 0. Without these explicitly
+// defined, the architectural compiler directives inside init.cc evaluating
+// ICU_UTIL_DATA_IMPL will silently collapse into `#if (0 == 0)` and physically
+// strip the file loader from decoupled binaries.
+#ifndef ICU_UTIL_DATA_FILE
+#define ICU_UTIL_DATA_FILE 0
+#endif
+#ifndef ICU_UTIL_DATA_STATIC
+#define ICU_UTIL_DATA_STATIC 1
+#endif
+
 namespace cobalt {
 namespace common {
 namespace icu_init {

--- a/starboard/nplb/BUILD.gn
+++ b/starboard/nplb/BUILD.gn
@@ -347,6 +347,7 @@ test("nplb") {
   }
 
   deps = [
+    "//base:i18n",
     "//starboard:starboard_group",
     "//starboard:starboard_test_main",
     "//starboard/common",
@@ -373,7 +374,10 @@ test("nplb") {
     deps += [ "//starboard/nplb/compiler_compliance:cpp20_supported" ]
   }
 
-  data_deps = [ "//starboard/nplb/testdata/file_tests:nplb_file_tests_data" ]
+  data_deps = [
+    "//base:i18n",
+    "//starboard/nplb/testdata/file_tests:nplb_file_tests_data",
+  ]
 
   if (is_starboard) {
     sources += [

--- a/starboard/nplb/BUILD.gn
+++ b/starboard/nplb/BUILD.gn
@@ -347,7 +347,7 @@ test("nplb") {
   }
 
   deps = [
-    "//base:i18n",
+    "//cobalt/common/icu_init",
     "//starboard:starboard_group",
     "//starboard:starboard_test_main",
     "//starboard/common",
@@ -375,8 +375,8 @@ test("nplb") {
   }
 
   data_deps = [
-    "//base:i18n",
     "//starboard/nplb/testdata/file_tests:nplb_file_tests_data",
+    "//third_party/icu:icudata",
   ]
 
   if (is_starboard) {

--- a/starboard/nplb/posix_compliance/posix_compliance_icu.h
+++ b/starboard/nplb/posix_compliance/posix_compliance_icu.h
@@ -1,0 +1,33 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_NPLB_POSIX_COMPLIANCE_POSIX_COMPLIANCE_ICU_H_
+#define STARBOARD_NPLB_POSIX_COMPLIANCE_POSIX_COMPLIANCE_ICU_H_
+
+#include <mutex>
+
+#include "base/i18n/icu_util.h"
+
+namespace starboard {
+namespace nplb {
+
+inline void InitializePosixIcuOnce() {
+  static std::once_flag flag;
+  std::call_once(flag, []() { base::i18n::InitializeICU(); });
+}
+
+}  // namespace nplb
+}  // namespace starboard
+
+#endif  // STARBOARD_NPLB_POSIX_COMPLIANCE_POSIX_COMPLIANCE_ICU_H_

--- a/starboard/nplb/posix_compliance/posix_compliance_icu.h
+++ b/starboard/nplb/posix_compliance/posix_compliance_icu.h
@@ -17,14 +17,14 @@
 
 #include <mutex>
 
-#include "base/i18n/icu_util.h"
+#include "cobalt/common/icu_init/init.h"
 
 namespace starboard {
 namespace nplb {
 
 inline void InitializePosixIcuOnce() {
   static std::once_flag flag;
-  std::call_once(flag, []() { base::i18n::InitializeICU(); });
+  std::call_once(flag, []() { cobalt::common::icu_init::EnsureInitialized(); });
 }
 
 }  // namespace nplb

--- a/starboard/nplb/posix_compliance/posix_locale_set_test.cc
+++ b/starboard/nplb/posix_compliance/posix_locale_set_test.cc
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "build/build_config.h"
+#include "starboard/nplb/posix_compliance/posix_compliance_icu.h"
 #include "starboard/nplb/posix_compliance/posix_locale_helpers.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -39,6 +40,7 @@ namespace nplb {
 class ScopedLocale {
  public:
   ScopedLocale() {
+    starboard::nplb::InitializePosixIcuOnce();
     original_locale_ = setlocale(LC_ALL, NULL);
     // It's possible for setlocale to return NULL if the locale is invalid,
     // but we assume the initial state is valid. We duplicate the string

--- a/starboard/nplb/posix_compliance/scoped_tz_set.h
+++ b/starboard/nplb/posix_compliance/scoped_tz_set.h
@@ -17,6 +17,7 @@
 
 #include <time.h>
 
+#include "starboard/nplb/posix_compliance/posix_compliance_icu.h"
 #include "starboard/nplb/posix_compliance/scoped_tz_environment.h"
 
 namespace nplb {
@@ -28,6 +29,7 @@ class ScopedTzSet : public ScopedTzEnvironment {
  public:
   explicit ScopedTzSet(const char* new_tz_value)
       : ScopedTzEnvironment(new_tz_value) {
+    starboard::nplb::InitializePosixIcuOnce();
     tzset();
   }
 


### PR DESCRIPTION
### Summary
Decouples the ICU data file (`icudtl.dat`) from `libcobalt.so` by setting `icu_use_data_file = true` to prevent `.rodata` from forcing it into non-reclaimable dirty anonymous pages at runtime. This PR also rigidly scopes the ICU C++ initialization cleanly inside targeted NPLB POSIX RAII wrappers to isolate test states.

### Memory Impact
* **Steady PMF:** **-8.24 MB**
* **Steady VmRSS:** **-6.11 MB**
* **Peak VmRSS:** **-4.88 MB**

n=15 per arm: [4K](http://rdklabs.tv/experiments/exp-e8cdd78d-ff92-4da7-807f-1fd63fbdc1d0/visualization), [Shorts](http://rdklabs.tv/experiments/exp-f316cfa1-4ee1-4b74-9025-473c26a3c64e/visualization)

**Storage Footprint Tradeoff:** 
* `libcobalt.lz4`: -3.03 MB
* `icudtl.dat` (Standalone): +6.83 MB
* **Net Package Size Calculation:** **+3.48 MB**

*Deploying the `.dat` file natively uncompressed incurs a 7 MB package increase ( ~3.5 MB per slot) , but cleanly yields nearly 6 MB of dynamic runtime RAM savings.*

Bug: 552779286
TAG=agy
CONV=b9781e22-8064-42c7-958e-045878def62c
