### PR TITLE
tvos: Route data:application/x-mpegurl URLs to URL player

### DIFF
--- a/media/starboard/url_player_demuxer.cc
+++ b/media/starboard/url_player_demuxer.cc
@@ -31,6 +31,13 @@
 namespace media {
 
 bool IsHlsUrl(const GURL& url) {
+  if (url.SchemeIs("data")) {
+    auto spec = url.spec();
+    auto comma = spec.find(',');
+    auto header = (comma != std::string::npos) ? spec.substr(0, comma) : spec;
+    return header.find("application/x-mpegurl") != std::string::npos ||
+           header.find("application/vnd.apple.mpegurl") != std::string::npos;
+  }
   auto path = url.path_piece();
   return path.ends_with(".m3u8") ||
          path.find("hls_variant") != std::string_view::npos;

--- a/starboard/tvos/shared/media_can_play_mime_and_key_system.mm
+++ b/starboard/tvos/shared/media_can_play_mime_and_key_system.mm
@@ -92,7 +92,7 @@ SbMediaSupportType SbMediaCanPlayMimeAndKeySystem(const char* mime,
 
   // "application/x-mpegURL" is for hls content and will use UrlPlayer. The
   // supported types are different from SbPlayer.
-  if (strncmp(kUrlPlayerMimeType, mime, kUrlPlayerMimeTypeLength) == 0) {
+  if (strncasecmp(kUrlPlayerMimeType, mime, kUrlPlayerMimeTypeLength) == 0) {
     auto mime_type = starboard::MimeType::Create(mime);
     if (!mime_type) {
       return kSbMediaSupportTypeNotSupported;

--- a/third_party/blink/renderer/core/frame/csp/source_list_directive.cc
+++ b/third_party/blink/renderer/core/frame/csp/source_list_directive.cc
@@ -10,6 +10,7 @@
 #endif
 
 #include "base/feature_list.h"
+#include "build/build_config.h"
 #include "services/network/public/mojom/content_security_policy.mojom-blink.h"
 #include "third_party/blink/renderer/core/frame/csp/content_security_policy.h"
 #include "third_party/blink/renderer/core/frame/csp/csp_source.h"
@@ -97,6 +98,19 @@ CSPCheckResult CSPSourceListAllows(
       IsIPInLocalNetwork(url.Host().Utf8())) {
     return network::CSPCheckResult(true);
   }
+#if BUILDFLAG(IS_IOS_TVOS)
+  // Allow HLS data: URLs to bypass CSP on tvOS for the URL player path.
+  if (url.ProtocolIs("data")) {
+    String url_string = url.GetString();
+    wtf_size_t comma = url_string.find(',');
+    String header =
+        (comma != kNotFound) ? url_string.Left(comma) : url_string;
+    if (header.Contains("application/x-mpegurl") ||
+        header.Contains("application/vnd.apple.mpegurl")) {
+      return network::CSPCheckResult(true);
+    }
+  }
+#endif  // BUILDFLAG(IS_IOS_TVOS)
 #endif
 
   return CSPCheckResult::Blocked();

--- a/third_party/blink/renderer/core/html/media/html_media_element.cc
+++ b/third_party/blink/renderer/core/html/media/html_media_element.cc
@@ -306,7 +306,16 @@ bool CanLoadURL(const KURL& url, const String& content_type_str) {
   if (content_mime_type != "application/octet-stream" ||
       content_type_codecs.empty()) {
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
+#if BUILDFLAG(IS_IOS_TVOS)
+    // content_type_str is empty for src-attribute loads. Use the MIME
+    // type for data: URLs extracted by MimeTypeFromDataURL() so
+    // CanPlayMimeAndKeySystem receives a valid type instead of an
+    // empty string.
+    auto ascii = content_type_str.empty() ? content_mime_type.Ascii()
+                                          : content_type_str.Ascii();
+#else
     auto ascii = content_type_str.Ascii();
+#endif  // BUILDFLAG(IS_IOS_TVOS)
     SbMediaSupportType support_type =
         ::media::GetSbMediaInterface()->CanPlayMimeAndKeySystem(ascii.c_str(),
                                                                 "");
@@ -322,8 +331,7 @@ bool CanLoadURL(const KURL& url, const String& content_type_str) {
         result = MIMETypeRegistry::kSupported;
         break;
     }
-    LOG(INFO) << __func__ << "(" << content_type_str.Ascii() << ") -> "
-              << result;
+    LOG(INFO) << __func__ << "(" << ascii << ") -> " << result;
     return result;
 #else   // BUILDFLAG(USE_STARBOARD_MEDIA)
     return MIMETypeRegistry::SupportsMediaMIMEType(content_mime_type,


### PR DESCRIPTION
YouTube sends HLS multivariant playlists as inline data: URLs with MIME
type application/x-mpegurl. These were getting blocked in three places:
IsHlsUrl() didn't recognize data: scheme URLs, CanLoadURL() passed an
empty content type to CanPlayMimeAndKeySystem for src-attribute loads,
and CSP enforcement rejected them since YouTube's media-src doesn't
include data: (old Cobalt never enforced CSP on media sources).

Fix all three: add data: scheme handling to IsHlsUrl(), fall back to
the extracted MIME type in CanLoadURL() when content_type_str is empty,
and allow HLS data: URLs through CSP on tvOS.

Bug: 549709371