### PR TITLE
android: Enable seamless switch when Bluetooth speaker is connected

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/AudioOutputManager.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/AudioOutputManager.java
@@ -24,13 +24,13 @@ import android.media.AudioFormat;
 import android.media.AudioManager;
 import android.media.AudioTrack;
 import android.os.Build;
+import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 import dev.cobalt.util.Log;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.CopyOnWriteArrayList;
 import org.jni_zero.CalledByNative;
 import org.jni_zero.JNINamespace;
 import org.jni_zero.NativeMethods;
@@ -38,15 +38,15 @@ import org.jni_zero.NativeMethods;
 /** Creates and destroys AudioTrackBridge and handles the volume change. */
 @JNINamespace("starboard")
 public class AudioOutputManager {
-  private List<AudioTrackBridge> mAudioTrackBridgeList;
+  @NonNull private final List<AudioTrackBridge> mAudioTrackBridgeList;
   private Context mContext;
 
-  AtomicBoolean mHasAudioDeviceChanged = new AtomicBoolean(false);
   boolean mHasRegisteredAudioDeviceCallback = false;
 
   public AudioOutputManager(Context context) {
     mContext = context;
-    mAudioTrackBridgeList = new ArrayList<AudioTrackBridge>();
+    // CopyOnWriteArrayList allows thread-safe UI iteration without locking native threads.
+    mAudioTrackBridgeList = new CopyOnWriteArrayList<AudioTrackBridge>();
   }
 
   @CalledByNative
@@ -72,7 +72,6 @@ public class AudioOutputManager {
       return null;
     }
     mAudioTrackBridgeList.add(audioTrackBridge);
-    mHasAudioDeviceChanged.set(false);
 
     if (mHasRegisteredAudioDeviceCallback || isWebAudio) {
       return audioTrackBridge;
@@ -82,26 +81,56 @@ public class AudioOutputManager {
     audioManager.registerAudioDeviceCallback(
         new AudioDeviceCallback() {
           // Since registering a callback triggers an immediate call to onAudioDevicesAdded() with
-          // current devices, don't set |mHasAudioDeviceChanged| for this initial call.
+          // current devices, don't notify tracks for this initial call.
           private boolean mInitialDevicesAdded = false;
 
-          private void handleConnectedDeviceChange(AudioDeviceInfo[] devices) {
+          private void handleConnectedDeviceChange(AudioDeviceInfo[] devices, boolean isAdded) {
+            AudioDeviceInfo relevantDevice = null;
             for (AudioDeviceInfo info : devices) {
               // TODO: Determine if AudioDeviceInfo.TYPE_HDMI_EARC should be checked in API 31.
               if (info.isSink()
                   && (info.getType() == AudioDeviceInfo.TYPE_BLUETOOTH_A2DP
                       || info.getType() == AudioDeviceInfo.TYPE_HDMI_ARC
                       || info.getType() == AudioDeviceInfo.TYPE_HDMI)) {
-                // TODO: Avoid destroying the AudioTrack if the new devices can support the current
-                // AudioFormat.
-                Log.v(
-                    TAG,
-                    "Setting |mHasAudioDeviceChanged| to true for audio device %s, %s.",
-                    info.getProductName(),
-                    getDeviceTypeName(info.getType()));
-                mHasAudioDeviceChanged.set(true);
+                relevantDevice = info;
                 break;
               }
+            }
+            if (relevantDevice == null) {
+              return;
+            }
+
+            String eventName = isAdded ? "added" : "removed";
+            // If all active audio tracks are PCM and seamless switching is enabled, Android OS
+            // automatically handles dynamic routing (e.g. to Bluetooth A2DP or built-in speakers)
+            // without requiring player recreation. While player recreation is avoided, an audio
+            // sink flush (RESET_AND_CONTINUE) is still performed to reset timestamps and latency.
+            // Only flag player recreation (RESTART_PLAYER) if seamless switching is disabled or
+            // there is an active passthrough track that cannot be routed to incompatible sinks.
+            if (AudioOutputManagerJni.get().isSeamlessAudioSwitchingEnabled()
+                && !hasActivePassthroughTrack(mAudioTrackBridgeList)) {
+              Log.i(
+                  TAG,
+                  "Audio device %s: %s (%s). Notifying active tracks (RESET_AND_CONTINUE) "
+                      + "for seamless PCM playback.",
+                  eventName,
+                  relevantDevice.getProductName(),
+                  getDeviceTypeName(relevantDevice.getType()));
+              for (AudioTrackBridge bridge : mAudioTrackBridgeList) {
+                bridge.onAudioDeviceChanged(AudioDeviceChange.RESET_AND_CONTINUE);
+              }
+              return;
+            }
+
+            Log.i(
+                TAG,
+                "Audio device %s: %s (%s). Notifying active tracks (RESTART_PLAYER) "
+                    + "to renegotiate audio capabilities.",
+                eventName,
+                relevantDevice.getProductName(),
+                getDeviceTypeName(relevantDevice.getType()));
+            for (AudioTrackBridge bridge : mAudioTrackBridgeList) {
+              bridge.onAudioDeviceChanged(AudioDeviceChange.RESTART_PLAYER);
             }
           }
 
@@ -112,7 +141,7 @@ public class AudioOutputManager {
                 "onAudioDevicesAdded() called, |mInitialDevicesAdded| is: %b.",
                 mInitialDevicesAdded);
             if (mInitialDevicesAdded) {
-              handleConnectedDeviceChange(addedDevices);
+              handleConnectedDeviceChange(addedDevices, /* isAdded= */ true);
               return;
             }
             mInitialDevicesAdded = true;
@@ -121,7 +150,7 @@ public class AudioOutputManager {
           @Override
           public void onAudioDevicesRemoved(AudioDeviceInfo[] removedDevices) {
             Log.v(TAG, "onAudioDevicesRemoved() called.");
-            handleConnectedDeviceChange(removedDevices);
+            handleConnectedDeviceChange(removedDevices, /* isAdded= */ false);
           }
         },
         null);
@@ -190,6 +219,22 @@ public class AudioOutputManager {
       return true;
     }
 
+    return false;
+  }
+
+  private static boolean isPassthroughEncoding(int encoding) {
+    return encoding == AudioFormat.ENCODING_AC3
+        || encoding == AudioFormat.ENCODING_E_AC3
+        || encoding == AudioFormat.ENCODING_E_AC3_JOC;
+  }
+
+  private static boolean hasActivePassthroughTrack(
+      @NonNull List<AudioTrackBridge> audioTrackBridges) {
+    for (AudioTrackBridge bridge : audioTrackBridges) {
+      if (isPassthroughEncoding(bridge.getSampleType())) {
+        return true;
+      }
+    }
     return false;
   }
 
@@ -485,9 +530,7 @@ public class AudioOutputManager {
   @RequiresApi(29)
   /** Returns whether direct playback on surround `encoding` is supported for API 29 and above. */
   private boolean hasDirectSurroundPlaybackSupportForV29(int encoding, int sampleRate) {
-    if (encoding != AudioFormat.ENCODING_AC3
-        && encoding != AudioFormat.ENCODING_E_AC3
-        && encoding != AudioFormat.ENCODING_E_AC3_JOC) {
+    if (!isPassthroughEncoding(encoding)) {
       Log.w(
           TAG,
           "hasDirectSurroundPlaybackSupportForV29() encountered unsupported encoding %d.",
@@ -521,11 +564,6 @@ public class AudioOutputManager {
         .build();
   }
 
-  @CalledByNative
-  private boolean getAndResetHasAudioDeviceChanged() {
-    return mHasAudioDeviceChanged.getAndSet(false);
-  }
-
   private static AudioDeviceCallback sAudioDeviceCallback =
       new AudioDeviceCallback() {
         @Override
@@ -554,5 +592,7 @@ public class AudioOutputManager {
   @NativeMethods
   interface Natives {
     void onAudioDeviceChanged();
+
+    boolean isSeamlessAudioSwitchingEnabled();
   }
 }

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/AudioTrackBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/AudioTrackBridge.java
@@ -28,8 +28,10 @@ import dev.cobalt.util.Log;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Locale;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.jni_zero.CalledByNative;
 import org.jni_zero.JNINamespace;
+import org.jni_zero.JniType;
 
 /**
  * A wrapper of the android AudioTrack class. Android AudioTrack would not start playing until the
@@ -56,14 +58,30 @@ public class AudioTrackBridge {
   private long mMaxFramePositionSoFar = 0;
 
   private final boolean mTunnelModeEnabled;
+  private final int mSampleType;
   // The following variables are used only when |tunnelModeEnabled| is true.
   private ByteBuffer mAvSyncHeader;
   private int mAvSyncPacketBytesRemaining;
+
+  private final AtomicInteger mAudioDeviceChange = new AtomicInteger(AudioDeviceChange.NONE);
+
+  public void onAudioDeviceChanged(@AudioDeviceChange int change) {
+    mAudioDeviceChange.accumulateAndGet(change, Math::max);
+  }
+
+  @CalledByNative
+  private @JniType("starboard::AudioDeviceChange") int getAndResetAudioDeviceChange() {
+    return mAudioDeviceChange.getAndSet(AudioDeviceChange.NONE);
+  }
 
   // Pre-allocated byte[] or float[] shared with C++ via getPreAllocatedAudioDataAs*Array() to avoid
   // allocation on every WriteSample(). C++ writes directly to this array,
   // which is then passed back to Java write*() methods.
   private Object mPreAllocatedAudioData;
+
+  public int getSampleType() {
+    return mSampleType;
+  }
 
   private static int getBytesPerSample(int audioFormat) {
     switch (audioFormat) {
@@ -102,6 +120,7 @@ public class AudioTrackBridge {
       int preferredBufferSizeInBytes,
       int tunnelModeAudioSessionId,
       boolean isWebAudio) {
+    mSampleType = sampleType;
 
     mTunnelModeEnabled = tunnelModeAudioSessionId != TunnelModeAudioSessionId.NONE;
     int channelConfig;

--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -473,6 +473,7 @@ test("starboard_platform_tests") {
 
 java_cpp_enum("java_enums") {
   sources = [
+    "audio_track.h",
     "media_codec.h",
     "media_common.h",
     "media_drm_bridge.h",

--- a/starboard/android/shared/audio_output_manager.cc
+++ b/starboard/android/shared/audio_output_manager.cc
@@ -14,10 +14,13 @@
 
 #include "starboard/android/shared/audio_output_manager.h"
 
+#include <atomic>
+
 #include "starboard/android/shared/media_capabilities_cache.h"
 #include "starboard/android/shared/media_common.h"
 #include "starboard/android/shared/starboard_bridge.h"
 #include "starboard/common/log.h"
+#include "starboard/common/string.h"
 #include "starboard/media.h"
 #include "starboard/shared/starboard/media/media_util.h"
 #include "starboard/shared/starboard/media/mime_supportability_cache.h"
@@ -65,6 +68,8 @@ constexpr int TYPE_USB_DEVICE = 11;
 constexpr int TYPE_USB_HEADSET = 22;
 constexpr int TYPE_WIRED_HEADPHONES = 4;
 constexpr int TYPE_WIRED_HEADSET = 3;
+
+std::atomic<bool> g_enable_seamless_audio_switching = false;
 
 SbMediaAudioConnector GetConnectorFromAndroidOutputType(
     int android_output_device_type) {
@@ -200,10 +205,8 @@ int AudioOutputManager::GetMinBufferSizeInFrames(
          GetBytesPerSample(sample_type);
 }
 
-bool AudioOutputManager::GetAndResetHasAudioDeviceChanged(JNIEnv* env) {
-  SB_DCHECK(env);
-  return Java_AudioOutputManager_getAndResetHasAudioDeviceChanged(
-             env, j_audio_output_manager_) == JNI_TRUE;
+void AudioOutputManager::SetSeamlessAudioSwitching(bool enable) {
+  g_enable_seamless_audio_switching.store(enable, std::memory_order_relaxed);
 }
 
 std::optional<int> AudioOutputManager::GenerateTunnelModeAudioSessionId(
@@ -267,6 +270,10 @@ void JNI_AudioOutputManager_OnAudioDeviceChanged(JNIEnv* env) {
   // so we have to reload codec capabilities.
   MediaCapabilitiesCache::GetInstance()->ClearCache();
   MimeSupportabilityCache::GetInstance()->ClearCachedMimeSupportabilities();
+}
+
+jboolean JNI_AudioOutputManager_IsSeamlessAudioSwitchingEnabled(JNIEnv* env) {
+  return g_enable_seamless_audio_switching.load(std::memory_order_relaxed);
 }
 
 }  // namespace starboard

--- a/starboard/android/shared/audio_output_manager.h
+++ b/starboard/android/shared/audio_output_manager.h
@@ -27,6 +27,8 @@ namespace starboard {
 
 class AudioOutputManager {
  public:
+  static void SetSeamlessAudioSwitching(bool enable);
+
   // Returns the singleton.
   static AudioOutputManager* GetInstance();
 
@@ -56,8 +58,6 @@ class AudioOutputManager {
                                SbMediaAudioSampleType sample_type,
                                int channels,
                                int sampling_frequency_hz);
-
-  bool GetAndResetHasAudioDeviceChanged(JNIEnv* env);
 
   std::optional<int> GenerateTunnelModeAudioSessionId(JNIEnv* env,
                                                       int numberOfChannels);

--- a/starboard/android/shared/audio_renderer_passthrough.cc
+++ b/starboard/android/shared/audio_renderer_passthrough.cc
@@ -18,11 +18,13 @@
 #include <utility>
 
 #include "starboard/android/shared/audio_decoder_passthrough.h"
+#include "starboard/android/shared/media_capabilities_cache.h"
 #include "starboard/android/shared/media_codec_audio_decoder.h"
 #include "starboard/common/check_op.h"
 #include "starboard/common/string.h"
 #include "starboard/common/thread_options.h"
 #include "starboard/common/time.h"
+#include "starboard/shared/starboard/media/mime_supportability_cache.h"
 #include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
@@ -471,11 +473,14 @@ void AudioRendererPassthrough::UpdateStatusAndWriteData(
   SB_DCHECK(error_cb_);
   SB_DCHECK(audio_track_bridge_);
 
-  if (audio_track_bridge_->GetAndResetHasAudioDeviceChanged()) {
+  // Encoded passthrough bitstreams (e.g. AC3/E-AC3) cannot be seamlessly routed
+  // across different sinks (e.g. Bluetooth or built-in speakers), so any device
+  // change requires recreating the player to renegotiate audio capabilities.
+  if (audio_track_bridge_->GetAndResetAudioDeviceChange() !=
+      AudioDeviceChange::kNone) {
     SB_LOG(INFO) << "Audio device changed, raising a capability changed error "
                     "to restart playback.";
-    error_cb_(kSbPlayerErrorCapabilityChanged,
-              "Audio device capability changed");
+    ReportCapabilityChanged();
     audio_track_bridge_->PauseAndFlush();
     return;
   }
@@ -551,8 +556,7 @@ void AudioRendererPassthrough::UpdateStatusAndWriteData(
           SB_LOG(INFO)
               << "Write error for dead audio track, audio device capability "
                  "has likely changed. Restarting playback.";
-          error_cb_(kSbPlayerErrorCapabilityChanged,
-                    "Audio device capability changed");
+          ReportCapabilityChanged();
         } else {
           // `kSbPlayerErrorDecode` is used for general SbPlayer error, there is
           // no error code corresponding to audio sink.
@@ -607,6 +611,14 @@ void AudioRendererPassthrough::UpdateStatusAndWriteData(
       std::bind(&AudioRendererPassthrough::UpdateStatusAndWriteData, this,
                 current_state),
       fully_written ? 0 : kAudioTrackUpdateInternal);
+}
+
+void AudioRendererPassthrough::ReportCapabilityChanged() {
+  // Invalidate caches so subsequent isTypeSupported() queries see live state.
+  MediaCapabilitiesCache::GetInstance()->ClearCache();
+  MimeSupportabilityCache::GetInstance()->ClearCachedMimeSupportabilities();
+
+  error_cb_(kSbPlayerErrorCapabilityChanged, "Audio device capability changed");
 }
 
 // This function can be called from *any* threads.

--- a/starboard/android/shared/audio_renderer_passthrough.h
+++ b/starboard/android/shared/audio_renderer_passthrough.h
@@ -98,6 +98,7 @@ class AudioRendererPassthrough : public AudioRenderer,
   void CreateAudioTrackAndStartProcessing();
   void FlushAudioTrackAndStopProcessing(int64_t seek_to_time);
   void UpdateStatusAndWriteData(const AudioTrackState previous_state);
+  void ReportCapabilityChanged();
   void OnDecoderConsumed();
   void OnDecoderOutput();
 

--- a/starboard/android/shared/audio_track.h
+++ b/starboard/android/shared/audio_track.h
@@ -45,6 +45,13 @@ class AudioTrack {
     kPlaying = 3,
   };
 
+  // GENERATED_JAVA_ENUM_PACKAGE: dev.cobalt.media
+  enum class AudioDeviceChange {
+    kNone,
+    kResetAndContinue,  // Seamless: flush & re-feed without destroying player
+    kRestartPlayer,     // Capability changed: tear down player & recreate
+  };
+
   // The maximum number of frames that can be written to android audio track per
   // write request.
   static constexpr int kMaxFramesPerRequest = 65'536;
@@ -88,11 +95,13 @@ class AudioTrack {
   // |updated_at| contains the timestamp when the audio timestamp is updated on
   // return.  It can be nullptr.
   virtual int64_t GetAudioTimestamp(int64_t* updated_at) = 0;
-  virtual bool GetAndResetHasAudioDeviceChanged() = 0;
+  virtual AudioDeviceChange GetAndResetAudioDeviceChange() = 0;
   virtual int GetUnderrunCount() = 0;
   virtual int GetStartThresholdInFrames() = 0;
   virtual PlayState GetPlayState() = 0;
 };
+
+using AudioDeviceChange = AudioTrack::AudioDeviceChange;
 
 }  // namespace starboard
 

--- a/starboard/android/shared/audio_track_audio_sink_type.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type.cc
@@ -282,28 +282,43 @@ void AudioTrackAudioSink::AudioThreadFunc() {
   bool release_frames_after_audio_starts = false;
 #endif
 
+  auto reset_and_flush = [&]() {
+    audio_track_->PauseAndFlush();
+    frames_in_audio_track = 0;
+    // Set to -1 to ignore the first playback head position read after a
+    // flush. This avoids using a stale value from before the reset, which
+    // could lead to incorrect frame consumption calculations.
+    last_playback_head_position = -1;
+    last_playback_head_event_at = -1;
+    is_flushed_ = true;
+  };
+
   while (!quit_) {
     if (flush_requested_) {
-      audio_track_->PauseAndFlush();
-      frames_in_audio_track = 0;
+      reset_and_flush();
       accumulated_written_frames = 0;
-      last_playback_head_event_at = -1;
-      // Set to -1 to ignore the first playback head position read after a
-      // flush. This avoids using a stale value from before the reset, which
-      // could lead to incorrect frame consumption calculations.
-      last_playback_head_position = -1;
-      is_flushed_ = true;
       flush_requested_ = false;
       continue;
     }
 
     int64_t playback_head_position = 0;
     int64_t frames_consumed_at = 0;
-    if (audio_track_->GetAndResetHasAudioDeviceChanged()) {
+    AudioDeviceChange device_change =
+        audio_track_->GetAndResetAudioDeviceChange();
+    if (device_change == AudioDeviceChange::kRestartPlayer) {
       SB_LOG(INFO) << "Audio device changed, raising a capability changed "
                       "error to restart playback.";
       ReportError(true, "Audio device capability changed");
       break;
+    }
+    if (device_change == AudioDeviceChange::kResetAndContinue) {
+      SB_LOG(INFO) << "Seamless audio device changed, resetting audio track "
+                      "and sink buffer.";
+      // On seamless route switches (e.g., 2-ch speaker <-> Bluetooth), flush
+      // queued audio to reset timestamps and latency. Unconsumed frames in the
+      // buffer will be re-fed on the next iteration when playback resumes.
+      reset_and_flush();
+      continue;
     }
 
     if (pause_using_audio_track_state_) {

--- a/starboard/android/shared/audio_track_audio_sink_type.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type.cc
@@ -318,6 +318,7 @@ void AudioTrackAudioSink::AudioThreadFunc() {
       // queued audio to reset timestamps and latency. Unconsumed frames in the
       // buffer will be re-fed on the next iteration when playback resumes.
       reset_and_flush();
+      was_playing = false;
       continue;
     }
 

--- a/starboard/android/shared/audio_track_audio_sink_type_test.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type_test.cc
@@ -313,13 +313,17 @@ TEST_F(AudioTrackAudioSinkTest, AudioDeviceChangeResetAndContinue) {
   }
   EXPECT_GE(track_ptr->pause_and_flush_count(), 1);
 
-  // Verify that frames are re-fed to the track after flush.
+  // Verify that playback resumes and frames are re-fed to the track after
+  // flush.
   elapsed_ms = 0;
-  while (track_ptr->written_frames() == 0 && elapsed_ms < 1000) {
+  while ((track_ptr->written_frames() == 0 ||
+          track_ptr->play_state() != AudioTrack::PlayState::kPlaying) &&
+         elapsed_ms < 1000) {
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
     elapsed_ms += 10;
   }
   EXPECT_GT(track_ptr->written_frames(), 0);
+  EXPECT_EQ(track_ptr->play_state(), AudioTrack::PlayState::kPlaying);
 
   // Verify playback continues seamlessly without error.
   EXPECT_FALSE(error_reported_);

--- a/starboard/android/shared/audio_track_audio_sink_type_test.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type_test.cc
@@ -68,6 +68,7 @@ class AudioTrackAudioSinkTest : public ::testing::Test {
     auto* fixture = static_cast<AudioTrackAudioSinkTest*>(context);
     std::lock_guard<std::mutex> lock(fixture->error_mutex_);
     fixture->error_reported_ = true;
+    fixture->capability_changed_ = capability_changed;
     fixture->error_msg_ = error_message;
   }
 
@@ -80,6 +81,7 @@ class AudioTrackAudioSinkTest : public ::testing::Test {
   std::atomic<int> total_frames_consumed_ = 0;
   std::mutex error_mutex_;
   std::atomic<bool> error_reported_ = false;
+  std::atomic<bool> capability_changed_ = false;
   std::string error_msg_;
 };
 
@@ -264,6 +266,112 @@ TEST_F(AudioTrackAudioSinkTest,
   {
     std::lock_guard<std::mutex> lock(error_mutex_);
     EXPECT_EQ(error_msg_, "AudioTrack expected written frames is negative.");
+  }
+
+  sink.reset();
+}
+
+TEST_F(AudioTrackAudioSinkTest, AudioDeviceChangeResetAndContinue) {
+  AudioTrackAudioSinkType type;
+  auto fake_track = std::make_unique<FakeAudioTrack>(
+      2, 48000, kSbMediaAudioSampleTypeFloat32);
+  FakeAudioTrack* track_ptr = fake_track.get();
+
+  AudioTrackAudioSinkType::Callbacks callbacks{
+      UpdateSourceStatusCB,
+      ConsumeFramesCB,
+      ErrorCB,
+  };
+
+  frames_in_buffer_ = 512;
+  auto sink = AudioTrackAudioSink::CreateForTesting(
+      &type, 2, 48000, kSbMediaAudioSampleTypeFloat32, frame_buffers_, 1024,
+      512, callbacks, 0,
+      /*tunnel_mode_audio_session_id=*/std::nullopt,
+      /*allow_audio_writing_on_pause=*/false,
+      /*pause_using_audio_track_state=*/false, std::move(fake_track), this);
+
+  ASSERT_NE(sink, nullptr);
+
+  // Wait until the initial frames are written to the audio track.
+  int elapsed_ms = 0;
+  while (track_ptr->written_frames() == 0 && elapsed_ms < 1000) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    elapsed_ms += 10;
+  }
+  EXPECT_GT(track_ptr->written_frames(), 0);
+  EXPECT_EQ(track_ptr->pause_and_flush_count(), 0);
+
+  // Simulate seamless audio device change.
+  track_ptr->simulate_device_change(AudioDeviceChange::kResetAndContinue);
+
+  // Wait for PauseAndFlush() to be called on device change.
+  elapsed_ms = 0;
+  while (track_ptr->pause_and_flush_count() == 0 && elapsed_ms < 1000) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    elapsed_ms += 10;
+  }
+  EXPECT_GE(track_ptr->pause_and_flush_count(), 1);
+
+  // Verify that frames are re-fed to the track after flush.
+  elapsed_ms = 0;
+  while (track_ptr->written_frames() == 0 && elapsed_ms < 1000) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    elapsed_ms += 10;
+  }
+  EXPECT_GT(track_ptr->written_frames(), 0);
+
+  // Verify playback continues seamlessly without error.
+  EXPECT_FALSE(error_reported_);
+
+  sink.reset();
+}
+
+TEST_F(AudioTrackAudioSinkTest, AudioDeviceChangeRestartPlayer) {
+  AudioTrackAudioSinkType type;
+  auto fake_track = std::make_unique<FakeAudioTrack>(
+      2, 48000, kSbMediaAudioSampleTypeFloat32);
+  FakeAudioTrack* track_ptr = fake_track.get();
+
+  AudioTrackAudioSinkType::Callbacks callbacks{
+      UpdateSourceStatusCB,
+      ConsumeFramesCB,
+      ErrorCB,
+  };
+
+  frames_in_buffer_ = 512;
+  auto sink = AudioTrackAudioSink::CreateForTesting(
+      &type, 2, 48000, kSbMediaAudioSampleTypeFloat32, frame_buffers_, 1024,
+      512, callbacks, 0,
+      /*tunnel_mode_audio_session_id=*/std::nullopt,
+      /*allow_audio_writing_on_pause=*/false,
+      /*pause_using_audio_track_state=*/false, std::move(fake_track), this);
+
+  ASSERT_NE(sink, nullptr);
+
+  // Wait until initial frames are written.
+  int elapsed_ms = 0;
+  while (track_ptr->written_frames() == 0 && elapsed_ms < 1000) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    elapsed_ms += 10;
+  }
+  EXPECT_GT(track_ptr->written_frames(), 0);
+
+  // Simulate audio device change requiring player restart.
+  track_ptr->simulate_device_change(AudioDeviceChange::kRestartPlayer);
+
+  // Wait for ErrorCB to be triggered.
+  elapsed_ms = 0;
+  while (!error_reported_ && elapsed_ms < 1000) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    elapsed_ms += 10;
+  }
+
+  EXPECT_TRUE(error_reported_);
+  EXPECT_TRUE(capability_changed_);
+  {
+    std::lock_guard<std::mutex> lock(error_mutex_);
+    EXPECT_EQ(error_msg_, "Audio device capability changed");
   }
 
   sink.reset();

--- a/starboard/android/shared/audio_track_bridge.cc
+++ b/starboard/android/shared/audio_track_bridge.cc
@@ -267,10 +267,10 @@ int64_t AudioTrackBridge::GetAudioTimestamp(int64_t* updated_at) {
   return Java_AudioTimestamp_getFramePosition(env, j_audio_timestamp);
 }
 
-bool AudioTrackBridge::GetAndResetHasAudioDeviceChanged() {
+AudioTrack::AudioDeviceChange AudioTrackBridge::GetAndResetAudioDeviceChange() {
   JNIEnv* env = AttachCurrentThread();
-  return AudioOutputManager::GetInstance()->GetAndResetHasAudioDeviceChanged(
-      env);
+  return Java_AudioTrackBridge_getAndResetAudioDeviceChange(
+      env, j_audio_track_bridge_);
 }
 
 int AudioTrackBridge::GetUnderrunCount() {

--- a/starboard/android/shared/audio_track_bridge.h
+++ b/starboard/android/shared/audio_track_bridge.h
@@ -73,7 +73,7 @@ class AudioTrackBridge : public AudioTrack {
   // |updated_at| contains the timestamp when the audio timestamp is updated on
   // return.  It can be nullptr.
   int64_t GetAudioTimestamp(int64_t* updated_at) override;
-  bool GetAndResetHasAudioDeviceChanged() override;
+  AudioDeviceChange GetAndResetAudioDeviceChange() override;
   int GetUnderrunCount() override;
   int GetStartThresholdInFrames() override;
   PlayState GetPlayState() override;

--- a/starboard/android/shared/fake_audio_track.cc
+++ b/starboard/android/shared/fake_audio_track.cc
@@ -50,6 +50,7 @@ void FakeAudioTrack::PauseAndFlush() {
   play_state_ = PlayState::kPaused;
   written_frames_ = 0;
   consumed_frames_ = 0;
+  ++pause_and_flush_count_;
 }
 
 int FakeAudioTrack::WriteSample(Span<const float> samples) {
@@ -104,11 +105,11 @@ int64_t FakeAudioTrack::GetAudioTimestamp(int64_t* updated_at) {
   return consumed_frames_;
 }
 
-bool FakeAudioTrack::GetAndResetHasAudioDeviceChanged() {
+AudioTrack::AudioDeviceChange FakeAudioTrack::GetAndResetAudioDeviceChange() {
   std::lock_guard lock(mutex_);
-  bool changed = device_changed_;
-  device_changed_ = false;
-  return changed;
+  AudioDeviceChange change = device_change_;
+  device_change_ = AudioDeviceChange::kNone;
+  return change;
 }
 
 int FakeAudioTrack::GetUnderrunCount() {
@@ -151,14 +152,24 @@ AudioTrack::PlayState FakeAudioTrack::play_state() const {
   return play_state_;
 }
 
+int FakeAudioTrack::pause_and_flush_count() const {
+  std::lock_guard lock(mutex_);
+  return pause_and_flush_count_;
+}
+
 void FakeAudioTrack::set_consumed_frames(int64_t consumed) {
   std::lock_guard lock(mutex_);
   consumed_frames_ = consumed;
 }
 
-void FakeAudioTrack::simulate_device_change(bool changed) {
+void FakeAudioTrack::simulate_device_change(AudioDeviceChange change) {
   std::lock_guard lock(mutex_);
-  device_changed_ = changed;
+  device_change_ = change;
+}
+
+void FakeAudioTrack::simulate_device_change(bool changed) {
+  simulate_device_change(changed ? AudioDeviceChange::kRestartPlayer
+                                 : AudioDeviceChange::kNone);
 }
 
 void FakeAudioTrack::set_underrun_count(int count) {

--- a/starboard/android/shared/fake_audio_track.h
+++ b/starboard/android/shared/fake_audio_track.h
@@ -48,7 +48,7 @@ class FakeAudioTrack : public AudioTrack {
   void SetVolume(double volume) override;
 
   int64_t GetAudioTimestamp(int64_t* updated_at) override;
-  bool GetAndResetHasAudioDeviceChanged() override;
+  AudioDeviceChange GetAndResetAudioDeviceChange() override;
   int GetUnderrunCount() override;
   int GetStartThresholdInFrames() override;
   PlayState GetPlayState() override;
@@ -59,7 +59,9 @@ class FakeAudioTrack : public AudioTrack {
   double playback_rate() const;
   double volume() const;
   PlayState play_state() const;
+  int pause_and_flush_count() const;
   void set_consumed_frames(int64_t consumed);
+  void simulate_device_change(AudioDeviceChange change);
   void simulate_device_change(bool changed);
   void set_underrun_count(int count);
   void set_write_error(int error_code);
@@ -70,11 +72,12 @@ class FakeAudioTrack : public AudioTrack {
 
   mutable std::mutex mutex_;
   PlayState play_state_ = PlayState::kStopped;
+  int pause_and_flush_count_ = 0;
   int64_t written_frames_ = 0;
   int64_t consumed_frames_ = 0;
   double playback_rate_ = 1.0;
   double volume_ = 1.0;
-  bool device_changed_ = false;
+  AudioDeviceChange device_change_ = AudioDeviceChange::kNone;
   int underrun_count_ = 0;
   int start_threshold_ = 1024;
   int write_error_code_ = 0;

--- a/starboard/android/shared/ndk_audio_track.cc
+++ b/starboard/android/shared/ndk_audio_track.cc
@@ -265,16 +265,17 @@ int64_t NdkAudioTrack::GetAudioTimestamp(int64_t* updated_at) {
   return frames_read;
 }
 
-bool NdkAudioTrack::GetAndResetHasAudioDeviceChanged() {
+// TODO: b/523148108 - Implement seamless switch for NDK.
+AudioTrack::AudioDeviceChange NdkAudioTrack::GetAndResetAudioDeviceChange() {
   if (has_reported_device_changed_) {
-    return false;
+    return AudioDeviceChange::kNone;
   }
   aaudio_stream_state_t state = AAudio::Stream_GetState(stream_.get());
   if (state == AAUDIO_STREAM_STATE_DISCONNECTED) {
     has_reported_device_changed_ = true;
-    return true;
+    return AudioDeviceChange::kRestartPlayer;
   }
-  return false;
+  return AudioDeviceChange::kNone;
 }
 
 int NdkAudioTrack::GetUnderrunCount() {

--- a/starboard/android/shared/ndk_audio_track.h
+++ b/starboard/android/shared/ndk_audio_track.h
@@ -76,7 +76,7 @@ class NdkAudioTrack final : public AudioTrack {
   void SetVolume(double volume) override;
 
   int64_t GetAudioTimestamp(int64_t* updated_at) override;
-  bool GetAndResetHasAudioDeviceChanged() override;
+  AudioDeviceChange GetAndResetAudioDeviceChange() override;
   int GetUnderrunCount() override;
   int GetStartThresholdInFrames() override;
   PlayState GetPlayState() override;

--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -593,6 +593,9 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
       SB_LOG_IF(INFO, pause_using_audio_track_state)
           << "pause_using_audio_track_state is set to true.";
 
+      AudioOutputManager::SetSeamlessAudioSwitching(
+          experimental_features.GetBool(kMediaSeamlessAudioSwitching));
+
       const bool force_platform_opus_decoder = force_platform_opus_decoder_;
       auto decoder_creator =
           [enable_flush_during_seek, force_platform_opus_decoder, job_queue](

--- a/starboard/shared/starboard/experimental_features.h
+++ b/starboard/shared/starboard/experimental_features.h
@@ -224,6 +224,9 @@ inline constexpr ExperimentalFeatureKey<bool> kMediaNdkVideo("Media.NdkVideo");
 inline constexpr ExperimentalFeatureKey<bool> kMediaPauseUsingAudioTrackState(
     "Media.PauseUsingAudioTrackState");
 
+inline constexpr ExperimentalFeatureKey<bool> kMediaSeamlessAudioSwitching(
+    "Media.SeamlessAudioSwitching");
+
 inline constexpr ExperimentalFeatureKey<bool> kMediaSkipFlushOnDecoderTeardown(
     "Media.SkipFlushOnDecoderTeardown");
 


### PR DESCRIPTION
Android's AudioFlinger dynamically routes active PCM AudioTracks between built-in speakers and Bluetooth A2DP devices without requiring player pipeline destruction.

Previously, any Bluetooth or HDMI audio device change unconditionally triggered a capability changed error, destroying and recreating the entire player pipeline and hardware video decoder (causing a ~2.5s black screen).

This change allows PCM audio playback to transition seamlessly across audio device changes without player recreation:
- Guard the feature behind the `Media.EnableSeamlessAudioSwitching` experimental feature flag.
- Introduce an `AudioDeviceChange` enum (`kNone`, `kResetAndContinue`, `kRestartPlayer`) shared between C++ and Java via `java_cpp_enum`.
- For seamless transitions (`kResetAndContinue`), flush and re-feed unconsumed frames from the sink ring buffer to re-baseline timestamps and latency without tearing down the player or decoder.
- Continue triggering `kRestartPlayer` if an active track uses encoded passthrough (e.g. AC3/E-AC3) or if the new device configuration supports surround passthrough, allowing the player to renegotiate surround formats.
- Add unit tests for `AudioDeviceChange` handling in `audio_track_audio_sink_type_test`.

Bug: 523148108
