### PR TITLE
evergreen: Add unit tests for loader app telemetry

### DIFF
--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -386,6 +386,10 @@ test("cobalt_unittests") {
     ]
   }
 
+  if (use_evergreen) {
+    sources += [ "//cobalt/browser/loader_app_metrics_unittest.cc" ]
+  }
+
   sources += [ "//cobalt/shell/browser/shell_test_support.h" ]
 
   if (!is_android) {

--- a/cobalt/browser/loader_app_metrics.cc
+++ b/cobalt/browser/loader_app_metrics.cc
@@ -27,10 +27,17 @@ namespace browser {
 
 namespace {
 
+GetExtensionCallback g_get_extension_for_testing;
+
 const StarboardExtensionLoaderAppMetricsApi* GetLoaderAppMetricsExtension() {
+  const void* extension =
+      g_get_extension_for_testing
+          ? g_get_extension_for_testing.Run(
+                kStarboardExtensionLoaderAppMetricsName)
+          : SbSystemGetExtension(kStarboardExtensionLoaderAppMetricsName);
+
   const auto* metrics_extension =
-      static_cast<const StarboardExtensionLoaderAppMetricsApi*>(
-          SbSystemGetExtension(kStarboardExtensionLoaderAppMetricsName));
+      static_cast<const StarboardExtensionLoaderAppMetricsApi*>(extension);
 
   if (!metrics_extension) {
     LOG(WARNING) << "LoaderAppMetrics: Extension not found.";
@@ -112,6 +119,10 @@ void RecordLoaderAppSpaceMetrics(
 }
 
 }  // namespace
+
+void SetGetExtensionForTesting(GetExtensionCallback get_extension_callback) {
+  g_get_extension_for_testing = std::move(get_extension_callback);
+}
 
 void RecordLoaderAppMetrics() {
   const auto* metrics_extension = GetLoaderAppMetricsExtension();

--- a/cobalt/browser/loader_app_metrics.cc
+++ b/cobalt/browser/loader_app_metrics.cc
@@ -18,6 +18,7 @@
 
 #include "base/logging.h"
 #include "base/metrics/histogram_functions.h"
+#include "base/no_destructor.h"
 #include "base/time/time.h"
 #include "starboard/extension/loader_app_metrics.h"
 #include "starboard/system.h"
@@ -27,13 +28,15 @@ namespace browser {
 
 namespace {
 
-GetExtensionCallback g_get_extension_for_testing;
+GetExtensionCallback& GetTestingCallback() {
+  static base::NoDestructor<GetExtensionCallback> callback;
+  return *callback;
+}
 
 const StarboardExtensionLoaderAppMetricsApi* GetLoaderAppMetricsExtension() {
   const void* extension =
-      g_get_extension_for_testing
-          ? g_get_extension_for_testing.Run(
-                kStarboardExtensionLoaderAppMetricsName)
+      !GetTestingCallback().is_null()
+          ? GetTestingCallback().Run(kStarboardExtensionLoaderAppMetricsName)
           : SbSystemGetExtension(kStarboardExtensionLoaderAppMetricsName);
 
   const auto* metrics_extension =
@@ -121,7 +124,8 @@ void RecordLoaderAppSpaceMetrics(
 }  // namespace
 
 void SetGetExtensionForTesting(GetExtensionCallback get_extension_callback) {
-  g_get_extension_for_testing = std::move(get_extension_callback);
+  GetExtensionCallback& testing_callback = GetTestingCallback();
+  testing_callback = std::move(get_extension_callback);
 }
 
 void RecordLoaderAppMetrics() {

--- a/cobalt/browser/loader_app_metrics.h
+++ b/cobalt/browser/loader_app_metrics.h
@@ -15,10 +15,17 @@
 #ifndef COBALT_BROWSER_LOADER_APP_METRICS_H_
 #define COBALT_BROWSER_LOADER_APP_METRICS_H_
 
+#include "base/functional/callback.h"
+
 namespace cobalt {
 namespace browser {
 
 void RecordLoaderAppMetrics();
+
+using GetExtensionCallback = base::RepeatingCallback<const void*(const char*)>;
+
+// Injects a custom Starboard extension getter callback for testing.
+void SetGetExtensionForTesting(GetExtensionCallback get_extension_callback);
 
 }  // namespace browser
 }  // namespace cobalt

--- a/cobalt/browser/loader_app_metrics_unittest.cc
+++ b/cobalt/browser/loader_app_metrics_unittest.cc
@@ -1,0 +1,368 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cobalt/browser/loader_app_metrics.h"
+
+#include <cstring>
+
+#include "base/functional/bind.h"
+#include "base/test/metrics/histogram_tester.h"
+#include "starboard/extension/loader_app_metrics.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace cobalt {
+namespace browser {
+namespace {
+
+constexpr char kElfLoadDuration[] = "Cobalt.LoaderApp.ElfLoadDuration";
+constexpr char kElfDecompressionDuration[] =
+    "Cobalt.LoaderApp.ElfDecompressionDuration";
+constexpr char kElfLoadUnexplainedDuration[] =
+    "Cobalt.LoaderApp.ElfLoadUnexplainedDuration";
+constexpr char kMaxSampledUsedCpuMemoryDuringElfLoad[] =
+    "Cobalt.LoaderApp.MaxSampledUsedCPUMemoryDuringELFLoad";
+constexpr char kSlotSelectionStatus[] = "Cobalt.LoaderApp.SlotSelectionStatus";
+
+class LoaderAppMetricsTest : public testing::Test {
+ protected:
+  void SetExtension(const StarboardExtensionLoaderAppMetricsApi* extension) {
+    SetGetExtensionForTesting(base::BindRepeating(
+        [](const StarboardExtensionLoaderAppMetricsApi* ext,
+           const char* name) -> const void* {
+          if (std::strcmp(name, kStarboardExtensionLoaderAppMetricsName) == 0) {
+            return ext;
+          }
+          return nullptr;
+        },
+        extension));
+  }
+
+  void TearDown() override {
+    SetGetExtensionForTesting(GetExtensionCallback());
+  }
+
+  base::HistogramTester histogram_tester_;
+};
+
+// The mutators need to be defined but their implementations aren't important:
+// the code-under-test only uses the accessors and these are stubbed in the
+// tests.
+void SetCrashpadInstallationStatus(CrashpadInstallationStatus status) {}
+void SetElfLibraryStoredCompressed(bool compressed) {}
+void SetElfLoadDurationMicroseconds(int64_t microseconds) {}
+void SetElfDecompressionDurationMicroseconds(int64_t microseconds) {}
+void RecordUsedCpuBytesDuringElfLoad(int64_t bytes) {}
+void SetSlotSelectionStatus(SlotSelectionStatus status) {}
+
+TEST_F(LoaderAppMetricsTest, NoExtensionRecordsNoSamples) {
+  SetExtension(nullptr);
+  RecordLoaderAppMetrics();
+
+  histogram_tester_.ExpectTotalCount(kSlotSelectionStatus, 0);
+  histogram_tester_.ExpectTotalCount(kElfLoadDuration, 0);
+  histogram_tester_.ExpectTotalCount(kElfDecompressionDuration, 0);
+  histogram_tester_.ExpectTotalCount(kElfLoadUnexplainedDuration, 0);
+  histogram_tester_.ExpectTotalCount(kMaxSampledUsedCpuMemoryDuringElfLoad, 0);
+}
+
+TEST_F(LoaderAppMetricsTest, ExtensionNameMismatchRecordsNoSamples) {
+  StarboardExtensionLoaderAppMetricsApi stub_api = {
+      "dev.cobalt.extension.WrongName",
+      3,
+      &SetCrashpadInstallationStatus,
+      []() { return CrashpadInstallationStatus::kUnknown; },
+      &SetElfLibraryStoredCompressed,
+      []() { return true; },
+      &SetElfLoadDurationMicroseconds,
+      []() -> int64_t { return 10'000; },
+      &SetElfDecompressionDurationMicroseconds,
+      []() -> int64_t { return 7'000; },
+      &RecordUsedCpuBytesDuringElfLoad,
+      []() -> int64_t { return 99'000'000; },
+      &SetSlotSelectionStatus,
+      []() { return SlotSelectionStatus::kCurrentSlot; },
+  };
+
+  // Provide the extension even when queried for
+  // kStarboardExtensionLoaderAppMetricsName. This simulates a bug in a
+  // platform's implementation of SbSystemGetExtension().
+  SetGetExtensionForTesting(
+      base::BindRepeating([](const StarboardExtensionLoaderAppMetricsApi* ext,
+                             const char* name) -> const void* { return ext; },
+                          &stub_api));
+
+  RecordLoaderAppMetrics();
+
+  histogram_tester_.ExpectTotalCount(kSlotSelectionStatus, 0);
+  histogram_tester_.ExpectTotalCount(kElfLoadDuration, 0);
+  histogram_tester_.ExpectTotalCount(kElfDecompressionDuration, 0);
+  histogram_tester_.ExpectTotalCount(kElfLoadUnexplainedDuration, 0);
+  histogram_tester_.ExpectTotalCount(kMaxSampledUsedCpuMemoryDuringElfLoad, 0);
+}
+
+TEST_F(LoaderAppMetricsTest, V1ExtensionVersionTooLowRecordsNoSamples) {
+  StarboardExtensionLoaderAppMetricsApi stub_v1_loader_app_metrics_api = {
+      kStarboardExtensionLoaderAppMetricsName, 1,
+      &SetCrashpadInstallationStatus,
+      []() { return CrashpadInstallationStatus::kUnknown; }};
+
+  SetExtension(&stub_v1_loader_app_metrics_api);
+  RecordLoaderAppMetrics();
+
+  histogram_tester_.ExpectTotalCount(kSlotSelectionStatus, 0);
+  histogram_tester_.ExpectTotalCount(kElfLoadDuration, 0);
+  histogram_tester_.ExpectTotalCount(kElfDecompressionDuration, 0);
+  histogram_tester_.ExpectTotalCount(kElfLoadUnexplainedDuration, 0);
+  histogram_tester_.ExpectTotalCount(kMaxSampledUsedCpuMemoryDuringElfLoad, 0);
+}
+
+TEST_F(LoaderAppMetricsTest, V2ExtensionVersionTooLowForSlotSelectionSample) {
+  StarboardExtensionLoaderAppMetricsApi stub_v2_loader_app_metrics_api = {
+      kStarboardExtensionLoaderAppMetricsName,
+      2,
+      &SetCrashpadInstallationStatus,
+      []() { return CrashpadInstallationStatus::kUnknown; },
+      &SetElfLibraryStoredCompressed,
+      []() { return false; },
+      &SetElfLoadDurationMicroseconds,
+      []() -> int64_t { return 10'000; },
+      &SetElfDecompressionDurationMicroseconds,
+      []() -> int64_t { return 7'000; },
+      &RecordUsedCpuBytesDuringElfLoad,
+      []() -> int64_t { return 99'000'000; }};
+
+  SetExtension(&stub_v2_loader_app_metrics_api);
+  RecordLoaderAppMetrics();
+
+  histogram_tester_.ExpectTotalCount(kSlotSelectionStatus, 0);
+}
+
+TEST_F(LoaderAppMetricsTest,
+       V2ExtensionWithUncompressedElfRecordsNoLoadPerformanceSamples) {
+  StarboardExtensionLoaderAppMetricsApi stub_v2_loader_app_metrics_api = {
+      kStarboardExtensionLoaderAppMetricsName,
+      2,
+      &SetCrashpadInstallationStatus,
+      []() { return CrashpadInstallationStatus::kUnknown; },
+      &SetElfLibraryStoredCompressed,
+      []() { return false; },
+      &SetElfLoadDurationMicroseconds,
+      []() -> int64_t { return 10'000; },
+      &SetElfDecompressionDurationMicroseconds,
+      []() -> int64_t { return 7'000; },
+      &RecordUsedCpuBytesDuringElfLoad,
+      []() -> int64_t { return 99'000'000; }};
+
+  SetExtension(&stub_v2_loader_app_metrics_api);
+  RecordLoaderAppMetrics();
+
+  histogram_tester_.ExpectTotalCount(kElfLoadDuration, 0);
+  histogram_tester_.ExpectTotalCount(kElfDecompressionDuration, 0);
+  histogram_tester_.ExpectTotalCount(kElfLoadUnexplainedDuration, 0);
+  histogram_tester_.ExpectTotalCount(kMaxSampledUsedCpuMemoryDuringElfLoad, 0);
+}
+
+TEST_F(LoaderAppMetricsTest,
+       V2ExtensionWithNegativeElfLoadDurationRecordsOnlySpaceSample) {
+  StarboardExtensionLoaderAppMetricsApi stub_v2_loader_app_metrics_api = {
+      kStarboardExtensionLoaderAppMetricsName,
+      2,
+      &SetCrashpadInstallationStatus,
+      []() { return CrashpadInstallationStatus::kUnknown; },
+      &SetElfLibraryStoredCompressed,
+      []() { return true; },
+      &SetElfLoadDurationMicroseconds,
+      []() -> int64_t { return -1; },
+      &SetElfDecompressionDurationMicroseconds,
+      []() -> int64_t { return 999; },
+      &RecordUsedCpuBytesDuringElfLoad,
+      []() -> int64_t { return 99'000'000; }};
+
+  SetExtension(&stub_v2_loader_app_metrics_api);
+  RecordLoaderAppMetrics();
+
+  histogram_tester_.ExpectTotalCount(kElfLoadDuration, 0);
+  histogram_tester_.ExpectTotalCount(kElfDecompressionDuration, 0);
+  histogram_tester_.ExpectTotalCount(kElfLoadUnexplainedDuration, 0);
+  histogram_tester_.ExpectUniqueSample(kMaxSampledUsedCpuMemoryDuringElfLoad,
+                                       99, 1);
+}
+
+TEST_F(LoaderAppMetricsTest,
+       V2ExtensionWithNegativeDecompressionDurationSkipsDurationSubmetrics) {
+  // Simulates libcobalt.zst where elf_load_duration is recorded, but
+  // decompression duration is not yet provided (-1).
+  StarboardExtensionLoaderAppMetricsApi stub_v2_loader_app_metrics_api = {
+      kStarboardExtensionLoaderAppMetricsName,
+      2,
+      &SetCrashpadInstallationStatus,
+      []() { return CrashpadInstallationStatus::kUnknown; },
+      &SetElfLibraryStoredCompressed,
+      []() { return true; },
+      &SetElfLoadDurationMicroseconds,
+      []() -> int64_t { return 10'000; },
+      &SetElfDecompressionDurationMicroseconds,
+      []() -> int64_t { return -1; },
+      &RecordUsedCpuBytesDuringElfLoad,
+      []() -> int64_t { return 99'000'000; }};
+
+  SetExtension(&stub_v2_loader_app_metrics_api);
+  RecordLoaderAppMetrics();
+
+  histogram_tester_.ExpectUniqueSample(kElfLoadDuration, 10, 1);
+  histogram_tester_.ExpectTotalCount(kElfDecompressionDuration, 0);
+  histogram_tester_.ExpectTotalCount(kElfLoadUnexplainedDuration, 0);
+  histogram_tester_.ExpectUniqueSample(kMaxSampledUsedCpuMemoryDuringElfLoad,
+                                       99, 1);
+}
+
+TEST_F(LoaderAppMetricsTest,
+       V2ExtensionWithDecompressionGTLoadDurationSkipsDurationSubmetrics) {
+  StarboardExtensionLoaderAppMetricsApi stub_v2_loader_app_metrics_api = {
+      kStarboardExtensionLoaderAppMetricsName,
+      2,
+      &SetCrashpadInstallationStatus,
+      []() { return CrashpadInstallationStatus::kUnknown; },
+      &SetElfLibraryStoredCompressed,
+      []() { return true; },
+      &SetElfLoadDurationMicroseconds,
+      []() -> int64_t { return 10'000; },
+      &SetElfDecompressionDurationMicroseconds,
+      []() -> int64_t { return 11'000; },
+      &RecordUsedCpuBytesDuringElfLoad,
+      []() -> int64_t { return 99'000'000; }};
+
+  SetExtension(&stub_v2_loader_app_metrics_api);
+  RecordLoaderAppMetrics();
+
+  histogram_tester_.ExpectUniqueSample(kElfLoadDuration, 10, 1);
+  histogram_tester_.ExpectTotalCount(kElfDecompressionDuration, 0);
+  histogram_tester_.ExpectTotalCount(kElfLoadUnexplainedDuration, 0);
+  histogram_tester_.ExpectUniqueSample(kMaxSampledUsedCpuMemoryDuringElfLoad,
+                                       99, 1);
+}
+
+TEST_F(LoaderAppMetricsTest,
+       V2ExtensionWithNegativeMaxSampledUsedCpuBytesRecordsOnlyTimeSamples) {
+  StarboardExtensionLoaderAppMetricsApi stub_v2_loader_app_metrics_api = {
+      kStarboardExtensionLoaderAppMetricsName,
+      2,
+      &SetCrashpadInstallationStatus,
+      []() { return CrashpadInstallationStatus::kUnknown; },
+      &SetElfLibraryStoredCompressed,
+      []() { return true; },
+      &SetElfLoadDurationMicroseconds,
+      []() -> int64_t { return 10'000; },
+      &SetElfDecompressionDurationMicroseconds,
+      []() -> int64_t { return 7'000; },
+      &RecordUsedCpuBytesDuringElfLoad,
+      []() -> int64_t { return -1; }};
+
+  SetExtension(&stub_v2_loader_app_metrics_api);
+  RecordLoaderAppMetrics();
+
+  histogram_tester_.ExpectUniqueSample(kElfLoadDuration, 10, 1);
+  histogram_tester_.ExpectUniqueSample(kElfDecompressionDuration, 7, 1);
+  histogram_tester_.ExpectUniqueSample(kElfLoadUnexplainedDuration, 3, 1);
+  histogram_tester_.ExpectTotalCount(kMaxSampledUsedCpuMemoryDuringElfLoad, 0);
+}
+
+TEST_F(LoaderAppMetricsTest,
+       V2ExtensionWithValidDataRecordsAllLoadPerformanceSamples) {
+  StarboardExtensionLoaderAppMetricsApi stub_v2_loader_app_metrics_api = {
+      kStarboardExtensionLoaderAppMetricsName,
+      2,
+      &SetCrashpadInstallationStatus,
+      []() { return CrashpadInstallationStatus::kUnknown; },
+      &SetElfLibraryStoredCompressed,
+      []() { return true; },
+      &SetElfLoadDurationMicroseconds,
+      []() -> int64_t { return 10'000; },
+      &SetElfDecompressionDurationMicroseconds,
+      []() -> int64_t { return 7'000; },
+      &RecordUsedCpuBytesDuringElfLoad,
+      []() -> int64_t { return 99'000'000; }};
+
+  SetExtension(&stub_v2_loader_app_metrics_api);
+  RecordLoaderAppMetrics();
+
+  histogram_tester_.ExpectUniqueSample(kElfLoadDuration, 10, 1);
+  histogram_tester_.ExpectUniqueSample(kElfDecompressionDuration, 7, 1);
+  histogram_tester_.ExpectUniqueSample(kElfLoadUnexplainedDuration, 3, 1);
+  histogram_tester_.ExpectUniqueSample(kMaxSampledUsedCpuMemoryDuringElfLoad,
+                                       99, 1);
+}
+
+TEST_F(LoaderAppMetricsTest,
+       V3ExtensionRecordsSlotSelectionStatusAndPerformanceMetrics) {
+  StarboardExtensionLoaderAppMetricsApi stub_v3_loader_app_metrics_api = {
+      kStarboardExtensionLoaderAppMetricsName,
+      3,
+      &SetCrashpadInstallationStatus,
+      []() { return CrashpadInstallationStatus::kUnknown; },
+      &SetElfLibraryStoredCompressed,
+      []() { return true; },
+      &SetElfLoadDurationMicroseconds,
+      []() -> int64_t { return 10'000; },
+      &SetElfDecompressionDurationMicroseconds,
+      []() -> int64_t { return 7'000; },
+      &RecordUsedCpuBytesDuringElfLoad,
+      []() -> int64_t { return 99'000'000; },
+      &SetSlotSelectionStatus,
+      []() { return SlotSelectionStatus::kCurrentSlot; }};
+
+  SetExtension(&stub_v3_loader_app_metrics_api);
+  RecordLoaderAppMetrics();
+
+  histogram_tester_.ExpectUniqueSample(kSlotSelectionStatus,
+                                       SlotSelectionStatus::kCurrentSlot, 1);
+  histogram_tester_.ExpectUniqueSample(kElfLoadDuration, 10, 1);
+  histogram_tester_.ExpectUniqueSample(kElfDecompressionDuration, 7, 1);
+  histogram_tester_.ExpectUniqueSample(kElfLoadUnexplainedDuration, 3, 1);
+  histogram_tester_.ExpectUniqueSample(kMaxSampledUsedCpuMemoryDuringElfLoad,
+                                       99, 1);
+}
+
+TEST_F(LoaderAppMetricsTest,
+       V3ExtensionWithUncompressedElfRecordsSlotSelectionStatusOnly) {
+  StarboardExtensionLoaderAppMetricsApi stub_v3_loader_app_metrics_api = {
+      kStarboardExtensionLoaderAppMetricsName,
+      3,
+      &SetCrashpadInstallationStatus,
+      []() { return CrashpadInstallationStatus::kUnknown; },
+      &SetElfLibraryStoredCompressed,
+      []() { return false; },
+      &SetElfLoadDurationMicroseconds,
+      []() -> int64_t { return 10'000; },
+      &SetElfDecompressionDurationMicroseconds,
+      []() -> int64_t { return 7'000; },
+      &RecordUsedCpuBytesDuringElfLoad,
+      []() -> int64_t { return 99'000'000; },
+      &SetSlotSelectionStatus,
+      []() { return SlotSelectionStatus::kRollForward; }};
+
+  SetExtension(&stub_v3_loader_app_metrics_api);
+  RecordLoaderAppMetrics();
+
+  histogram_tester_.ExpectUniqueSample(kSlotSelectionStatus,
+                                       SlotSelectionStatus::kRollForward, 1);
+  histogram_tester_.ExpectTotalCount(kElfLoadDuration, 0);
+  histogram_tester_.ExpectTotalCount(kElfDecompressionDuration, 0);
+  histogram_tester_.ExpectTotalCount(kElfLoadUnexplainedDuration, 0);
+  histogram_tester_.ExpectTotalCount(kMaxSampledUsedCpuMemoryDuringElfLoad, 0);
+}
+
+}  // namespace
+}  // namespace browser
+}  // namespace cobalt


### PR DESCRIPTION
The unit tests for this module have not yet been brought forward from 25.lts.1+. This PR adds back unit tests, following a similar high level testing approach but making a few changes
* Some test cases are added, removed, changed to reflect changes in the module's behaviors
* To enable stubbing of the different tested scenarios, the module still uses dependency injection to enable the tests to provide a stub LoadeAppMetrics extension implementation. But in line with upstream Chromium code, the dependency is now injected via a ForTesting() function instead of as an optional param in the existing public RecordLoaderAppMetrics() function.

Issue: 537769651