### PR TITLE
starboard: Use DecodedAudio::CreateEOSBuffer() instead of default constructor

### DIFF
--- a/starboard/android/shared/audio_decoder_passthrough.h
+++ b/starboard/android/shared/audio_decoder_passthrough.h
@@ -81,7 +81,7 @@ class AudioDecoderPassthrough : public AudioDecoder {
     SB_CHECK(thread_checker_.CalledOnValidThread());
     SB_DCHECK(output_cb_);
 
-    decoded_audios_.push(DecodedAudio());
+    decoded_audios_.push(DecodedAudio::CreateEOSBuffer());
     output_cb_();
   }
 

--- a/starboard/android/shared/media_codec_audio_decoder.cc
+++ b/starboard/android/shared/media_codec_audio_decoder.cc
@@ -290,7 +290,7 @@ void MediaCodecAudioDecoder::ProcessOutputBuffer(
   if (dequeue_output_result.flags & MediaCodec::kBufferFlagEndOfStream) {
     {
       std::lock_guard lock(decoded_audios_mutex_);
-      decoded_audios_.push(DecodedAudio());
+      decoded_audios_.push(DecodedAudio::CreateEOSBuffer());
     }
     audio_frame_discarder_.OnDecodedAudioEndOfStream();
     Schedule(output_cb_);

--- a/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.cc
@@ -271,7 +271,7 @@ void FfmpegAudioDecoderImpl<FFMPEG>::WriteEndOfStream() {
   // to ensure that Decode() is not called when the stream is ended.
   stream_ended_ = true;
   // Put EOS into the queue.
-  decoded_audios_.push(DecodedAudio());
+  decoded_audios_.push(DecodedAudio::CreateEOSBuffer());
 
   Schedule(output_cb_);
 }

--- a/starboard/shared/libfdkaac/fdk_aac_audio_decoder.cc
+++ b/starboard/shared/libfdkaac/fdk_aac_audio_decoder.cc
@@ -117,7 +117,7 @@ void FdkAacAudioDecoder::WriteEndOfStream() {
   }
   stream_ended_ = true;
   // Put EOS into the queue.
-  decoded_audios_.push(DecodedAudio());
+  decoded_audios_.push(DecodedAudio::CreateEOSBuffer());
   Schedule(output_cb_);
 }
 

--- a/starboard/shared/opus/opus_audio_decoder.cc
+++ b/starboard/shared/opus/opus_audio_decoder.cc
@@ -130,7 +130,7 @@ void OpusAudioDecoder::WriteEndOfStream() {
   }
 
   // Put EOS into the queue.
-  decoded_audios_.push(DecodedAudio());
+  decoded_audios_.push(DecodedAudio::CreateEOSBuffer());
 
   Schedule(output_cb_);
 }

--- a/starboard/shared/starboard/player/decoded_audio_internal.cc
+++ b/starboard/shared/starboard/player/decoded_audio_internal.cc
@@ -63,6 +63,11 @@ void ConvertSample(const float* source, int16_t* destination) {
 
 }  // namespace
 
+// static
+DecodedAudio DecodedAudio::CreateEOSBuffer() {
+  return DecodedAudio();
+}
+
 DecodedAudio::DecodedAudio()
     : channels_(0),
       sample_type_(kSbMediaAudioSampleTypeInt16Deprecated),

--- a/starboard/shared/starboard/player/decoded_audio_internal.h
+++ b/starboard/shared/starboard/player/decoded_audio_internal.h
@@ -28,7 +28,7 @@ namespace starboard {
 // frames with continuous timestamps.
 class DecodedAudio {
  public:
-  DecodedAudio();  // Signal an EOS.
+  static DecodedAudio CreateEOSBuffer();
   // TODO(b/272837615): Remove `storage_type` support and always store data in
   // interleaved. Refactor the places that store sample in planar to convert the
   // samples to interleaved on creation.
@@ -105,6 +105,8 @@ class DecodedAudio {
   DecodedAudio CloneForTesting() const;
 
  private:
+  DecodedAudio();
+
   DecodedAudio SwitchSampleTypeTo(SbMediaAudioSampleType new_sample_type,
                                   bool enable_simd) const;
   DecodedAudio SwitchStorageTypeTo(

--- a/starboard/shared/starboard/player/decoded_audio_test_internal.cc
+++ b/starboard/shared/starboard/player/decoded_audio_test_internal.cc
@@ -172,8 +172,8 @@ void Verify(const DecodedAudio& decoded_audio) {
   }
 }
 
-TEST(DecodedAudioTest, DefaultCtor) {
-  DecodedAudio decoded_audio;
+TEST(DecodedAudioTest, CreateEOSBuffer) {
+  DecodedAudio decoded_audio = DecodedAudio::CreateEOSBuffer();
   EXPECT_TRUE(decoded_audio.is_end_of_stream());
 }
 

--- a/starboard/shared/starboard/player/filter/adaptive_audio_decoder_internal.cc
+++ b/starboard/shared/starboard/player/filter/adaptive_audio_decoder_internal.cc
@@ -143,7 +143,7 @@ void AdaptiveAudioDecoder::WriteEndOfStream() {
   if (first_input_written_) {
     audio_decoder_->WriteEndOfStream();
   } else {
-    decoded_audios_.push(DecodedAudio());
+    decoded_audios_.push(DecodedAudio::CreateEOSBuffer());
     Schedule(output_cb_);
   }
 }

--- a/starboard/shared/starboard/player/filter/audio_channel_layout_mixer_impl.cc
+++ b/starboard/shared/starboard/player/filter/audio_channel_layout_mixer_impl.cc
@@ -317,6 +317,8 @@ DecodedAudio AudioChannelLayoutMixerImpl::Mix(DecodedAudio input) {
   if (!matrix) {
     SB_NOTREACHED() << "Mixing " << input.channels() << " channels to "
                     << output_channels_ << " channels is not supported.";
+    // TODO: b/553577796 - Refactor Mix() to return std::optional<DecodedAudio>
+    // to signal errors instead of returning an EOS buffer.
     return DecodedAudio::CreateEOSBuffer();
   }
 

--- a/starboard/shared/starboard/player/filter/audio_channel_layout_mixer_impl.cc
+++ b/starboard/shared/starboard/player/filter/audio_channel_layout_mixer_impl.cc
@@ -317,7 +317,7 @@ DecodedAudio AudioChannelLayoutMixerImpl::Mix(DecodedAudio input) {
   if (!matrix) {
     SB_NOTREACHED() << "Mixing " << input.channels() << " channels to "
                     << output_channels_ << " channels is not supported.";
-    return DecodedAudio();
+    return DecodedAudio::CreateEOSBuffer();
   }
 
   if (sample_type_ == kSbMediaAudioSampleTypeInt16Deprecated) {

--- a/starboard/shared/starboard/player/filter/audio_time_stretcher.h
+++ b/starboard/shared/starboard/player/filter/audio_time_stretcher.h
@@ -186,7 +186,7 @@ class AudioTimeStretcher {
   // number of requested samples. Furthermore, due to overlap-and-add,
   // the last half-window of the output is incomplete, which is stored in this
   // buffer.
-  DecodedAudio wsola_output_;
+  DecodedAudio wsola_output_ = DecodedAudio::CreateEOSBuffer();
 
   // Overlap-and-add window.
   std::unique_ptr<float[]> ola_window_;
@@ -196,19 +196,23 @@ class AudioTimeStretcher {
   std::unique_ptr<float[]> transition_window_;
 
   // Auxiliary variables to avoid allocation in every iteration.
+  // For now, we initialize DecodedAudio buffers with EOS to serve as
+  // placeholders.
+  // TODO: go/cobalt-pr/12223 - Handle placeholders properly (e.g.
+  // std::optional).
 
   // Stores the optimal block in every iteration. This is the most
   // similar block to |target_block_| within |search_block_| and it is
   // overlap-and-added to |wsola_output_|.
-  DecodedAudio optimal_block_;
+  DecodedAudio optimal_block_ = DecodedAudio::CreateEOSBuffer();
 
   // A block of data that search is performed over to find the |optimal_block_|.
-  DecodedAudio search_block_;
+  DecodedAudio search_block_ = DecodedAudio::CreateEOSBuffer();
 
   // Stores the target block, denoted as |target| above. |search_block_| is
   // searched for a block (|optimal_block_|) that is most similar to
   // |target_block_|.
-  DecodedAudio target_block_;
+  DecodedAudio target_block_ = DecodedAudio::CreateEOSBuffer();
 
   // The initial and maximum capacity calculated by Initialize().
   int initial_capacity_;

--- a/starboard/shared/starboard/player/filter/audio_time_stretcher.h
+++ b/starboard/shared/starboard/player/filter/audio_time_stretcher.h
@@ -198,8 +198,7 @@ class AudioTimeStretcher {
   // Auxiliary variables to avoid allocation in every iteration.
   // For now, we initialize DecodedAudio buffers with EOS to serve as
   // placeholders.
-  // TODO: go/cobalt-pr/12223 - Handle placeholders properly (e.g.
-  // std::optional).
+  // TODO: b/553577796 - Handle placeholders properly (e.g. std::optional).
 
   // Stores the optimal block in every iteration. This is the most
   // similar block to |target_block_| within |search_block_| and it is

--- a/starboard/shared/starboard/player/filter/stub_audio_decoder.cc
+++ b/starboard/shared/starboard/player/filter/stub_audio_decoder.cc
@@ -118,7 +118,7 @@ void StubAudioDecoder::WriteEndOfStream() {
         std::bind(&StubAudioDecoder::DecodeEndOfStream, this));
     return;
   }
-  decoded_audios_.push(DecodedAudio());
+  decoded_audios_.push(DecodedAudio::CreateEOSBuffer());
   output_cb_();
 }
 
@@ -275,7 +275,7 @@ void StubAudioDecoder::DecodeEndOfStream() {
     Schedule(output_cb_);
   }
   std::lock_guard lock(decoded_audios_mutex_);
-  decoded_audios_.push(DecodedAudio());
+  decoded_audios_.push(DecodedAudio::CreateEOSBuffer());
   Schedule(output_cb_);
 }
 

--- a/starboard/shared/starboard/player/filter/testing/audio_renderer_internal_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_renderer_internal_test.cc
@@ -69,10 +69,11 @@ class AudioRendererTest : public ::testing::Test {
                                           kDefaultSamplesPerSecond);
 
     ON_CALL(*audio_decoder_, Read(_))
-        .WillByDefault(DoAll(
-            SetArgPointee<0>(kDefaultSamplesPerSecond), InvokeWithoutArgs([]() {
-              return std::optional<DecodedAudio>(DecodedAudio());
-            })));
+        .WillByDefault(DoAll(SetArgPointee<0>(kDefaultSamplesPerSecond),
+                             InvokeWithoutArgs([]() {
+                               return std::optional<DecodedAudio>(
+                                   DecodedAudio::CreateEOSBuffer());
+                             })));
     ON_CALL(*audio_renderer_sink_, Start(_, _, _, _, _, _, _, _))
         .WillByDefault(DoAll(InvokeWithoutArgs([this]() {
                                audio_renderer_sink_->SetHasStarted(true);
@@ -337,7 +338,7 @@ TEST_F(AudioRendererTest, SunnyDay) {
 
   audio_renderer_->Play();
 
-  SendDecoderOutput(DecodedAudio());
+  SendDecoderOutput(DecodedAudio::CreateEOSBuffer());
 
   int64_t media_time = audio_renderer_->GetCurrentMediaTime(
       &is_playing, &is_eos_played, &is_underflow, &playback_rate);
@@ -426,7 +427,7 @@ TEST_F(AudioRendererTest, SunnyDayWithDoublePlaybackRateAndInt16Samples) {
 
   audio_renderer_->Play();
 
-  SendDecoderOutput(DecodedAudio());
+  SendDecoderOutput(DecodedAudio::CreateEOSBuffer());
 
   int64_t media_time = audio_renderer_->GetCurrentMediaTime(
       &is_playing, &is_eos_played, &is_underflow, &playback_rate);
@@ -485,7 +486,7 @@ TEST_F(AudioRendererTest, StartPlayBeforePreroll) {
 
   int frames_written = FillRendererWithDecodedAudioAndWriteEOS(0);
 
-  SendDecoderOutput(DecodedAudio());
+  SendDecoderOutput(DecodedAudio::CreateEOSBuffer());
 
   bool is_playing = false;
   bool is_eos_played = true;
@@ -558,7 +559,7 @@ TEST_F(AudioRendererTest, DecoderReturnsEOSWithoutAnyData) {
   EXPECT_FALSE(prerolled_);
 
   // Return EOS from decoder without sending any audio data, which is valid.
-  SendDecoderOutput(DecodedAudio());
+  SendDecoderOutput(DecodedAudio::CreateEOSBuffer());
 
   EXPECT_TRUE(audio_renderer_->IsEndOfStreamPlayed());
   EXPECT_TRUE(prerolled_);
@@ -608,7 +609,7 @@ TEST_F(AudioRendererTest, DecoderConsumeAllInputBeforeReturningData) {
   EXPECT_FALSE(prerolled_);
 
   // Return EOS from decoder without sending any audio data, which is valid.
-  SendDecoderOutput(DecodedAudio());
+  SendDecoderOutput(DecodedAudio::CreateEOSBuffer());
 
   EXPECT_TRUE(audio_renderer_->IsEndOfStreamPlayed());
   EXPECT_TRUE(prerolled_);
@@ -671,7 +672,7 @@ TEST_F(AudioRendererTest, MoreNumberOfOutputBuffersThanInputBuffers) {
 
   audio_renderer_->Play();
 
-  SendDecoderOutput(DecodedAudio());
+  SendDecoderOutput(DecodedAudio::CreateEOSBuffer());
 
   int64_t media_time = audio_renderer_->GetCurrentMediaTime(
       &is_playing, &is_eos_played, &is_underflow, &playback_rate);
@@ -766,7 +767,7 @@ TEST_F(AudioRendererTest, LessNumberOfOutputBuffersThanInputBuffers) {
 
   audio_renderer_->Play();
 
-  SendDecoderOutput(DecodedAudio());
+  SendDecoderOutput(DecodedAudio::CreateEOSBuffer());
 
   int64_t media_time = audio_renderer_->GetCurrentMediaTime(
       &is_playing, &is_eos_played, &is_underflow, &playback_rate);
@@ -840,7 +841,7 @@ TEST_F(AudioRendererTest, Seek) {
 
   audio_renderer_->Play();
 
-  SendDecoderOutput(DecodedAudio());
+  SendDecoderOutput(DecodedAudio::CreateEOSBuffer());
 
   int64_t media_time = audio_renderer_->GetCurrentMediaTime(
       &is_playing, &is_eos_played, &is_underflow, &playback_rate);
@@ -876,7 +877,7 @@ TEST_F(AudioRendererTest, Seek) {
   EXPECT_TRUE(prerolled_);
 
   audio_renderer_->Play();
-  SendDecoderOutput(DecodedAudio());
+  SendDecoderOutput(DecodedAudio::CreateEOSBuffer());
 
   renderer_callback_->GetSourceStatus(&frames_in_buffer, &offset_in_frames,
                                       &is_playing, &is_eos_reached);

--- a/starboard/tvos/shared/media/audio_decoder.mm
+++ b/starboard/tvos/shared/media/audio_decoder.mm
@@ -151,7 +151,7 @@ void TvosAudioDecoder::WriteEndOfStream() {
 
   stream_ended_ = true;
   // Put EOS into the queue.
-  decoded_audios_.push(DecodedAudio());
+  decoded_audios_.push(DecodedAudio::CreateEOSBuffer());
 
   audio_frame_discarder_.OnDecodedAudioEndOfStream();
 


### PR DESCRIPTION
Replace direct calls to DecodedAudio's default constructor with the explicit static factory method DecodedAudio::CreateEOSBuffer() to make call sites more readable and explicit. Make the default constructor private to prevent unintended instantiation.

Issue: 414009070