### PR TITLE
Use a separate quota manager for cache

### DIFF
--- a/cobalt/browser/cache_storage_browsertest.cc
+++ b/cobalt/browser/cache_storage_browsertest.cc
@@ -1,0 +1,371 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <optional>
+#include <string>
+
+#include "cobalt/testing/browser_tests/browser/test_shell.h"
+#include "cobalt/testing/browser_tests/content_browser_test.h"
+#include "content/browser/storage_partition_impl.h"
+#include "content/public/browser/browser_context.h"
+#include "content/public/browser/storage_partition.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/browser_test_utils.h"
+#include "net/test/embedded_test_server/embedded_test_server.h"
+#include "storage/browser/quota/quota_settings.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
+
+namespace cobalt {
+
+class CacheStorageBrowserTest : public content::ContentBrowserTest {
+ public:
+  CacheStorageBrowserTest() = default;
+  ~CacheStorageBrowserTest() = default;
+
+  void SetUpOnMainThread() override {
+    content::ContentBrowserTest::SetUpOnMainThread();
+
+    content::StoragePartition* partition = shell()
+                                               ->web_contents()
+                                               ->GetBrowserContext()
+                                               ->GetDefaultStoragePartition();
+    auto* partition_impl =
+        static_cast<content::StoragePartitionImpl*>(partition);
+    if (partition_impl->HasSplitQuota()) {
+      SetSplitQuotaSettings();
+    } else {
+      SetUnifiedQuotaSettings();
+    }
+  }
+
+  void TearDownOnMainThread() override {
+    content::StoragePartition::SetDefaultQuotaSettingsForTesting(nullptr);
+    content::StoragePartition::SetDefaultCacheQuotaSettingsForTesting(nullptr);
+  }
+
+ private:
+  // Simulates a configuration where persistent storage and cache are on
+  // separate physical partitions with different sizes.
+  void SetSplitQuotaSettings() {
+    static storage::QuotaSettings quota_settings(
+        storage::GetHardCodedSettings(1 * 1024 * 1024));
+    content::StoragePartition::SetDefaultQuotaSettingsForTesting(
+        &quota_settings);
+
+    static storage::QuotaSettings cache_quota_settings(
+        storage::GetHardCodedSettings(24 * 1024 * 1024));
+    content::StoragePartition::SetDefaultCacheQuotaSettingsForTesting(
+        &cache_quota_settings);
+  }
+
+  void SetUnifiedQuotaSettings() {
+    static storage::QuotaSettings quota_settings(
+        storage::GetHardCodedSettings(24 * 1024 * 1024));
+    content::StoragePartition::SetDefaultQuotaSettingsForTesting(
+        &quota_settings);
+  }
+};
+
+// Verifies that the cache quota is applied to cache writes.
+// Calls cache.put to write 2MiB of binary data to Cache Storage, then reads it
+// back via cache.match to verify size and data integrity.
+IN_PROC_BROWSER_TEST_F(CacheStorageBrowserTest, PutTwoMegabyteToCache) {
+  ASSERT_TRUE(embedded_test_server()->Start());
+  GURL url = embedded_test_server()->GetURL("/title1.html");
+  ASSERT_TRUE(NavigateToURL(shell()->web_contents(), url));
+
+  const char kScript[] = R"(
+    (async () => {
+      try {
+        const cache = await caches.open('cobalt-test-2mb-cache');
+        const kPayloadSize = 2 * 1024 * 1024;
+        const payload = new Uint8Array(kPayloadSize);
+        for (let i = 0; i < kPayloadSize; i++) {
+          payload[i] = i % 256;
+        }
+
+        const request = new Request('/test-2mb-resource');
+        const response = new Response(payload, {
+          status: 200,
+          statusText: 'OK',
+          headers: {
+            'Content-Type': 'application/octet-stream',
+            'X-Custom-Header': 'Cobalt2MBTest'
+          }
+        });
+
+        await cache.put(request, response);
+
+        // Retrieve the cached response.
+        const matched = await cache.match(request);
+        if (!matched) {
+          return { success: false, error: 'cache.match returned null' };
+        }
+        if (matched.status !== 200) {
+          return { success: false, error: `Unexpected status code: ${matched.status}` };
+        }
+        if (matched.headers.get('X-Custom-Header') !== 'Cobalt2MBTest') {
+          return { success: false, error: 'Custom header mismatch' };
+        }
+        if (matched.headers.get('Content-Type') !== 'application/octet-stream') {
+          return { success: false, error: 'Content-Type header mismatch' };
+        }
+
+        // Verify that the retrieved payload size matches what was written.
+        const buffer = await matched.arrayBuffer();
+        if (buffer.byteLength !== kPayloadSize) {
+          return {
+            success: false,
+            error: `Byte length mismatch: expected ${kPayloadSize}, got ${buffer.byteLength}`
+          };
+        }
+
+        const resultView = new Uint8Array(buffer);
+        for (let i = 0; i < kPayloadSize; i += 4096) {
+          if (resultView[i] !== (i % 256)) {
+            return {
+              success: false,
+              error: `Byte mismatch at offset ${i}: expected ${i % 256}, got ${resultView[i]}`
+            };
+          }
+        }
+
+        return { success: true };
+      } catch (err) {
+        return { success: false, error: err.toString() };
+      }
+    })()
+  )";
+
+  content::EvalJsResult eval_result =
+      content::EvalJs(shell()->web_contents(), kScript);
+  ASSERT_TRUE(eval_result.value.is_dict());
+  const base::Value::Dict& dict = eval_result.value.GetDict();
+
+  std::optional<bool> success = dict.FindBool("success");
+  ASSERT_TRUE(success.has_value())
+      << "Response dictionary missing 'success' field";
+
+  if (!*success) {
+    const std::string* error = dict.FindString("error");
+    FAIL() << "JavaScript cache.put test failed: "
+           << (error ? *error : "Unknown error");
+  }
+  EXPECT_TRUE(*success);
+}
+
+// Calls cache.put to write 1MB, then overwrites the entry with a new payload.
+IN_PROC_BROWSER_TEST_F(CacheStorageBrowserTest, PutAndOverwriteOneMegabyte) {
+  ASSERT_TRUE(embedded_test_server()->Start());
+  GURL url = embedded_test_server()->GetURL("/title1.html");
+  ASSERT_TRUE(NavigateToURL(shell()->web_contents(), url));
+
+  const char kScript[] = R"(
+    (async () => {
+      try {
+        const cache = await caches.open('cobalt-test-overwrite-cache');
+        const kPayloadSize = 1024 * 1024;
+        const request = new Request('/test-overwrite-1mb');
+
+        // Initial 1MB payload (pattern A: i % 256)
+        const payloadA = new Uint8Array(kPayloadSize);
+        for (let i = 0; i < kPayloadSize; i++) {
+          payloadA[i] = i % 256;
+        }
+        await cache.put(request, new Response(payloadA, {
+          headers: { 'X-Version': 'A' }
+        }));
+
+        // Replacement 1MB payload (pattern B: (255 - (i % 256)))
+        const payloadB = new Uint8Array(kPayloadSize);
+        for (let i = 0; i < kPayloadSize; i++) {
+          payloadB[i] = 255 - (i % 256);
+        }
+        await cache.put(request, new Response(payloadB, {
+          headers: { 'X-Version': 'B' }
+        }));
+
+        // Verify the replaced entry
+        const matched = await cache.match(request);
+        if (!matched) {
+          return { success: false, error: 'cache.match returned null after overwrite' };
+        }
+        if (matched.headers.get('X-Version') !== 'B') {
+          return { success: false, error: 'Header did not update to version B' };
+        }
+
+        const buffer = await matched.arrayBuffer();
+        if (buffer.byteLength !== kPayloadSize) {
+          return { success: false, error: `Size mismatch after overwrite: ${buffer.byteLength}` };
+        }
+
+        const resultView = new Uint8Array(buffer);
+        for (let i = 0; i < kPayloadSize; i += 4096) {
+          const expectedByte = 255 - (i % 256);
+          if (resultView[i] !== expectedByte) {
+            return {
+              success: false,
+              error: `Byte mismatch in overwritten payload at ${i}: expected ${expectedByte}, got ${resultView[i]}`
+            };
+          }
+        }
+
+        return { success: true };
+      } catch (err) {
+        return { success: false, error: err.toString() };
+      }
+    })()
+  )";
+
+  content::EvalJsResult eval_result =
+      content::EvalJs(shell()->web_contents(), kScript);
+  ASSERT_TRUE(eval_result.value.is_dict());
+  const base::Value::Dict& dict = eval_result.value.GetDict();
+
+  std::optional<bool> success = dict.FindBool("success");
+  ASSERT_TRUE(success.has_value())
+      << "Response dictionary missing 'success' field";
+  if (!*success) {
+    const std::string* error = dict.FindString("error");
+    FAIL() << "JavaScript cache.put overwrite test failed: "
+           << (error ? *error : "Unknown error");
+  }
+  EXPECT_TRUE(*success);
+}
+
+// Verifies that the persistent storage quota is applied correctly.
+// Attempts to write 2MB to persistent storage via IndexedDB. This write should
+// fail since persistent storage quota is 1MB.
+// If this is a platform that only supports unified quota, we explicitly lower
+// the quota to 1MB here so we don't have to write a 24MB payload.
+IN_PROC_BROWSER_TEST_F(CacheStorageBrowserTest,
+                       FailToWriteMoreThanOneMegabyteToPersistentStorage) {
+  ASSERT_TRUE(embedded_test_server()->Start());
+  GURL url = embedded_test_server()->GetURL("/title1.html");
+  ASSERT_TRUE(NavigateToURL(shell()->web_contents(), url));
+
+  static storage::QuotaSettings quota_settings(
+      storage::GetHardCodedSettings(1024 * 1024));
+  content::StoragePartition::SetDefaultQuotaSettingsForTesting(&quota_settings);
+
+  const char kScript[] = R"(
+    (async () => {
+      try {
+        const db = await new Promise((resolve, reject) => {
+          const req = indexedDB.open('cobalt-test-quota-db', 1);
+          req.onupgradeneeded = (e) => {
+            e.target.result.createObjectStore('test-store', { keyPath: 'id' });
+          };
+          req.onsuccess = (e) => resolve(e.target.result);
+          req.onerror = (e) => reject(req.error);
+        });
+
+        // Generate uncompressible data using XOR-shift PRNG so Snappy compression does not shrink it.
+        // This usually shouldn't matter but is done just in case.
+        const kChunkSize = 256 * 1024; // 256KB
+        const chunk = new Uint8Array(kChunkSize);
+        let state = 123456789;
+        for (let i = 0; i < kChunkSize; i++) {
+          state ^= (state << 13);
+          state ^= (state >> 17);
+          state ^= (state << 5);
+          chunk[i] = state & 0xFF;
+        }
+
+        // Attempt to write up to 2MB in chunks (8 * 256KB = 2MB). This should fail.
+        let writeFailedWithQuota = false;
+        let errorDetail = '';
+
+        for (let i = 0; i < 8; i++) {
+          const writeResult = await new Promise((resolve) => {
+            let settled = false;
+            const tx = db.transaction(['test-store'], 'readwrite');
+            const store = tx.objectStore('test-store');
+            const putReq = store.put({ id: i, data: chunk });
+
+            putReq.onerror = (e) => {
+              e.preventDefault();
+              e.stopPropagation();
+            };
+
+            tx.oncomplete = () => {
+              if (!settled) {
+                settled = true;
+                resolve({ success: true });
+              }
+            };
+
+            tx.onabort = () => {
+              if (!settled) {
+                settled = true;
+                const err = tx.error ? tx.error.name : (putReq.error ? putReq.error.name : 'Aborted');
+                resolve({ success: false, error: err });
+              }
+            };
+
+            tx.onerror = (e) => {
+              e.preventDefault();
+              if (!settled) {
+                settled = true;
+                const err = tx.error ? tx.error.name : (putReq.error ? putReq.error.name : 'Error');
+                resolve({ success: false, error: err });
+              }
+            };
+          });
+
+          if (!writeResult.success) {
+            writeFailedWithQuota = true;
+            errorDetail = writeResult.error;
+            break;
+          }
+        }
+
+        if (!writeFailedWithQuota) {
+          return {
+            failedAsExpected: false,
+            error: 'Writing 2MB to persistent storage unexpectedly succeeded!'
+          };
+        }
+
+        return {
+          failedAsExpected: true,
+          errorName: errorDetail
+        };
+      } catch (err) {
+        return {
+          failedAsExpected: true,
+          errorName: err.toString()
+        };
+      }
+    })()
+  )";
+
+  content::EvalJsResult eval_result =
+      content::EvalJs(shell()->web_contents(), kScript);
+  ASSERT_TRUE(eval_result.value.is_dict());
+  const base::Value::Dict& dict = eval_result.value.GetDict();
+
+  std::optional<bool> failed_as_expected = dict.FindBool("failedAsExpected");
+  ASSERT_TRUE(failed_as_expected.has_value())
+      << "Response dictionary missing 'failedAsExpected' field";
+
+  if (!*failed_as_expected) {
+    const std::string* error = dict.FindString("error");
+    FAIL() << "Test failed: " << (error ? *error : "Unknown error");
+  }
+  EXPECT_TRUE(*failed_as_expected);
+}
+
+}  // namespace cobalt

--- a/cobalt/shell/browser/shell_content_browser_client.cc
+++ b/cobalt/shell/browser/shell_content_browser_client.cc
@@ -393,6 +393,21 @@ ShellContentBrowserClient::GetGeneratedCodeCacheSettings(
   return GeneratedCodeCacheSettings(true, 0, context->GetPath());
 }
 
+base::FilePath ShellContentBrowserClient::GetCacheStoragePath(
+    content::BrowserContext* browser_context,
+    const base::FilePath& partition_path,
+    const base::FilePath& relative_partition_path) {
+#if BUILDFLAG(IS_STARBOARD)
+  base::FilePath cache_dir;
+  if (base::PathService::Get(base::DIR_CACHE, &cache_dir)) {
+    return relative_partition_path.empty()
+               ? cache_dir
+               : cache_dir.Append(relative_partition_path);
+  }
+#endif
+  return base::FilePath();
+}
+
 base::OnceClosure ShellContentBrowserClient::SelectClientCertificate(
     BrowserContext* browser_context,
     int process_id,

--- a/cobalt/shell/browser/shell_content_browser_client.h
+++ b/cobalt/shell/browser/shell_content_browser_client.h
@@ -107,6 +107,10 @@ class ShellContentBrowserClient : public ContentBrowserClient {
       bool* out_block_is_site_setting_specific) override;
   GeneratedCodeCacheSettings GetGeneratedCodeCacheSettings(
       content::BrowserContext* context) override;
+  base::FilePath GetCacheStoragePath(
+      content::BrowserContext* browser_context,
+      const base::FilePath& partition_path,
+      const base::FilePath& relative_partition_path) override;
   base::OnceClosure SelectClientCertificate(
       BrowserContext* browser_context,
       int process_id,

--- a/cobalt/testing/browser_tests/BUILD.gn
+++ b/cobalt/testing/browser_tests/BUILD.gn
@@ -217,6 +217,7 @@ test("cobalt_browsertests") {
 
   sources = [
     # TODO(b/458665232): restore browser tests in M138.
+    "//cobalt/browser/cache_storage_browsertest.cc",
     "//cobalt/browser/h5vcc_runtime_browsertest.cc",
     "//cobalt/browser/h5vcc_system_browsertest.cc",
 

--- a/cobalt/testing/filters/evergreen-arm-hardfp-rdk/cobalt_browsertests_loader_filter.json
+++ b/cobalt/testing/filters/evergreen-arm-hardfp-rdk/cobalt_browsertests_loader_filter.json
@@ -1,5 +1,6 @@
 {
   "failing_tests": [
+    "CacheStorageBrowserTest.*",
     "NavigationBrowserTest.*",
     "CommitNavigationRaceBrowserTest.*",
     "SubresourceLoadingTest.*",

--- a/content/browser/storage_partition_impl.cc
+++ b/content/browser/storage_partition_impl.cc
@@ -195,10 +195,6 @@
 #include "content/public/browser/cdm_storage_data_model.h"
 #endif  // BUILDFLAG(ENABLE_LIBRARY_CDMS)
 
-#if BUILDFLAG(IS_STARBOARD)
-#include "base/path_service.h"
-#endif
-
 using CookieDeletionFilter = network::mojom::CookieDeletionFilter;
 using CookieDeletionFilterPtr = network::mojom::CookieDeletionFilterPtr;
 
@@ -925,9 +921,7 @@ class StoragePartitionImpl::DataDeletionHelper {
       const base::FilePath& path,
       DOMStorageContextWrapper* dom_storage_context,
       storage::QuotaManager* quota_manager,
-#if BUILDFLAG(IS_STARBOARD)
       storage::QuotaManager* cache_quota_manager,
-#endif
       storage::SpecialStoragePolicy* special_storage_policy,
       storage::FileSystemContext* filesystem_context,
       network::mojom::CookieManager* cookie_manager,
@@ -1403,13 +1397,12 @@ void StoragePartitionImpl::Initialize(
   base::FilePath cache_storage_path = path;
   scoped_refptr<storage::QuotaManagerProxy> cache_quota_manager_proxy =
       quota_manager_proxy;
-#if BUILDFLAG(IS_STARBOARD)
   if (!is_in_memory()) {
-    base::FilePath cache_dir;
-    if (base::PathService::Get(base::DIR_CACHE, &cache_dir)) {
-      cache_storage_path = config_.partition_domain().empty()
-                               ? cache_dir
-                               : cache_dir.Append(relative_partition_path_);
+    base::FilePath custom_cache_path =
+        GetContentClient()->browser()->GetCacheStoragePath(
+            browser_context_, partition_path_, relative_partition_path_);
+    if (!custom_cache_path.empty()) {
+      cache_storage_path = custom_cache_path;
       cache_quota_context_ = base::MakeRefCounted<QuotaContext>(
           is_in_memory(), cache_storage_path,
           browser_context_->GetSpecialStoragePolicy(),
@@ -1424,7 +1417,6 @@ void StoragePartitionImpl::Initialize(
       }
     }
   }
-#endif
 
   cache_storage_control_wrapper_ = std::make_unique<CacheStorageControlWrapper>(
       GetIOThreadTaskRunner({}), cache_storage_path,
@@ -1782,16 +1774,10 @@ QuotaContext* StoragePartitionImpl::GetQuotaContext() {
   return quota_context_.get();
 }
 
-#if BUILDFLAG(IS_COBALT)
 bool StoragePartitionImpl::HasSplitQuota() {
   DCHECK(initialized_);
-#if BUILDFLAG(IS_STARBOARD)
   return cache_quota_context_ != nullptr;
-#else
-  return false;
-#endif  // BUILDFLAG(IS_STARBOARD)
 }
-#endif  // BUILDFLAG(IS_COBALT)
 
 storage::mojom::CacheStorageControl*
 StoragePartitionImpl::GetCacheStorageControl() {
@@ -2874,9 +2860,7 @@ void StoragePartitionImpl::ClearDataImpl(
       storage_key, filter_builder, std::move(storage_key_policy_matcher),
       std::move(cookie_deletion_filter), GetPath(), dom_storage_context_.get(),
       quota_manager_.get(),
-#if BUILDFLAG(IS_STARBOARD)
       cache_quota_manager_.get(),
-#endif
       special_storage_policy_.get(), filesystem_context_.get(),
       GetCookieManagerForBrowserProcess(),
 #if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
@@ -3064,9 +3048,7 @@ void StoragePartitionImpl::DataDeletionHelper::ClearDataOnUIThread(
     const base::FilePath& path,
     DOMStorageContextWrapper* dom_storage_context,
     storage::QuotaManager* quota_manager,
-#if BUILDFLAG(IS_STARBOARD)
     storage::QuotaManager* cache_quota_manager,
-#endif
     storage::SpecialStoragePolicy* special_storage_policy,
     storage::FileSystemContext* filesystem_context,
     network::mojom::CookieManager* cookie_manager,
@@ -3204,7 +3186,6 @@ void StoragePartitionImpl::DataDeletionHelper::ClearDataOnUIThread(
                        storage_key, storage_policy_ref,
                        combined_storage_key_matcher, perform_storage_cleanup,
                        CreateTaskCompletionClosure(TracingDataType::kQuota)));
-#if BUILDFLAG(IS_STARBOARD)
     if (cache_quota_manager &&
         (remove_mask_ & REMOVE_DATA_MASK_CACHE_STORAGE)) {
       GetIOThreadTaskRunner({})->PostTask(
@@ -3216,7 +3197,6 @@ void StoragePartitionImpl::DataDeletionHelper::ClearDataOnUIThread(
                          combined_storage_key_matcher, perform_storage_cleanup,
                          CreateTaskCompletionClosure(TracingDataType::kQuota)));
     }
-#endif
   }
 
   if (remove_mask_ & REMOVE_DATA_MASK_LOCAL_STORAGE) {
@@ -3727,7 +3707,6 @@ void StoragePartitionImpl::GetQuotaSettings(
       storage::GetDefaultDeviceInfoHelper(), std::move(callback));
 }
 
-#if BUILDFLAG(IS_STARBOARD)
 void StoragePartitionImpl::GetCacheQuotaSettings(
     storage::OptionalQuotaSettingsCallback callback) {
   if (g_test_cache_quota_settings) {
@@ -3736,21 +3715,16 @@ void StoragePartitionImpl::GetCacheQuotaSettings(
     return;
   }
 
-  base::FilePath cache_path = GetPath();
-  if (!is_in_memory()) {
-    base::FilePath cache_dir;
-    if (base::PathService::Get(base::DIR_CACHE, &cache_dir)) {
-      cache_path = config_.partition_domain().empty()
-                       ? cache_dir
-                       : cache_dir.Append(relative_partition_path_);
-    }
+  base::FilePath cache_path =
+      GetContentClient()->browser()->GetCacheStoragePath(
+          browser_context_, partition_path_, relative_partition_path_);
+  if (cache_path.empty()) {
+    cache_path = GetPath();
   }
 
-  storage::GetNominalDynamicSettings(
-      cache_path, browser_context_->IsOffTheRecord(),
-      storage::GetDefaultDeviceInfoHelper(), std::move(callback));
+  GetContentClient()->browser()->GetCacheQuotaSettings(
+      browser_context_, cache_path, std::move(callback));
 }
-#endif
 
 void StoragePartitionImpl::InitNetworkContext() {
   network::mojom::NetworkContextParamsPtr context_params =

--- a/content/browser/storage_partition_impl.cc
+++ b/content/browser/storage_partition_impl.cc
@@ -209,6 +209,7 @@ namespace {
 using Type = StoragePartitionImpl::ContextType;
 
 const storage::QuotaSettings* g_test_quota_settings;
+const storage::QuotaSettings* g_test_cache_quota_settings;
 
 // Timeout after which the
 // History.ClearBrowsingData.Duration.SlowTasks180sStoragePartition histogram is
@@ -924,6 +925,9 @@ class StoragePartitionImpl::DataDeletionHelper {
       const base::FilePath& path,
       DOMStorageContextWrapper* dom_storage_context,
       storage::QuotaManager* quota_manager,
+#if BUILDFLAG(IS_STARBOARD)
+      storage::QuotaManager* cache_quota_manager,
+#endif
       storage::SpecialStoragePolicy* special_storage_policy,
       storage::FileSystemContext* filesystem_context,
       network::mojom::CookieManager* cookie_manager,
@@ -1397,6 +1401,8 @@ void StoragePartitionImpl::Initialize(
           std::move(file_system_access_context), GetIOThreadTaskRunner({}));
 
   base::FilePath cache_storage_path = path;
+  scoped_refptr<storage::QuotaManagerProxy> cache_quota_manager_proxy =
+      quota_manager_proxy;
 #if BUILDFLAG(IS_STARBOARD)
   if (!is_in_memory()) {
     base::FilePath cache_dir;
@@ -1404,13 +1410,25 @@ void StoragePartitionImpl::Initialize(
       cache_storage_path = config_.partition_domain().empty()
                                ? cache_dir
                                : cache_dir.Append(relative_partition_path_);
+      cache_quota_context_ = base::MakeRefCounted<QuotaContext>(
+          is_in_memory(), cache_storage_path,
+          browser_context_->GetSpecialStoragePolicy(),
+          base::BindRepeating(&StoragePartitionImpl::GetCacheQuotaSettings,
+                              weak_factory_.GetWeakPtr()));
+      cache_quota_manager_ = cache_quota_context_->quota_manager();
+      cache_quota_manager_proxy = cache_quota_manager_->proxy();
+      if (storage_notification_service) {
+        cache_quota_manager_->SetStoragePressureCallback(
+            storage_notification_service
+                ->CreateThreadSafePressureNotificationCallback());
+      }
     }
   }
 #endif
 
   cache_storage_control_wrapper_ = std::make_unique<CacheStorageControlWrapper>(
       GetIOThreadTaskRunner({}), cache_storage_path,
-      browser_context_->GetSpecialStoragePolicy(), quota_manager_proxy,
+      browser_context_->GetSpecialStoragePolicy(), cache_quota_manager_proxy,
       ChromeBlobStorageContext::GetRemoteFor(browser_context_));
 
   service_worker_context_ = new ServiceWorkerContextWrapper(browser_context_);
@@ -1763,6 +1781,17 @@ QuotaContext* StoragePartitionImpl::GetQuotaContext() {
   DCHECK(initialized_);
   return quota_context_.get();
 }
+
+#if BUILDFLAG(IS_COBALT)
+bool StoragePartitionImpl::HasSplitQuota() {
+  DCHECK(initialized_);
+#if BUILDFLAG(IS_STARBOARD)
+  return cache_quota_context_ != nullptr;
+#else
+  return false;
+#endif  // BUILDFLAG(IS_STARBOARD)
+}
+#endif  // BUILDFLAG(IS_COBALT)
 
 storage::mojom::CacheStorageControl*
 StoragePartitionImpl::GetCacheStorageControl() {
@@ -2844,20 +2873,18 @@ void StoragePartitionImpl::ClearDataImpl(
   helper->ClearDataOnUIThread(
       storage_key, filter_builder, std::move(storage_key_policy_matcher),
       std::move(cookie_deletion_filter), GetPath(), dom_storage_context_.get(),
-      quota_manager_.get(), special_storage_policy_.get(),
-      filesystem_context_.get(), GetCookieManagerForBrowserProcess(),
+      quota_manager_.get(),
+#if BUILDFLAG(IS_STARBOARD)
+      cache_quota_manager_.get(),
+#endif
+      special_storage_policy_.get(), filesystem_context_.get(),
+      GetCookieManagerForBrowserProcess(),
 #if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
-      interest_group_manager_.get(),
-      attribution_manager_.get(),
-      aggregation_service_.get(),
-      private_aggregation_manager_.get(),
+      interest_group_manager_.get(), attribution_manager_.get(),
+      aggregation_service_.get(), private_aggregation_manager_.get(),
       shared_storage_manager_.get(),
 #else
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
+      nullptr, nullptr, nullptr, nullptr, nullptr,
 #endif
 #if BUILDFLAG(ENABLE_LIBRARY_CDMS)
       cdm_storage_manager_.get(),
@@ -3037,6 +3064,9 @@ void StoragePartitionImpl::DataDeletionHelper::ClearDataOnUIThread(
     const base::FilePath& path,
     DOMStorageContextWrapper* dom_storage_context,
     storage::QuotaManager* quota_manager,
+#if BUILDFLAG(IS_STARBOARD)
+    storage::QuotaManager* cache_quota_manager,
+#endif
     storage::SpecialStoragePolicy* special_storage_policy,
     storage::FileSystemContext* filesystem_context,
     network::mojom::CookieManager* cookie_manager,
@@ -3174,6 +3204,19 @@ void StoragePartitionImpl::DataDeletionHelper::ClearDataOnUIThread(
                        storage_key, storage_policy_ref,
                        combined_storage_key_matcher, perform_storage_cleanup,
                        CreateTaskCompletionClosure(TracingDataType::kQuota)));
+#if BUILDFLAG(IS_STARBOARD)
+    if (cache_quota_manager &&
+        (remove_mask_ & REMOVE_DATA_MASK_CACHE_STORAGE)) {
+      GetIOThreadTaskRunner({})->PostTask(
+          FROM_HERE,
+          base::BindOnce(&DataDeletionHelper::ClearQuotaManagedDataOnIOThread,
+                         base::Unretained(this),
+                         base::WrapRefCounted(cache_quota_manager), begin, end,
+                         storage_key, storage_policy_ref,
+                         combined_storage_key_matcher, perform_storage_cleanup,
+                         CreateTaskCompletionClosure(TracingDataType::kQuota)));
+    }
+#endif
   }
 
   if (remove_mask_ & REMOVE_DATA_MASK_LOCAL_STORAGE) {
@@ -3684,6 +3727,31 @@ void StoragePartitionImpl::GetQuotaSettings(
       storage::GetDefaultDeviceInfoHelper(), std::move(callback));
 }
 
+#if BUILDFLAG(IS_STARBOARD)
+void StoragePartitionImpl::GetCacheQuotaSettings(
+    storage::OptionalQuotaSettingsCallback callback) {
+  if (g_test_cache_quota_settings) {
+    // For debugging tests harness can inject settings.
+    std::move(callback).Run(*g_test_cache_quota_settings);
+    return;
+  }
+
+  base::FilePath cache_path = GetPath();
+  if (!is_in_memory()) {
+    base::FilePath cache_dir;
+    if (base::PathService::Get(base::DIR_CACHE, &cache_dir)) {
+      cache_path = config_.partition_domain().empty()
+                       ? cache_dir
+                       : cache_dir.Append(relative_partition_path_);
+    }
+  }
+
+  storage::GetNominalDynamicSettings(
+      cache_path, browser_context_->IsOffTheRecord(),
+      storage::GetDefaultDeviceInfoHelper(), std::move(callback));
+}
+#endif
+
 void StoragePartitionImpl::InitNetworkContext() {
   network::mojom::NetworkContextParamsPtr context_params =
       network::mojom::NetworkContextParams::New();
@@ -3810,6 +3878,11 @@ void StoragePartitionImpl::CreateURLLoaderFactoryForBrowserProcessInternal(
 void StoragePartition::SetDefaultQuotaSettingsForTesting(
     const storage::QuotaSettings* settings) {
   g_test_quota_settings = settings;
+}
+
+void StoragePartition::SetDefaultCacheQuotaSettingsForTesting(
+    const storage::QuotaSettings* settings) {
+  g_test_cache_quota_settings = settings;
 }
 
 mojo::PendingRemote<network::mojom::CookieAccessObserver>
@@ -3951,8 +4024,7 @@ StoragePartitionImpl::URLLoaderNetworkContext::~URLLoaderNetworkContext() =
 StoragePartitionImpl::URLLoaderNetworkContext
 StoragePartitionImpl::URLLoaderNetworkContext::CreateForRenderFrameHost(
     GlobalRenderFrameHostId render_frame_host_id) {
-  return StoragePartitionImpl::URLLoaderNetworkContext(
-      render_frame_host_id);
+  return StoragePartitionImpl::URLLoaderNetworkContext(render_frame_host_id);
 }
 
 StoragePartitionImpl::URLLoaderNetworkContext

--- a/content/browser/storage_partition_impl.cc
+++ b/content/browser/storage_partition_impl.cc
@@ -205,7 +205,9 @@ namespace {
 using Type = StoragePartitionImpl::ContextType;
 
 const storage::QuotaSettings* g_test_quota_settings;
+#if BUILDFLAG(IS_COBALT)
 const storage::QuotaSettings* g_test_cache_quota_settings;
+#endif
 
 // Timeout after which the
 // History.ClearBrowsingData.Duration.SlowTasks180sStoragePartition histogram is
@@ -921,7 +923,9 @@ class StoragePartitionImpl::DataDeletionHelper {
       const base::FilePath& path,
       DOMStorageContextWrapper* dom_storage_context,
       storage::QuotaManager* quota_manager,
+#if BUILDFLAG(IS_COBALT)
       storage::QuotaManager* cache_quota_manager,
+#endif
       storage::SpecialStoragePolicy* special_storage_policy,
       storage::FileSystemContext* filesystem_context,
       network::mojom::CookieManager* cookie_manager,
@@ -1395,8 +1399,7 @@ void StoragePartitionImpl::Initialize(
           std::move(file_system_access_context), GetIOThreadTaskRunner({}));
 
   base::FilePath cache_storage_path = path;
-  scoped_refptr<storage::QuotaManagerProxy> cache_quota_manager_proxy =
-      quota_manager_proxy;
+#if BUILDFLAG(IS_COBALT)
   if (!is_in_memory()) {
     base::FilePath custom_cache_path =
         GetContentClient()->browser()->GetCacheStoragePath(
@@ -1409,7 +1412,7 @@ void StoragePartitionImpl::Initialize(
           base::BindRepeating(&StoragePartitionImpl::GetCacheQuotaSettings,
                               weak_factory_.GetWeakPtr()));
       cache_quota_manager_ = cache_quota_context_->quota_manager();
-      cache_quota_manager_proxy = cache_quota_manager_->proxy();
+      quota_manager_proxy = cache_quota_manager_->proxy();
       if (storage_notification_service) {
         cache_quota_manager_->SetStoragePressureCallback(
             storage_notification_service
@@ -1417,10 +1420,11 @@ void StoragePartitionImpl::Initialize(
       }
     }
   }
+#endif  // BUILDFLAG(IS_COBALT)
 
   cache_storage_control_wrapper_ = std::make_unique<CacheStorageControlWrapper>(
       GetIOThreadTaskRunner({}), cache_storage_path,
-      browser_context_->GetSpecialStoragePolicy(), cache_quota_manager_proxy,
+      browser_context_->GetSpecialStoragePolicy(), quota_manager_proxy,
       ChromeBlobStorageContext::GetRemoteFor(browser_context_));
 
   service_worker_context_ = new ServiceWorkerContextWrapper(browser_context_);
@@ -1774,10 +1778,12 @@ QuotaContext* StoragePartitionImpl::GetQuotaContext() {
   return quota_context_.get();
 }
 
+#if BUILDFLAG(IS_COBALT)
 bool StoragePartitionImpl::HasSplitQuota() {
   DCHECK(initialized_);
   return cache_quota_context_ != nullptr;
 }
+#endif  // BUILDFLAG(IS_COBALT)
 
 storage::mojom::CacheStorageControl*
 StoragePartitionImpl::GetCacheStorageControl() {
@@ -2860,15 +2866,23 @@ void StoragePartitionImpl::ClearDataImpl(
       storage_key, filter_builder, std::move(storage_key_policy_matcher),
       std::move(cookie_deletion_filter), GetPath(), dom_storage_context_.get(),
       quota_manager_.get(),
+#if BUILDFLAG(IS_COBALT)
       cache_quota_manager_.get(),
+#endif
       special_storage_policy_.get(), filesystem_context_.get(),
       GetCookieManagerForBrowserProcess(),
 #if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
-      interest_group_manager_.get(), attribution_manager_.get(),
-      aggregation_service_.get(), private_aggregation_manager_.get(),
+      interest_group_manager_.get(),
+      attribution_manager_.get(),
+      aggregation_service_.get(),
+      private_aggregation_manager_.get(),
       shared_storage_manager_.get(),
 #else
-      nullptr, nullptr, nullptr, nullptr, nullptr,
+      nullptr,
+      nullptr,
+      nullptr,
+      nullptr,
+      nullptr,
 #endif
 #if BUILDFLAG(ENABLE_LIBRARY_CDMS)
       cdm_storage_manager_.get(),
@@ -3048,7 +3062,9 @@ void StoragePartitionImpl::DataDeletionHelper::ClearDataOnUIThread(
     const base::FilePath& path,
     DOMStorageContextWrapper* dom_storage_context,
     storage::QuotaManager* quota_manager,
+#if BUILDFLAG(IS_COBALT)
     storage::QuotaManager* cache_quota_manager,
+#endif
     storage::SpecialStoragePolicy* special_storage_policy,
     storage::FileSystemContext* filesystem_context,
     network::mojom::CookieManager* cookie_manager,
@@ -3186,6 +3202,7 @@ void StoragePartitionImpl::DataDeletionHelper::ClearDataOnUIThread(
                        storage_key, storage_policy_ref,
                        combined_storage_key_matcher, perform_storage_cleanup,
                        CreateTaskCompletionClosure(TracingDataType::kQuota)));
+#if BUILDFLAG(IS_COBALT)
     if (cache_quota_manager &&
         (remove_mask_ & REMOVE_DATA_MASK_CACHE_STORAGE)) {
       GetIOThreadTaskRunner({})->PostTask(
@@ -3197,6 +3214,7 @@ void StoragePartitionImpl::DataDeletionHelper::ClearDataOnUIThread(
                          combined_storage_key_matcher, perform_storage_cleanup,
                          CreateTaskCompletionClosure(TracingDataType::kQuota)));
     }
+#endif  // BUILDFLAG(IS_COBALT)
   }
 
   if (remove_mask_ & REMOVE_DATA_MASK_LOCAL_STORAGE) {
@@ -3707,6 +3725,7 @@ void StoragePartitionImpl::GetQuotaSettings(
       storage::GetDefaultDeviceInfoHelper(), std::move(callback));
 }
 
+#if BUILDFLAG(IS_COBALT)
 void StoragePartitionImpl::GetCacheQuotaSettings(
     storage::OptionalQuotaSettingsCallback callback) {
   if (g_test_cache_quota_settings) {
@@ -3725,6 +3744,7 @@ void StoragePartitionImpl::GetCacheQuotaSettings(
   GetContentClient()->browser()->GetCacheQuotaSettings(
       browser_context_, cache_path, std::move(callback));
 }
+#endif  // BUILDFLAG(IS_COBALT)
 
 void StoragePartitionImpl::InitNetworkContext() {
   network::mojom::NetworkContextParamsPtr context_params =
@@ -3854,10 +3874,12 @@ void StoragePartition::SetDefaultQuotaSettingsForTesting(
   g_test_quota_settings = settings;
 }
 
+#if BUILDFLAG(IS_COBALT)
 void StoragePartition::SetDefaultCacheQuotaSettingsForTesting(
     const storage::QuotaSettings* settings) {
   g_test_cache_quota_settings = settings;
 }
+#endif  // BUILDFLAG(IS_COBALT)
 
 mojo::PendingRemote<network::mojom::CookieAccessObserver>
 StoragePartitionImpl::CreateCookieAccessObserverForServiceWorker() {
@@ -3998,7 +4020,8 @@ StoragePartitionImpl::URLLoaderNetworkContext::~URLLoaderNetworkContext() =
 StoragePartitionImpl::URLLoaderNetworkContext
 StoragePartitionImpl::URLLoaderNetworkContext::CreateForRenderFrameHost(
     GlobalRenderFrameHostId render_frame_host_id) {
-  return StoragePartitionImpl::URLLoaderNetworkContext(render_frame_host_id);
+  return StoragePartitionImpl::URLLoaderNetworkContext(
+      render_frame_host_id);
 }
 
 StoragePartitionImpl::URLLoaderNetworkContext

--- a/content/browser/storage_partition_impl.h
+++ b/content/browser/storage_partition_impl.h
@@ -302,9 +302,7 @@ class CONTENT_EXPORT StoragePartitionImpl
   FileSystemAccessManagerImpl* GetFileSystemAccessManager();
   BucketManager* GetBucketManager();
   QuotaContext* GetQuotaContext();
-#if BUILDFLAG(IS_COBALT)
   bool HasSplitQuota();
-#endif
   // Use inside content.
   AttributionManager* GetAttributionManager();
   void SetFontAccessManagerForTesting(
@@ -748,9 +746,7 @@ class CONTENT_EXPORT StoragePartitionImpl
   // Function used by the quota system to ask the embedder for the
   // storage configuration info.
   void GetQuotaSettings(storage::OptionalQuotaSettingsCallback callback);
-#if BUILDFLAG(IS_STARBOARD)
   void GetCacheQuotaSettings(storage::OptionalQuotaSettingsCallback callback);
-#endif
 
   // Called to initialize `network_context_` when `GetNetworkContext()` is
   // first called or there is an error.
@@ -791,10 +787,8 @@ class CONTENT_EXPORT StoragePartitionImpl
   mojo::Remote<storage::mojom::Partition> remote_partition_;
   scoped_refptr<QuotaContext> quota_context_;
   scoped_refptr<storage::QuotaManager> quota_manager_;
-#if BUILDFLAG(IS_STARBOARD)
   scoped_refptr<QuotaContext> cache_quota_context_;
   scoped_refptr<storage::QuotaManager> cache_quota_manager_;
-#endif
   scoped_refptr<storage::FileSystemContext> filesystem_context_;
   scoped_refptr<DOMStorageContextWrapper> dom_storage_context_;
   std::unique_ptr<LockManager<storage::BucketId>> lock_manager_;

--- a/content/browser/storage_partition_impl.h
+++ b/content/browser/storage_partition_impl.h
@@ -21,6 +21,7 @@
 #include "base/memory/scoped_refptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
+#include "build/build_config.h"
 #include "components/services/storage/privileged/mojom/indexed_db_client_state_checker.mojom.h"
 #include "components/services/storage/public/mojom/partition.mojom.h"
 #include "components/services/storage/public/mojom/storage_service.mojom-forward.h"
@@ -301,6 +302,9 @@ class CONTENT_EXPORT StoragePartitionImpl
   FileSystemAccessManagerImpl* GetFileSystemAccessManager();
   BucketManager* GetBucketManager();
   QuotaContext* GetQuotaContext();
+#if BUILDFLAG(IS_COBALT)
+  bool HasSplitQuota();
+#endif
   // Use inside content.
   AttributionManager* GetAttributionManager();
   void SetFontAccessManagerForTesting(
@@ -744,6 +748,9 @@ class CONTENT_EXPORT StoragePartitionImpl
   // Function used by the quota system to ask the embedder for the
   // storage configuration info.
   void GetQuotaSettings(storage::OptionalQuotaSettingsCallback callback);
+#if BUILDFLAG(IS_STARBOARD)
+  void GetCacheQuotaSettings(storage::OptionalQuotaSettingsCallback callback);
+#endif
 
   // Called to initialize `network_context_` when `GetNetworkContext()` is
   // first called or there is an error.
@@ -784,6 +791,10 @@ class CONTENT_EXPORT StoragePartitionImpl
   mojo::Remote<storage::mojom::Partition> remote_partition_;
   scoped_refptr<QuotaContext> quota_context_;
   scoped_refptr<storage::QuotaManager> quota_manager_;
+#if BUILDFLAG(IS_STARBOARD)
+  scoped_refptr<QuotaContext> cache_quota_context_;
+  scoped_refptr<storage::QuotaManager> cache_quota_manager_;
+#endif
   scoped_refptr<storage::FileSystemContext> filesystem_context_;
   scoped_refptr<DOMStorageContextWrapper> dom_storage_context_;
   std::unique_ptr<LockManager<storage::BucketId>> lock_manager_;

--- a/content/browser/storage_partition_impl.h
+++ b/content/browser/storage_partition_impl.h
@@ -21,7 +21,6 @@
 #include "base/memory/scoped_refptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
-#include "build/build_config.h"
 #include "components/services/storage/privileged/mojom/indexed_db_client_state_checker.mojom.h"
 #include "components/services/storage/public/mojom/partition.mojom.h"
 #include "components/services/storage/public/mojom/storage_service.mojom-forward.h"
@@ -302,7 +301,9 @@ class CONTENT_EXPORT StoragePartitionImpl
   FileSystemAccessManagerImpl* GetFileSystemAccessManager();
   BucketManager* GetBucketManager();
   QuotaContext* GetQuotaContext();
+  #if BUILDFLAG(IS_COBALT)
   bool HasSplitQuota();
+  #endif
   // Use inside content.
   AttributionManager* GetAttributionManager();
   void SetFontAccessManagerForTesting(
@@ -746,7 +747,9 @@ class CONTENT_EXPORT StoragePartitionImpl
   // Function used by the quota system to ask the embedder for the
   // storage configuration info.
   void GetQuotaSettings(storage::OptionalQuotaSettingsCallback callback);
+  #if BUILDFLAG(IS_COBALT)
   void GetCacheQuotaSettings(storage::OptionalQuotaSettingsCallback callback);
+  #endif
 
   // Called to initialize `network_context_` when `GetNetworkContext()` is
   // first called or there is an error.
@@ -787,8 +790,10 @@ class CONTENT_EXPORT StoragePartitionImpl
   mojo::Remote<storage::mojom::Partition> remote_partition_;
   scoped_refptr<QuotaContext> quota_context_;
   scoped_refptr<storage::QuotaManager> quota_manager_;
+  #if BUILDFLAG(IS_COBALT)
   scoped_refptr<QuotaContext> cache_quota_context_;
   scoped_refptr<storage::QuotaManager> cache_quota_manager_;
+  #endif
   scoped_refptr<storage::FileSystemContext> filesystem_context_;
   scoped_refptr<DOMStorageContextWrapper> dom_storage_context_;
   std::unique_ptr<LockManager<storage::BucketId>> lock_manager_;

--- a/content/public/browser/content_browser_client.cc
+++ b/content/public/browser/content_browser_client.cc
@@ -81,6 +81,7 @@
 #include "services/network/public/mojom/web_transport.mojom.h"
 #include "services/video_effects/public/cpp/buildflags.h"
 #include "storage/browser/quota/quota_manager.h"
+#include "storage/browser/quota/quota_settings.h"
 #include "third_party/blink/public/common/features.h"
 #include "third_party/blink/public/common/features_generated.h"
 #include "third_party/blink/public/common/loader/url_loader_throttle.h"
@@ -748,6 +749,22 @@ GeneratedCodeCacheSettings ContentBrowserClient::GetGeneratedCodeCacheSettings(
     BrowserContext* context) {
   // By default, code cache is disabled, embedders should override.
   return GeneratedCodeCacheSettings(false, 0, base::FilePath());
+}
+
+base::FilePath ContentBrowserClient::GetCacheStoragePath(
+    BrowserContext* browser_context,
+    const base::FilePath& partition_path,
+    const base::FilePath& relative_partition_path) {
+  return base::FilePath();
+}
+
+void ContentBrowserClient::GetCacheQuotaSettings(
+    BrowserContext* browser_context,
+    const base::FilePath& cache_path,
+    storage::OptionalQuotaSettingsCallback callback) {
+  storage::GetNominalDynamicSettings(
+      cache_path, browser_context ? browser_context->IsOffTheRecord() : false,
+      storage::GetDefaultDeviceInfoHelper(), std::move(callback));
 }
 
 std::string ContentBrowserClient::GetWebUIHostnameForCodeCacheMetrics(

--- a/content/public/browser/content_browser_client.cc
+++ b/content/public/browser/content_browser_client.cc
@@ -81,7 +81,9 @@
 #include "services/network/public/mojom/web_transport.mojom.h"
 #include "services/video_effects/public/cpp/buildflags.h"
 #include "storage/browser/quota/quota_manager.h"
+#if BUILDFLAG(IS_COBALT)
 #include "storage/browser/quota/quota_settings.h"
+#endif
 #include "third_party/blink/public/common/features.h"
 #include "third_party/blink/public/common/features_generated.h"
 #include "third_party/blink/public/common/loader/url_loader_throttle.h"
@@ -751,6 +753,7 @@ GeneratedCodeCacheSettings ContentBrowserClient::GetGeneratedCodeCacheSettings(
   return GeneratedCodeCacheSettings(false, 0, base::FilePath());
 }
 
+#if BUILDFLAG(IS_COBALT)
 base::FilePath ContentBrowserClient::GetCacheStoragePath(
     BrowserContext* browser_context,
     const base::FilePath& partition_path,
@@ -766,6 +769,7 @@ void ContentBrowserClient::GetCacheQuotaSettings(
       cache_path, browser_context ? browser_context->IsOffTheRecord() : false,
       storage::GetDefaultDeviceInfoHelper(), std::move(callback));
 }
+#endif  // BUILDFLAG(IS_COBALT)
 
 std::string ContentBrowserClient::GetWebUIHostnameForCodeCacheMetrics(
     const GURL& webui_url) const {

--- a/content/public/browser/content_browser_client.h
+++ b/content/public/browser/content_browser_client.h
@@ -84,6 +84,7 @@
 #include "services/network/public/mojom/websocket.mojom-forward.h"
 #include "services/video_effects/public/cpp/buildflags.h"
 #include "storage/browser/file_system/file_system_context.h"
+#include "storage/browser/quota/quota_settings.h"
 #include "third_party/blink/public/common/mediastream/media_devices.h"
 #include "third_party/blink/public/common/user_agent/user_agent_metadata.h"
 #include "third_party/blink/public/mojom/ai/ai_manager.mojom-forward.h"
@@ -1330,6 +1331,22 @@ class CONTENT_EXPORT ContentBrowserClient {
   // can be cached and the amount of disk space used for caching generated code.
   virtual GeneratedCodeCacheSettings GetGeneratedCodeCacheSettings(
       BrowserContext* context);
+
+  // Returns the cache storage directory path for the given BrowserContext,
+  // partition path, and relative partition path. If this returns an empty
+  // FilePath, Cache Storage will use the default partition path and share the
+  // primary QuotaManager.
+  virtual base::FilePath GetCacheStoragePath(
+      BrowserContext* browser_context,
+      const base::FilePath& partition_path,
+      const base::FilePath& relative_partition_path);
+
+  // Returns quota settings for Cache Storage when a custom cache storage path is
+  // used. By default, computes nominal dynamic settings on the cache directory.
+  virtual void GetCacheQuotaSettings(
+      BrowserContext* browser_context,
+      const base::FilePath& cache_path,
+      storage::OptionalQuotaSettingsCallback callback);
 
   // Gets the metrics appropriate hostname for a given WebUI URL for code cache
   // metrics. Returns an empty string if no relevant mapping has been defined.

--- a/content/public/browser/content_browser_client.h
+++ b/content/public/browser/content_browser_client.h
@@ -84,7 +84,9 @@
 #include "services/network/public/mojom/websocket.mojom-forward.h"
 #include "services/video_effects/public/cpp/buildflags.h"
 #include "storage/browser/file_system/file_system_context.h"
+#if BUILDFLAG(IS_COBALT)
 #include "storage/browser/quota/quota_settings.h"
+#endif
 #include "third_party/blink/public/common/mediastream/media_devices.h"
 #include "third_party/blink/public/common/user_agent/user_agent_metadata.h"
 #include "third_party/blink/public/mojom/ai/ai_manager.mojom-forward.h"
@@ -1332,6 +1334,7 @@ class CONTENT_EXPORT ContentBrowserClient {
   virtual GeneratedCodeCacheSettings GetGeneratedCodeCacheSettings(
       BrowserContext* context);
 
+#if BUILDFLAG(IS_COBALT)
   // Returns the cache storage directory path for the given BrowserContext,
   // partition path, and relative partition path. If this returns an empty
   // FilePath, Cache Storage will use the default partition path and share the
@@ -1347,6 +1350,7 @@ class CONTENT_EXPORT ContentBrowserClient {
       BrowserContext* browser_context,
       const base::FilePath& cache_path,
       storage::OptionalQuotaSettingsCallback callback);
+#endif  // BUILDFLAG(IS_COBALT)
 
   // Gets the metrics appropriate hostname for a given WebUI URL for code cache
   // metrics. Returns an empty string if no relevant mapping has been defined.

--- a/content/public/browser/storage_partition.h
+++ b/content/public/browser/storage_partition.h
@@ -393,6 +393,9 @@ class CONTENT_EXPORT StoragePartition {
   static void SetDefaultQuotaSettingsForTesting(
       const storage::QuotaSettings* settings);
 
+  static void SetDefaultCacheQuotaSettingsForTesting(
+      const storage::QuotaSettings* settings);
+
   virtual void OverrideDeleteStaleSessionOnlyCookiesDelayForTesting(
       const base::TimeDelta& delay) = 0;
 

--- a/content/public/browser/storage_partition.h
+++ b/content/public/browser/storage_partition.h
@@ -393,8 +393,10 @@ class CONTENT_EXPORT StoragePartition {
   static void SetDefaultQuotaSettingsForTesting(
       const storage::QuotaSettings* settings);
 
+#if BUILDFLAG(IS_COBALT)
   static void SetDefaultCacheQuotaSettingsForTesting(
       const storage::QuotaSettings* settings);
+#endif
 
   virtual void OverrideDeleteStaleSessionOnlyCookiesDelayForTesting(
       const base::TimeDelta& delay) = 0;


### PR DESCRIPTION
This allows the cache and persistent storage directories to have separate quotas, which is required on systems where the two are on different physical partitions.

Previously, quota was always determined based on persistent storage, even for a cache on a separate partition.

A new browsertest is included that verifies the split quota manager behavior.

Also verified manually by mounting tmpfs partitions and symlinking them to `~/.cache/cobalt` and `~/.cobalt_files`.

Bug: 532240315