### PR TITLE
skills: Quote description scalar in cobalt-pr-bug-tag frontmatter

### DIFF
--- a/.agent/skills/cobalt-pr-bug-tag/SKILL.md
+++ b/.agent/skills/cobalt-pr-bug-tag/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cobalt-pr-bug-tag
-description: Guides the agent to explicitly search for related bugs and append "Bug: <id>" to commit messages and pull request descriptions when making Cobalt PRs.
+description: 'Guides the agent to explicitly search for related bugs and append "Bug: <id>" to commit messages and pull request descriptions when making Cobalt PRs.'
 ---
 
 # Skill: Cobalt PR Bug Tagging


### PR DESCRIPTION
The unquoted description in `.agent/skills/cobalt-pr-bug-tag/SKILL.md` contained the substring `"Bug: <id>"`. In YAML, a colon followed by whitespace (`: `) denotes a mapping key indicator. Because the scalar was unquoted, the YAML parser attempted to parse `"Bug:"` as a nested mapping within the scalar, causing frontmatter parsing to fail.

Wrap the description in single quotes to allow the colon and internal double quotes to parse correctly as a plain string scalar.

Bug: 527919588
TAG=agy
CONV=6e54fe2d-c778-48f3-a88a-f6852f93aece