### PR TITLE
android: Ensure MediaCrypto session exists before querying DRM metrics

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaDrmBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaDrmBridge.java
@@ -364,11 +364,15 @@ public class MediaDrmBridge {
     if (Build.VERSION.SDK_INT < 28) {
       return null;
     }
+    // Ensure a media crypto session exists so the DRM plugin has metrics populated.
+    if (mMediaCryptoSession == null) {
+      createMediaCryptoSessionWithAppProvisioning();
+    }
     byte[] metrics;
     try {
       metrics = mMediaDrm.getPropertyByteArray("metrics");
     } catch (Exception e) {
-      Log.e(TAG, "Failed to retrieve DRM Metrics.");
+      Log.e(TAG, "Failed to retrieve DRM Metrics.", e);
       return null;
     }
     return Base64.encode(metrics, Base64.NO_PADDING | Base64.NO_WRAP | Base64.URL_SAFE);

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaDrmBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaDrmBridge.java
@@ -364,12 +364,12 @@ public class MediaDrmBridge {
     if (Build.VERSION.SDK_INT < 28) {
       return null;
     }
-    // Ensure a media crypto session exists so the DRM plugin has metrics populated.
-    if (mMediaCryptoSession == null) {
-      createMediaCryptoSessionWithAppProvisioning();
-    }
     byte[] metrics;
     try {
+      // Ensure a media crypto session exists so the DRM plugin has metrics populated.
+      if (mMediaCryptoSession == null) {
+        createMediaCryptoSession();
+      }
       metrics = mMediaDrm.getPropertyByteArray("metrics");
     } catch (Exception e) {
       Log.e(TAG, "Failed to retrieve DRM Metrics.", e);


### PR DESCRIPTION
Now MediaDrm sessions are created on demand rather than eagerly at startup. If a client queries MediaKeys.getMetrics() before creating an EME session, the underlying DRM plugin may fail to provide metrics because no session exists yet.

This PR ensures the MediaCrypto session is initialized when getMetricsInBase64() is called.

Bug: 547679347