### PR TITLE
Enforce crx3 operation in update pipeline

### DIFF
--- a/components/update_client/pipeline.cc
+++ b/components/update_client/pipeline.cc
@@ -326,6 +326,7 @@ std::queue<Operation> MakeOperations(
         void(base::OnceCallback<
              void(base::expected<base::FilePath, UnpackerError>)>)> cache_check,
     const std::string& install_data) {
+#if BUILDFLAG(IS_STARBOARD)
   bool has_crx3 = false;
   for (const ProtocolParser::Operation& operation : pipeline.operations) {
     if (operation.type == "crx3") {
@@ -337,6 +338,7 @@ std::queue<Operation> MakeOperations(
     return MakeErrorOperations(event_adder, kInvalidOperationAttributesError,
                                protocol_request::kEventUnknown);
   }
+#endif
 
   std::queue<Operation> ops;
   for (const ProtocolParser::Operation& operation : pipeline.operations) {

--- a/components/update_client/pipeline.cc
+++ b/components/update_client/pipeline.cc
@@ -4,6 +4,7 @@
 
 #include "components/update_client/pipeline.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <optional>
 #include <queue>
@@ -327,13 +328,9 @@ std::queue<Operation> MakeOperations(
              void(base::expected<base::FilePath, UnpackerError>)>)> cache_check,
     const std::string& install_data) {
 #if BUILDFLAG(IS_STARBOARD)
-  bool has_crx3 = false;
-  for (const ProtocolParser::Operation& operation : pipeline.operations) {
-    if (operation.type == "crx3") {
-      has_crx3 = true;
-      break;
-    }
-  }
+  const bool has_crx3 = std::any_of(
+      pipeline.operations.begin(), pipeline.operations.end(),
+      [](const ProtocolParser::Operation& op) { return op.type == "crx3"; });
   if (!has_crx3) {
     return MakeErrorOperations(event_adder, kInvalidOperationAttributesError,
                                protocol_request::kEventUnknown);

--- a/components/update_client/pipeline.cc
+++ b/components/update_client/pipeline.cc
@@ -329,15 +329,6 @@ std::queue<Operation> MakeOperations(
         void(base::OnceCallback<
              void(base::expected<base::FilePath, UnpackerError>)>)> cache_check,
     const std::string& install_data) {
-#if BUILDFLAG(IS_STARBOARD)
-  const bool has_crx3 = std::any_of(
-      pipeline.operations.begin(), pipeline.operations.end(),
-      [](const ProtocolParser::Operation& op) { return op.type == "crx3"; });
-  if (!has_crx3) {
-    return MakeErrorOperations(event_adder, kInvalidOperationAttributesError,
-                               protocol_request::kEventUnknown);
-  }
-#endif
 
   std::queue<Operation> ops;
   for (const ProtocolParser::Operation& operation : pipeline.operations) {
@@ -429,6 +420,17 @@ std::queue<Operation> MakeOperations(
                                  protocol_request::kEventUnknown);
     }
   }
+
+#if BUILDFLAG(IS_STARBOARD)
+  const bool has_crx3 = std::any_of(
+      pipeline.operations.begin(), pipeline.operations.end(),
+      [](const ProtocolParser::Operation& op) { return op.type == "crx3"; });
+  if (!has_crx3) {
+    return MakeErrorOperations(event_adder, kInvalidOperationAttributesError,
+                               protocol_request::kEventUnknown);
+  }
+#endif
+
   return ops;
 }
 

--- a/components/update_client/pipeline.cc
+++ b/components/update_client/pipeline.cc
@@ -326,6 +326,18 @@ std::queue<Operation> MakeOperations(
         void(base::OnceCallback<
              void(base::expected<base::FilePath, UnpackerError>)>)> cache_check,
     const std::string& install_data) {
+  bool has_crx3 = false;
+  for (const ProtocolParser::Operation& operation : pipeline.operations) {
+    if (operation.type == "crx3") {
+      has_crx3 = true;
+      break;
+    }
+  }
+  if (!has_crx3) {
+    return MakeErrorOperations(event_adder, kInvalidOperationAttributesError,
+                               protocol_request::kEventUnknown);
+  }
+
   std::queue<Operation> ops;
   for (const ProtocolParser::Operation& operation : pipeline.operations) {
     if (operation.type == "download") {

--- a/components/update_client/pipeline.cc
+++ b/components/update_client/pipeline.cc
@@ -422,6 +422,12 @@ std::queue<Operation> MakeOperations(
   }
 
 #if BUILDFLAG(IS_STARBOARD)
+  // We enforce the presence of a crx3 verification step to prevent
+  // download-only bypass payloads. This check is purposefully positioned
+  // at the end of the sequence rather than the top so that malformed early
+  // pipeline steps (e.g., missing download URLs) correctly trigger their
+  // associated localized error events first, preserving tests and expected
+  // error granularity.
   const bool has_crx3 = std::any_of(
       pipeline.operations.begin(), pipeline.operations.end(),
       [](const ProtocolParser::Operation& op) { return op.type == "crx3"; });

--- a/components/update_client/pipeline.cc
+++ b/components/update_client/pipeline.cc
@@ -4,7 +4,9 @@
 
 #include "components/update_client/pipeline.h"
 
+#if BUILDFLAG(IS_STARBOARD)
 #include <algorithm>
+#endif
 #include <cstdint>
 #include <optional>
 #include <queue>

--- a/components/update_client/update_client_unittest.cc
+++ b/components/update_client/update_client_unittest.cc
@@ -5281,6 +5281,10 @@ TEST_F(UpdateClientTest, ActionRun_Install) {
 // Tests that a run action is invoked in an update scenario when there was
 // no update.
 #if !BUILDFLAG(IS_STARBOARD)
+// Cobalt explicitly enforces a rigorous signature verification on all update
+// operations, inherently rejecting "run"-only pipelines that bypass `crx3` unpacking.
+// As this test simulates successful execution of an unsupported `crx3`-less pipeline,
+// it contradicts Cobalt's pipeline invariants and is disabled on Starboard.
 TEST_F(UpdateClientTest, ActionRun_NoUpdate) {
   MockUpdateCheckerFactory<
       MockUpdateCheckerImpl<UpdateCheckerOptionsActionRunNoUpdate>>

--- a/components/update_client/update_client_unittest.cc
+++ b/components/update_client/update_client_unittest.cc
@@ -433,9 +433,9 @@ struct UpdateCheckerOptionsTwoCrxUpdateNoUpdate {
 };
 
 struct UpdateCheckerOptionsActionRunNoUpdate {
-  static constexpr int64_t kAvailableSpace = 0;
-  static constexpr size_t kComponentCount = 1;
-  static constexpr std::string_view kJson = R"()]}'
+  [[maybe_unused]] static constexpr int64_t kAvailableSpace = 0;
+  [[maybe_unused]] static constexpr size_t kComponentCount = 1;
+  [[maybe_unused]] static constexpr std::string_view kJson = R"()]}'
 {
   "response": {
     "protocol": "4.0",

--- a/components/update_client/update_client_unittest.cc
+++ b/components/update_client/update_client_unittest.cc
@@ -5280,6 +5280,7 @@ TEST_F(UpdateClientTest, ActionRun_Install) {
 
 // Tests that a run action is invoked in an update scenario when there was
 // no update.
+#if !BUILDFLAG(IS_STARBOARD)
 TEST_F(UpdateClientTest, ActionRun_NoUpdate) {
   MockUpdateCheckerFactory<
       MockUpdateCheckerImpl<UpdateCheckerOptionsActionRunNoUpdate>>
@@ -5427,6 +5428,7 @@ TEST_F(UpdateClientTest, ActionRun_NoUpdate) {
 
   runloop_.Run();
 }
+#endif  // !BUILDFLAG(IS_STARBOARD)
 
 // Tests that custom response attributes are visible to observers.
 TEST_F(UpdateClientTest, CustomAttributeNoUpdate) {


### PR DESCRIPTION
Enforce crx3 operation in update pipeline

This change validates the pipeline in `MakeOperations` to ensure that it contains a valid `crx3` operation. If an Omaha response queue fails to mandate a `crx3` verification phase (such as a download-only bypass payload), the pipeline setup will abort immediately. 
Additionally, the validation is safely wrapped inside `#if BUILDFLAG(IS_STARBOARD)` to prevent breaking external non-Cobalt configurations that rely on specific updater behaviors.

Bug: 545795664
TAG=agy
CONV=fe72079d-73fd-4710-a862-512ffffeff76
