### PR TITLE
ci: Add interactive confirmation and command logging to merge_autoroll.py

### DIFF
--- a/cobalt/devinfra/github/autoroll/merge_autoroll.py
+++ b/cobalt/devinfra/github/autoroll/merge_autoroll.py
@@ -217,24 +217,17 @@ def rebase_and_push(target, pr, env):
     git('rebase', f'origin/{target}')
 
     log(f'Pushing {target}...')
-    pr_url = pr.get('url', 'URL not found')
-    log(f'PR URL: {pr_url}')
-    try:
-      response = input(
-          'Do you want to merge this PR? Type "yes" to confirm: '
-      )
-    except EOFError:
-      log('No input provided (EOF). Aborting.')
-      response = 'no'
-
-    if response.strip().lower() == 'yes':
-      git('push',
-          REPO_URL,
-          f'HEAD:{target}',
-          authenticated=True,
-          env=env)
-    else:
+    log(f"PR URL: {pr['url']}")
+    response = input('Do you want to merge this PR? Type "yes" to confirm: ')
+    if response.strip().lower() != 'yes':
       log('Aborting push.')
+      return
+
+    git('push',
+        REPO_URL,
+        f'HEAD:{target}',
+        authenticated=True,
+        env=env)
   finally:
     log('Cleaning up temporary worktree...')
     os.chdir(orig_cwd)

--- a/cobalt/devinfra/github/autoroll/merge_autoroll.py
+++ b/cobalt/devinfra/github/autoroll/merge_autoroll.py
@@ -55,8 +55,8 @@ def git(*args, authenticated=False, **kwargs):
   auth_args = []
   if authenticated:
     auth_args = [
-        '-c', 'credential.helper=',
-        '-c', 'credential.helper=!gh auth git-credential'
+        '-c', 'credential.helper=', '-c',
+        'credential.helper=!gh auth git-credential'
     ]
   return run_cmd(['git'] + auth_args + list(args), **kwargs)
 
@@ -197,11 +197,7 @@ def rebase_and_push(target, pr, env):
         env=env)
 
     log('Creating temporary worktree...')
-    git('worktree',
-        'add',
-        '--no-checkout',
-        tmpdir,
-        f'origin/{head}')
+    git('worktree', 'add', '--no-checkout', tmpdir, f'origin/{head}')
     worktree_added = True
 
     os.chdir(tmpdir)
@@ -213,7 +209,8 @@ def rebase_and_push(target, pr, env):
     autoroll_files = ['.github/AUTOROLL', '.github/AUTOROLL_CHROMIUM']
     for f in autoroll_files:
       if has_conflicts(f):
-        log(f'Error: Autoroll file {f} contains conflict markers or is marked CONFLICTED.')
+        log(f'Error: Autoroll file {f} contains conflict markers or is marked CONFLICTED.'
+           )
         sys.exit(1)
 
     log('Rebasing...')
@@ -226,11 +223,7 @@ def rebase_and_push(target, pr, env):
       return
 
     log(f'Pushing {target}...')
-    git('push',
-        REPO_URL,
-        f'HEAD:{target}',
-        authenticated=True,
-        env=env)
+    git('push', REPO_URL, f'HEAD:{target}', authenticated=True, env=env)
   finally:
     log('Cleaning up temporary worktree...')
     os.chdir(orig_cwd)
@@ -242,8 +235,9 @@ def rebase_and_push(target, pr, env):
 
 def main():
   parser = argparse.ArgumentParser(
-      description=('Merge autoroll PRs. Target repository can be configured via '
-                   'the GITHUB_REPOSITORY environment variable.'))
+      description=(
+          'Merge autoroll PRs. Target repository can be configured via '
+          'the GITHUB_REPOSITORY environment variable.'))
   parser.add_argument(
       '--source-branch', required=True, help='Source branch name')
   parser.add_argument(

--- a/cobalt/devinfra/github/autoroll/merge_autoroll.py
+++ b/cobalt/devinfra/github/autoroll/merge_autoroll.py
@@ -28,9 +28,8 @@ import tempfile
 import time
 import urllib.request
 
-# Global configuration for target repository.
-REPO_OWNER_PATH = os.environ.get('GITHUB_REPOSITORY', 'youtube/cobalt_sandbox')
-REPO_URL = f'https://github.com/{REPO_OWNER_PATH}.git'
+# Global configuration default for target repository.
+DEFAULT_REPO = os.environ.get('GITHUB_REPOSITORY', 'youtube/cobalt_sandbox')
 
 # GitHub App IDs for cobalt-github-releaser.
 APP_ID = '3203510'
@@ -42,6 +41,8 @@ def log(msg):
 
 
 def run_cmd(cmd, check=True, **kwargs):
+  cmd_str = ' '.join(str(x) for x in cmd)
+  print(f'+ {cmd_str}')
   return subprocess.run(cmd, check=check, **kwargs).stdout
 
 
@@ -127,13 +128,13 @@ def read_private_key():
   return key_content
 
 
-def find_open_autoroll_pr(source, target, env):
+def find_open_autoroll_pr(source, target, env, repo):
   head_branch = f'autoroll-{source}-to-{target}'
   prs_json = gh(
       'pr',
       'list',
       '--repo',
-      REPO_OWNER_PATH,
+      repo,
       '--state',
       'open',
       '--head',
@@ -173,7 +174,7 @@ def has_conflicts(filepath):
   return False
 
 
-def rebase_and_push(target, pr, env):
+def rebase_and_push(target, pr, env, repo_url, dry_run=True):
   head = pr['headRefName']
   pr_number = pr['number']
   log(f'Found PR #{pr_number}: {head} -> {target}')
@@ -184,7 +185,7 @@ def rebase_and_push(target, pr, env):
   try:
     log('Fetching branches...')
     git('fetch',
-        REPO_URL,
+        repo_url,
         f'+{target}:refs/remotes/origin/{target}',
         f'+{head}:refs/remotes/origin/{head}',
         authenticated=True,
@@ -214,11 +215,14 @@ def rebase_and_push(target, pr, env):
     git('rebase', f'origin/{target}')
 
     log(f'Pushing {target}...')
-    git('push',
-        REPO_URL,
-        f'HEAD:{target}',
-        authenticated=True,
-        env=env)
+    if dry_run:
+      log(f'[DRY RUN] Would run: git push {repo_url} HEAD:{target}')
+    else:
+      git('push',
+          repo_url,
+          f'HEAD:{target}',
+          authenticated=True,
+          env=env)
   finally:
     log('Cleaning up temporary worktree...')
     os.chdir(orig_cwd)
@@ -238,11 +242,23 @@ def main():
       '--key-file',
       help=('Path to GitHub App Private Key (.pem file).'
             'Omit to provide key from stdin.'))
+  parser.add_argument(
+      '--repo',
+      help='GitHub repository (owner/repo).')
+  parser.add_argument(
+      '--apply',
+      action='store_true',
+      help='Apply changes (disable dry-run mode).')
   args = parser.parse_args()
 
   source = args.source_branch
   target = args.target_branch
   key_file = args.key_file
+
+  repo = args.repo or DEFAULT_REPO
+  repo_url = f'https://github.com/{repo}.git'
+
+  dry_run = not args.apply
 
   if not key_file:
     private_key = read_private_key()
@@ -253,8 +269,8 @@ def main():
   token = get_installation_access_token(APP_ID, key_file)
   env = {'GITHUB_TOKEN': token}
 
-  pr = find_open_autoroll_pr(source, target, env)
-  rebase_and_push(target, pr, env)
+  pr = find_open_autoroll_pr(source, target, env, repo)
+  rebase_and_push(target, pr, env, repo_url, dry_run=dry_run)
 
 
 if __name__ == '__main__':

--- a/cobalt/devinfra/github/autoroll/merge_autoroll.py
+++ b/cobalt/devinfra/github/autoroll/merge_autoroll.py
@@ -21,6 +21,7 @@ import argparse
 import base64
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -41,7 +42,7 @@ def log(msg):
 
 
 def run_cmd(cmd, check=True, **kwargs):
-  cmd_str = ' '.join(str(x) for x in cmd)
+  cmd_str = shlex.join(str(x) for x in cmd)
   print(f'+ {cmd_str}')
   return subprocess.run(cmd, check=check, **kwargs).stdout
 

--- a/cobalt/devinfra/github/autoroll/merge_autoroll.py
+++ b/cobalt/devinfra/github/autoroll/merge_autoroll.py
@@ -209,10 +209,8 @@ def rebase_and_push(target, pr, env):
     autoroll_files = ['.github/AUTOROLL', '.github/AUTOROLL_CHROMIUM']
     for f in autoroll_files:
       if has_conflicts(f):
-        log(
-            f'Error: Autoroll file {f} contains conflict markers or is '
-            'marked CONFLICTED.'
-        )
+        log(f'Error: Autoroll file {f} contains conflict markers or is '
+            'marked CONFLICTED.')
         sys.exit(1)
 
     log('Rebasing...')

--- a/cobalt/devinfra/github/autoroll/merge_autoroll.py
+++ b/cobalt/devinfra/github/autoroll/merge_autoroll.py
@@ -29,8 +29,9 @@ import tempfile
 import time
 import urllib.request
 
-# Global configuration default for target repository.
-DEFAULT_REPO = os.environ.get('GITHUB_REPOSITORY', 'youtube/cobalt_sandbox')
+# Global configuration for target repository.
+REPO_OWNER_PATH = os.environ.get('GITHUB_REPOSITORY', 'youtube/cobalt_sandbox')
+REPO_URL = f'https://github.com/{REPO_OWNER_PATH}.git'
 
 # GitHub App IDs for cobalt-github-releaser.
 APP_ID = '3203510'
@@ -129,13 +130,13 @@ def read_private_key():
   return key_content
 
 
-def find_open_autoroll_pr(source, target, env, repo):
+def find_open_autoroll_pr(source, target, env):
   head_branch = f'autoroll-{source}-to-{target}'
   prs_json = gh(
       'pr',
       'list',
       '--repo',
-      repo,
+      REPO_OWNER_PATH,
       '--state',
       'open',
       '--head',
@@ -175,7 +176,7 @@ def has_conflicts(filepath):
   return False
 
 
-def rebase_and_push(target, pr, env, repo_url, apply=False):
+def rebase_and_push(target, pr, env, apply=False):
   head = pr['headRefName']
   pr_number = pr['number']
   log(f'Found PR #{pr_number}: {head} -> {target}')
@@ -186,7 +187,7 @@ def rebase_and_push(target, pr, env, repo_url, apply=False):
   try:
     log('Fetching branches...')
     git('fetch',
-        repo_url,
+        REPO_URL,
         f'+{target}:refs/remotes/origin/{target}',
         f'+{head}:refs/remotes/origin/{head}',
         authenticated=True,
@@ -218,12 +219,12 @@ def rebase_and_push(target, pr, env, repo_url, apply=False):
     log(f'Pushing {target}...')
     if apply:
       git('push',
-          repo_url,
+          REPO_URL,
           f'HEAD:{target}',
           authenticated=True,
           env=env)
     else:
-      log(f'[DRY RUN] Would run: git push {repo_url} HEAD:{target}')
+      log(f'[DRY RUN] Would run: git push {REPO_URL} HEAD:{target}')
   finally:
     log('Cleaning up temporary worktree...')
     os.chdir(orig_cwd)
@@ -234,7 +235,9 @@ def rebase_and_push(target, pr, env, repo_url, apply=False):
 
 
 def main():
-  parser = argparse.ArgumentParser(description='Merge autoroll PRs.')
+  parser = argparse.ArgumentParser(
+      description=('Merge autoroll PRs. Target repository can be configured via '
+                   'the GITHUB_REPOSITORY environment variable.'))
   parser.add_argument(
       '--source-branch', required=True, help='Source branch name')
   parser.add_argument(
@@ -243,9 +246,6 @@ def main():
       '--key-file',
       help=('Path to GitHub App Private Key (.pem file).'
             'Omit to provide key from stdin.'))
-  parser.add_argument(
-      '--repo',
-      help='GitHub repository (owner/repo).')
   parser.add_argument(
       '--apply',
       action='store_true',
@@ -256,9 +256,6 @@ def main():
   target = args.target_branch
   key_file = args.key_file
 
-  repo = args.repo or DEFAULT_REPO
-  repo_url = f'https://github.com/{repo}.git'
-
   if not key_file:
     private_key = read_private_key()
     temp_fd, key_file = tempfile.mkstemp(suffix='.pem')
@@ -268,8 +265,8 @@ def main():
   token = get_installation_access_token(APP_ID, key_file)
   env = {'GITHUB_TOKEN': token}
 
-  pr = find_open_autoroll_pr(source, target, env, repo)
-  rebase_and_push(target, pr, env, repo_url, apply=args.apply)
+  pr = find_open_autoroll_pr(source, target, env)
+  rebase_and_push(target, pr, env, apply=args.apply)
 
 
 if __name__ == '__main__':

--- a/cobalt/devinfra/github/autoroll/merge_autoroll.py
+++ b/cobalt/devinfra/github/autoroll/merge_autoroll.py
@@ -43,7 +43,10 @@ def log(msg):
 
 
 def run_cmd(cmd, check=True, **kwargs):
-  cmd_str = shlex.join(str(x) for x in cmd)
+  if isinstance(cmd, str):
+    cmd_str = cmd
+  else:
+    cmd_str = shlex.join(str(x) for x in cmd)
   print(f'+ {cmd_str}')
   return subprocess.run(cmd, check=check, **kwargs).stdout
 

--- a/cobalt/devinfra/github/autoroll/merge_autoroll.py
+++ b/cobalt/devinfra/github/autoroll/merge_autoroll.py
@@ -142,7 +142,7 @@ def find_open_autoroll_pr(source, target, env):
       '--head',
       head_branch,
       '--json',
-      'number,headRefName,baseRefName,title',
+      'number,headRefName,baseRefName,title,url',
       capture_output=True,
       text=True,
       env=env)
@@ -176,7 +176,7 @@ def has_conflicts(filepath):
   return False
 
 
-def rebase_and_push(target, pr, env, apply=False):
+def rebase_and_push(target, pr, env):
   head = pr['headRefName']
   pr_number = pr['number']
   log(f'Found PR #{pr_number}: {head} -> {target}')
@@ -217,14 +217,24 @@ def rebase_and_push(target, pr, env, apply=False):
     git('rebase', f'origin/{target}')
 
     log(f'Pushing {target}...')
-    if apply:
+    pr_url = pr.get('url', 'URL not found')
+    log(f'PR URL: {pr_url}')
+    try:
+      response = input(
+          'Do you want to merge this PR? Type "yes" to confirm: '
+      )
+    except EOFError:
+      log('No input provided (EOF). Aborting.')
+      response = 'no'
+
+    if response.strip().lower() == 'yes':
       git('push',
           REPO_URL,
           f'HEAD:{target}',
           authenticated=True,
           env=env)
     else:
-      log(f'[DRY RUN] Would run: git push {REPO_URL} HEAD:{target}')
+      log('Aborting push.')
   finally:
     log('Cleaning up temporary worktree...')
     os.chdir(orig_cwd)
@@ -246,10 +256,6 @@ def main():
       '--key-file',
       help=('Path to GitHub App Private Key (.pem file).'
             'Omit to provide key from stdin.'))
-  parser.add_argument(
-      '--apply',
-      action='store_true',
-      help='Apply changes (disable dry-run mode).')
   args = parser.parse_args()
 
   source = args.source_branch
@@ -266,7 +272,7 @@ def main():
   env = {'GITHUB_TOKEN': token}
 
   pr = find_open_autoroll_pr(source, target, env)
-  rebase_and_push(target, pr, env, apply=args.apply)
+  rebase_and_push(target, pr, env)
 
 
 if __name__ == '__main__':

--- a/cobalt/devinfra/github/autoroll/merge_autoroll.py
+++ b/cobalt/devinfra/github/autoroll/merge_autoroll.py
@@ -175,7 +175,7 @@ def has_conflicts(filepath):
   return False
 
 
-def rebase_and_push(target, pr, env, repo_url, dry_run=True):
+def rebase_and_push(target, pr, env, repo_url, apply=False):
   head = pr['headRefName']
   pr_number = pr['number']
   log(f'Found PR #{pr_number}: {head} -> {target}')
@@ -216,14 +216,14 @@ def rebase_and_push(target, pr, env, repo_url, dry_run=True):
     git('rebase', f'origin/{target}')
 
     log(f'Pushing {target}...')
-    if dry_run:
-      log(f'[DRY RUN] Would run: git push {repo_url} HEAD:{target}')
-    else:
+    if apply:
       git('push',
           repo_url,
           f'HEAD:{target}',
           authenticated=True,
           env=env)
+    else:
+      log(f'[DRY RUN] Would run: git push {repo_url} HEAD:{target}')
   finally:
     log('Cleaning up temporary worktree...')
     os.chdir(orig_cwd)
@@ -259,8 +259,6 @@ def main():
   repo = args.repo or DEFAULT_REPO
   repo_url = f'https://github.com/{repo}.git'
 
-  dry_run = not args.apply
-
   if not key_file:
     private_key = read_private_key()
     temp_fd, key_file = tempfile.mkstemp(suffix='.pem')
@@ -271,7 +269,7 @@ def main():
   env = {'GITHUB_TOKEN': token}
 
   pr = find_open_autoroll_pr(source, target, env, repo)
-  rebase_and_push(target, pr, env, repo_url, dry_run=dry_run)
+  rebase_and_push(target, pr, env, repo_url, apply=args.apply)
 
 
 if __name__ == '__main__':

--- a/cobalt/devinfra/github/autoroll/merge_autoroll.py
+++ b/cobalt/devinfra/github/autoroll/merge_autoroll.py
@@ -174,7 +174,7 @@ def has_conflicts(filepath):
       for line in f:
         if line.startswith('CONFLICTED:') or line.startswith('<<<<<<<'):
           return True
-  except Exception as e:
+  except OSError as e:
     log(f'Error reading {filepath}: {e}')
   return False
 
@@ -209,8 +209,10 @@ def rebase_and_push(target, pr, env):
     autoroll_files = ['.github/AUTOROLL', '.github/AUTOROLL_CHROMIUM']
     for f in autoroll_files:
       if has_conflicts(f):
-        log(f'Error: Autoroll file {f} contains conflict markers or is marked CONFLICTED.'
-           )
+        log(
+            f'Error: Autoroll file {f} contains conflict markers or is '
+            'marked CONFLICTED.'
+        )
         sys.exit(1)
 
     log('Rebasing...')

--- a/cobalt/devinfra/github/autoroll/merge_autoroll.py
+++ b/cobalt/devinfra/github/autoroll/merge_autoroll.py
@@ -216,13 +216,13 @@ def rebase_and_push(target, pr, env):
     log('Rebasing...')
     git('rebase', f'origin/{target}')
 
-    log(f'Pushing {target}...')
-    log(f"PR URL: {pr['url']}")
+    log(f'PR URL: {pr["url"]}')
     response = input('Do you want to merge this PR? Type "yes" to confirm: ')
     if response.strip().lower() != 'yes':
       log('Aborting push.')
       return
 
+    log(f'Pushing {target}...')
     git('push',
         REPO_URL,
         f'HEAD:{target}',

--- a/cobalt/devinfra/github/autoroll/merge_autoroll_test.py
+++ b/cobalt/devinfra/github/autoroll/merge_autoroll_test.py
@@ -84,6 +84,7 @@ class TestMergeAutoroll(unittest.TestCase):
           'title': 'Autoroll from main to target',
           'headRefName': 'autoroll-main-to-target',
           'baseRefName': 'target',
+          'url': 'https://github.com/youtube/cobalt/pull/1',
       }]
 
     def run_side_effect(args, **kwargs):

--- a/cobalt/devinfra/github/autoroll/merge_autoroll_test.py
+++ b/cobalt/devinfra/github/autoroll/merge_autoroll_test.py
@@ -220,7 +220,8 @@ class TestMergeAutoroll(unittest.TestCase):
 
   @patch('subprocess.run')
   def test_main_conflicted_pr(self, mock_run):
-    # Mock gh pr list returning a conflicted PR (using the actual format from workflow)
+    # Mock gh pr list returning a conflicted PR (using the actual format from
+    # workflow)
     self._setup_mock_run(
         mock_run,
         prs_list=[{
@@ -256,7 +257,7 @@ class TestMergeAutoroll(unittest.TestCase):
 
         os.makedirs(os.path.join(test_tmpdir, '.github'))
         autoroll_path = os.path.join(test_tmpdir, '.github/AUTOROLL')
-        with open(autoroll_path, 'w') as f:
+        with open(autoroll_path, 'w', encoding='utf-8') as f:
           f.write(conflict_content)
 
         # Reset mock_run call history for each iteration

--- a/cobalt/devinfra/github/autoroll/merge_autoroll_test.py
+++ b/cobalt/devinfra/github/autoroll/merge_autoroll_test.py
@@ -140,7 +140,7 @@ class TestMergeAutoroll(unittest.TestCase):
 
     # Verify gh pr list call
     mock_run.assert_any_call([
-        'gh', 'pr', 'list', '--repo', merge_autoroll.DEFAULT_REPO,
+        'gh', 'pr', 'list', '--repo', merge_autoroll.REPO_OWNER_PATH,
         '--state', 'open', '--head', 'autoroll-main-to-target', '--json',
         'number,headRefName,baseRefName,title'
     ],
@@ -153,7 +153,7 @@ class TestMergeAutoroll(unittest.TestCase):
     mock_run.assert_any_call([
         'git', '-c', 'credential.helper=', '-c',
         'credential.helper=!gh auth git-credential', 'fetch',
-        f'https://github.com/{merge_autoroll.DEFAULT_REPO}.git', '+target:refs/remotes/origin/target',
+        merge_autoroll.REPO_URL, '+target:refs/remotes/origin/target',
         '+autoroll-main-to-target:refs/remotes/origin/autoroll-main-to-target'
     ],
                              check=True,
@@ -194,39 +194,7 @@ class TestMergeAutoroll(unittest.TestCase):
     mock_run.assert_any_call([
         'git', '-c', 'credential.helper=', '-c',
         'credential.helper=!gh auth git-credential', 'push',
-        f'https://github.com/{merge_autoroll.DEFAULT_REPO}.git', 'HEAD:target'
-    ],
-                             check=True,
-                             env=unittest.mock.ANY)
-
-  @patch('subprocess.run')
-  def test_main_custom_repo(self, mock_run):
-    self._setup_mock_run(mock_run)
-    custom_repo = 'my-org/my-repo'
-    custom_url = f'https://github.com/{custom_repo}.git'
-
-    # Test with --repo parameter
-    with patch('sys.argv', sys.argv + ['--repo', custom_repo, '--apply']):
-      with patch('sys.stdout'), patch('sys.stderr'):
-        merge_autoroll.main()
-
-    # Verify gh pr list call uses custom repo
-    mock_run.assert_any_call([
-        'gh', 'pr', 'list', '--repo', custom_repo,
-        '--state', 'open', '--head', 'autoroll-main-to-target', '--json',
-        'number,headRefName,baseRefName,title'
-    ],
-                             capture_output=True,
-                             text=True,
-                             check=True,
-                             env=unittest.mock.ANY)
-
-    # Verify git fetch call uses custom repo url
-    mock_run.assert_any_call([
-        'git', '-c', 'credential.helper=', '-c',
-        'credential.helper=!gh auth git-credential', 'fetch',
-        custom_url, '+target:refs/remotes/origin/target',
-        '+autoroll-main-to-target:refs/remotes/origin/autoroll-main-to-target'
+        merge_autoroll.REPO_URL, 'HEAD:target'
     ],
                              check=True,
                              env=unittest.mock.ANY)
@@ -239,7 +207,7 @@ class TestMergeAutoroll(unittest.TestCase):
         merge_autoroll.main()
     self.assertEqual(cm.exception.code, 0)
     mock_run.assert_called_once_with([
-        'gh', 'pr', 'list', '--repo', merge_autoroll.DEFAULT_REPO,
+        'gh', 'pr', 'list', '--repo', merge_autoroll.REPO_OWNER_PATH,
         '--state', 'open', '--head', 'autoroll-main-to-target', '--json',
         'number,headRefName,baseRefName,title'
     ],
@@ -266,7 +234,7 @@ class TestMergeAutoroll(unittest.TestCase):
 
     self.assertEqual(cm.exception.code, 1)
     mock_run.assert_called_once_with([
-        'gh', 'pr', 'list', '--repo', merge_autoroll.DEFAULT_REPO,
+        'gh', 'pr', 'list', '--repo', merge_autoroll.REPO_OWNER_PATH,
         '--state', 'open', '--head', 'autoroll-main-to-target', '--json',
         'number,headRefName,baseRefName,title'
     ],
@@ -309,7 +277,7 @@ class TestMergeAutoroll(unittest.TestCase):
       with self.assertRaises(subprocess.CalledProcessError):
         merge_autoroll.main()
     mock_run.assert_called_once_with([
-        'gh', 'pr', 'list', '--repo', merge_autoroll.DEFAULT_REPO,
+        'gh', 'pr', 'list', '--repo', merge_autoroll.REPO_OWNER_PATH,
         '--state', 'open', '--head', 'autoroll-main-to-target', '--json',
         'number,headRefName,baseRefName,title'
     ],

--- a/cobalt/devinfra/github/autoroll/merge_autoroll_test.py
+++ b/cobalt/devinfra/github/autoroll/merge_autoroll_test.py
@@ -131,10 +131,11 @@ class TestMergeAutoroll(unittest.TestCase):
     mock_run.side_effect = run_side_effect
 
   @patch('subprocess.run')
-  def test_main_success(self, mock_run):
+  @patch('builtins.input', return_value='no')
+  def test_main_success(self, mock_input, mock_run):
     self._setup_mock_run(mock_run)
 
-    # By default, dry_run=True, so push is NOT called.
+    # By default, confirmation is 'no', so push is NOT called.
     with patch('sys.stdout'), patch('sys.stderr'):
       merge_autoroll.main()
 
@@ -142,7 +143,7 @@ class TestMergeAutoroll(unittest.TestCase):
     mock_run.assert_any_call([
         'gh', 'pr', 'list', '--repo', merge_autoroll.REPO_OWNER_PATH,
         '--state', 'open', '--head', 'autoroll-main-to-target', '--json',
-        'number,headRefName,baseRefName,title'
+        'number,headRefName,baseRefName,title,url'
     ],
                              capture_output=True,
                              text=True,
@@ -182,13 +183,13 @@ class TestMergeAutoroll(unittest.TestCase):
     self.mock_get_token.assert_called_once_with('3203510', '/tmp/fake_key.pem')
 
   @patch('subprocess.run')
-  def test_main_success_apply(self, mock_run):
+  @patch('builtins.input', return_value='yes')
+  def test_main_success_confirm_yes(self, mock_input, mock_run):
     self._setup_mock_run(mock_run)
 
-    # Test with --apply which disables dry-run mode
-    with patch('sys.argv', sys.argv + ['--apply']):
-      with patch('sys.stdout'), patch('sys.stderr'):
-        merge_autoroll.main()
+    # Test with confirmation 'yes' which triggers push
+    with patch('sys.stdout'), patch('sys.stderr'):
+      merge_autoroll.main()
 
     # Verify git push was called
     mock_run.assert_any_call([
@@ -209,7 +210,7 @@ class TestMergeAutoroll(unittest.TestCase):
     mock_run.assert_called_once_with([
         'gh', 'pr', 'list', '--repo', merge_autoroll.REPO_OWNER_PATH,
         '--state', 'open', '--head', 'autoroll-main-to-target', '--json',
-        'number,headRefName,baseRefName,title'
+        'number,headRefName,baseRefName,title,url'
     ],
                                      capture_output=True,
                                      text=True,
@@ -236,7 +237,7 @@ class TestMergeAutoroll(unittest.TestCase):
     mock_run.assert_called_once_with([
         'gh', 'pr', 'list', '--repo', merge_autoroll.REPO_OWNER_PATH,
         '--state', 'open', '--head', 'autoroll-main-to-target', '--json',
-        'number,headRefName,baseRefName,title'
+        'number,headRefName,baseRefName,title,url'
     ],
                                      capture_output=True,
                                      text=True,
@@ -279,7 +280,7 @@ class TestMergeAutoroll(unittest.TestCase):
     mock_run.assert_called_once_with([
         'gh', 'pr', 'list', '--repo', merge_autoroll.REPO_OWNER_PATH,
         '--state', 'open', '--head', 'autoroll-main-to-target', '--json',
-        'number,headRefName,baseRefName,title'
+        'number,headRefName,baseRefName,title,url'
     ],
                                      capture_output=True,
                                      text=True,

--- a/cobalt/devinfra/github/autoroll/merge_autoroll_test.py
+++ b/cobalt/devinfra/github/autoroll/merge_autoroll_test.py
@@ -134,12 +134,13 @@ class TestMergeAutoroll(unittest.TestCase):
   def test_main_success(self, mock_run):
     self._setup_mock_run(mock_run)
 
+    # By default, dry_run=True, so push is NOT called.
     with patch('sys.stdout'), patch('sys.stderr'):
       merge_autoroll.main()
 
     # Verify gh pr list call
     mock_run.assert_any_call([
-        'gh', 'pr', 'list', '--repo', merge_autoroll.REPO_OWNER_PATH,
+        'gh', 'pr', 'list', '--repo', merge_autoroll.DEFAULT_REPO,
         '--state', 'open', '--head', 'autoroll-main-to-target', '--json',
         'number,headRefName,baseRefName,title'
     ],
@@ -148,11 +149,11 @@ class TestMergeAutoroll(unittest.TestCase):
                              check=True,
                              env=unittest.mock.ANY)
 
-    # Verify key subprocess calls
+    # Verify key subprocess calls (push should NOT be present)
     mock_run.assert_any_call([
         'git', '-c', 'credential.helper=', '-c',
         'credential.helper=!gh auth git-credential', 'fetch',
-        merge_autoroll.REPO_URL, '+target:refs/remotes/origin/target',
+        f'https://github.com/{merge_autoroll.DEFAULT_REPO}.git', '+target:refs/remotes/origin/target',
         '+autoroll-main-to-target:refs/remotes/origin/autoroll-main-to-target'
     ],
                              check=True,
@@ -168,18 +169,67 @@ class TestMergeAutoroll(unittest.TestCase):
                              check=True)
     mock_run.assert_any_call(['git', 'checkout'], check=True)
     mock_run.assert_any_call(['git', 'rebase', 'origin/target'], check=True)
-    mock_run.assert_any_call([
-        'git', '-c', 'credential.helper=', '-c',
-        'credential.helper=!gh auth git-credential', 'push',
-        merge_autoroll.REPO_URL, 'HEAD:target'
-    ],
-                             check=True,
-                             env=unittest.mock.ANY)
+
+    # Assert git push was NOT called
+    for call in mock_run.call_args_list:
+      args = call[0][0]
+      self.assertFalse(len(args) > 1 and args[0] == 'git' and args[1] == 'push')
+
     mock_run.assert_any_call(
         ['git', 'worktree', 'remove', '--force', unittest.mock.ANY],
         check=False)
 
     self.mock_get_token.assert_called_once_with('3203510', '/tmp/fake_key.pem')
+
+  @patch('subprocess.run')
+  def test_main_success_apply(self, mock_run):
+    self._setup_mock_run(mock_run)
+
+    # Test with --apply which disables dry-run mode
+    with patch('sys.argv', sys.argv + ['--apply']):
+      with patch('sys.stdout'), patch('sys.stderr'):
+        merge_autoroll.main()
+
+    # Verify git push was called
+    mock_run.assert_any_call([
+        'git', '-c', 'credential.helper=', '-c',
+        'credential.helper=!gh auth git-credential', 'push',
+        f'https://github.com/{merge_autoroll.DEFAULT_REPO}.git', 'HEAD:target'
+    ],
+                             check=True,
+                             env=unittest.mock.ANY)
+
+  @patch('subprocess.run')
+  def test_main_custom_repo(self, mock_run):
+    self._setup_mock_run(mock_run)
+    custom_repo = 'my-org/my-repo'
+    custom_url = f'https://github.com/{custom_repo}.git'
+
+    # Test with --repo parameter
+    with patch('sys.argv', sys.argv + ['--repo', custom_repo, '--apply']):
+      with patch('sys.stdout'), patch('sys.stderr'):
+        merge_autoroll.main()
+
+    # Verify gh pr list call uses custom repo
+    mock_run.assert_any_call([
+        'gh', 'pr', 'list', '--repo', custom_repo,
+        '--state', 'open', '--head', 'autoroll-main-to-target', '--json',
+        'number,headRefName,baseRefName,title'
+    ],
+                             capture_output=True,
+                             text=True,
+                             check=True,
+                             env=unittest.mock.ANY)
+
+    # Verify git fetch call uses custom repo url
+    mock_run.assert_any_call([
+        'git', '-c', 'credential.helper=', '-c',
+        'credential.helper=!gh auth git-credential', 'fetch',
+        custom_url, '+target:refs/remotes/origin/target',
+        '+autoroll-main-to-target:refs/remotes/origin/autoroll-main-to-target'
+    ],
+                             check=True,
+                             env=unittest.mock.ANY)
 
   @patch('subprocess.run')
   def test_main_no_pr_found(self, mock_run):
@@ -189,7 +239,7 @@ class TestMergeAutoroll(unittest.TestCase):
         merge_autoroll.main()
     self.assertEqual(cm.exception.code, 0)
     mock_run.assert_called_once_with([
-        'gh', 'pr', 'list', '--repo', merge_autoroll.REPO_OWNER_PATH,
+        'gh', 'pr', 'list', '--repo', merge_autoroll.DEFAULT_REPO,
         '--state', 'open', '--head', 'autoroll-main-to-target', '--json',
         'number,headRefName,baseRefName,title'
     ],
@@ -216,7 +266,7 @@ class TestMergeAutoroll(unittest.TestCase):
 
     self.assertEqual(cm.exception.code, 1)
     mock_run.assert_called_once_with([
-        'gh', 'pr', 'list', '--repo', merge_autoroll.REPO_OWNER_PATH,
+        'gh', 'pr', 'list', '--repo', merge_autoroll.DEFAULT_REPO,
         '--state', 'open', '--head', 'autoroll-main-to-target', '--json',
         'number,headRefName,baseRefName,title'
     ],
@@ -259,7 +309,7 @@ class TestMergeAutoroll(unittest.TestCase):
       with self.assertRaises(subprocess.CalledProcessError):
         merge_autoroll.main()
     mock_run.assert_called_once_with([
-        'gh', 'pr', 'list', '--repo', merge_autoroll.REPO_OWNER_PATH,
+        'gh', 'pr', 'list', '--repo', merge_autoroll.DEFAULT_REPO,
         '--state', 'open', '--head', 'autoroll-main-to-target', '--json',
         'number,headRefName,baseRefName,title'
     ],

--- a/cobalt/devinfra/github/autoroll/merge_autoroll_test.py
+++ b/cobalt/devinfra/github/autoroll/merge_autoroll_test.py
@@ -142,8 +142,8 @@ class TestMergeAutoroll(unittest.TestCase):
 
     # Verify gh pr list call
     mock_run.assert_any_call([
-        'gh', 'pr', 'list', '--repo', merge_autoroll.REPO_OWNER_PATH,
-        '--state', 'open', '--head', 'autoroll-main-to-target', '--json',
+        'gh', 'pr', 'list', '--repo', merge_autoroll.REPO_OWNER_PATH, '--state',
+        'open', '--head', 'autoroll-main-to-target', '--json',
         'number,headRefName,baseRefName,title,url'
     ],
                              capture_output=True,
@@ -209,8 +209,8 @@ class TestMergeAutoroll(unittest.TestCase):
         merge_autoroll.main()
     self.assertEqual(cm.exception.code, 0)
     mock_run.assert_called_once_with([
-        'gh', 'pr', 'list', '--repo', merge_autoroll.REPO_OWNER_PATH,
-        '--state', 'open', '--head', 'autoroll-main-to-target', '--json',
+        'gh', 'pr', 'list', '--repo', merge_autoroll.REPO_OWNER_PATH, '--state',
+        'open', '--head', 'autoroll-main-to-target', '--json',
         'number,headRefName,baseRefName,title,url'
     ],
                                      capture_output=True,
@@ -236,8 +236,8 @@ class TestMergeAutoroll(unittest.TestCase):
 
     self.assertEqual(cm.exception.code, 1)
     mock_run.assert_called_once_with([
-        'gh', 'pr', 'list', '--repo', merge_autoroll.REPO_OWNER_PATH,
-        '--state', 'open', '--head', 'autoroll-main-to-target', '--json',
+        'gh', 'pr', 'list', '--repo', merge_autoroll.REPO_OWNER_PATH, '--state',
+        'open', '--head', 'autoroll-main-to-target', '--json',
         'number,headRefName,baseRefName,title,url'
     ],
                                      capture_output=True,
@@ -279,8 +279,8 @@ class TestMergeAutoroll(unittest.TestCase):
       with self.assertRaises(subprocess.CalledProcessError):
         merge_autoroll.main()
     mock_run.assert_called_once_with([
-        'gh', 'pr', 'list', '--repo', merge_autoroll.REPO_OWNER_PATH,
-        '--state', 'open', '--head', 'autoroll-main-to-target', '--json',
+        'gh', 'pr', 'list', '--repo', merge_autoroll.REPO_OWNER_PATH, '--state',
+        'open', '--head', 'autoroll-main-to-target', '--json',
         'number,headRefName,baseRefName,title,url'
     ],
                                      capture_output=True,
@@ -356,8 +356,7 @@ class TestAppCredentialExchange(unittest.TestCase):
 
     with patch('sys.stdout'), patch('sys.stderr'):
       with self.assertRaises(urllib.error.HTTPError):
-        merge_autoroll.get_installation_access_token(
-            '12345', '/tmp/fake.pem')
+        merge_autoroll.get_installation_access_token('12345', '/tmp/fake.pem')
 
   # pylint: enable=unused-argument
 
@@ -388,11 +387,10 @@ class TestWrappers(unittest.TestCase):
   def test_git_wrapper_authenticated(self, mock_run):
     merge_autoroll.git('status', authenticated=True)
     mock_run.assert_called_once_with([
-        'git',
-        '-c', 'credential.helper=',
-        '-c', 'credential.helper=!gh auth git-credential',
-        'status'
-    ], check=True)
+        'git', '-c', 'credential.helper=', '-c',
+        'credential.helper=!gh auth git-credential', 'status'
+    ],
+                                     check=True)
 
   @patch('subprocess.run')
   def test_gh_wrapper_default_check(self, mock_run):


### PR DESCRIPTION
This PR modifies `merge_autoroll.py` to print all executed commands and require user confirmation before pushing changes.

### Key Changes:
*   **Command Logging**: `run_cmd` now prints every command it executes (prefixed with `+ `).
*   **Interactive Confirmation**: Prompt the user for confirmation (`yes`) before pushing the rebased changes. The prompt displays the PR URL.
*   **Documentation**: Updated the `argparse` help output to document that the target repository can be configured via the `GITHUB_REPOSITORY` environment variable.
*   **Tests**: Updated unit tests to mock `builtins.input` and verify the confirmation flow.

Bug: 553046598
