### PR TITLE
starboard: Modernize SbDrmSystemPrivate interface using std::string_view

### DIFF
--- a/starboard/android/shared/drm_system.cc
+++ b/starboard/android/shared/drm_system.cc
@@ -111,32 +111,17 @@ MediaDrmBridge::OperationResult DrmSystem::SessionUpdateRequest::Generate(
   return media_drm_bridge->CreateSession(ticket_, init_data_, mime_);
 }
 
-void DrmSystem::GenerateSessionUpdateRequest(int ticket,
-                                             const char* type,
-                                             const void* initialization_data,
-                                             int initialization_data_size) {
+void DrmSystem::GenerateSessionUpdateRequest(
+    int ticket,
+    std::string_view type,
+    std::string_view initialization_data) {
   SB_CHECK(thread_checker_.CalledOnValidThread());
   GenerateSessionUpdateRequest(std::make_unique<SessionUpdateRequest>(
-      ticket, type,
-      std::string_view(static_cast<const char*>(initialization_data),
-                       initialization_data_size)));
+      ticket, type, initialization_data));
 }
 
-void DrmSystem::UpdateSession(int ticket,
-                              const void* key,
-                              int key_size,
-                              const void* session_id,
-                              int session_id_size) {
+void DrmSystem::CloseSession(std::string_view session_id) {
   SB_CHECK(thread_checker_.CalledOnValidThread());
-  UpdateSession(
-      ticket, std::string_view(static_cast<const char*>(key), key_size),
-      std::string_view(static_cast<const char*>(session_id), session_id_size));
-}
-
-void DrmSystem::CloseSession(const void* session_id_data, int session_id_size) {
-  SB_CHECK(thread_checker_.CalledOnValidThread());
-  std::string session_id(static_cast<const char*>(session_id_data),
-                         session_id_size);
   {
     std::lock_guard scoped_lock(mutex_);
     auto iter = cached_drm_key_ids_.find(session_id);
@@ -145,7 +130,7 @@ void DrmSystem::CloseSession(const void* session_id_data, int session_id_size) {
     }
   }
 
-  std::string media_drm_session_id = [this, &session_id] {
+  std::string media_drm_session_id = [this, session_id] {
     std::lock_guard lock(mutex_);
     return std::string(session_id_mapper_.GetMediaDrmSessionId(session_id));
   }();
@@ -168,9 +153,9 @@ DrmSystem::DecryptStatus DrmSystem::Decrypt(InputBuffer* buffer) {
   return kSuccess;
 }
 
-const void* DrmSystem::GetMetrics(int* size) {
+std::optional<std::string_view> DrmSystem::GetMetrics() {
   SB_CHECK(thread_checker_.CalledOnValidThread());
-  return media_drm_bridge_->GetMetrics(size);
+  return media_drm_bridge_->GetMetrics();
 }
 
 void DrmSystem::OnSessionUpdate(int ticket,

--- a/starboard/android/shared/drm_system.h
+++ b/starboard/android/shared/drm_system.h
@@ -22,11 +22,12 @@
 #include <jni.h>
 
 #include <atomic>
+#include <functional>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <string_view>
-#include <unordered_map>
 #include <vector>
 
 #include "base/memory/raw_ptr.h"
@@ -56,23 +57,20 @@ class DrmSystem : public ::SbDrmSystemPrivate, public MediaDrmBridge::Host {
 
   ~DrmSystem() override;
   // SbDrmSystemPrivate override begins
-  void GenerateSessionUpdateRequest(int ticket,
-                                    const char* type,
-                                    const void* initialization_data,
-                                    int initialization_data_size) override;
+  void GenerateSessionUpdateRequest(
+      int ticket,
+      std::string_view type,
+      std::string_view initialization_data) override;
   void UpdateSession(int ticket,
-                     const void* key,
-                     int key_size,
-                     const void* session_id,
-                     int session_id_size) override;
-  void CloseSession(const void* session_id_data, int session_id_size) override;
+                     std::string_view key,
+                     std::string_view session_id) override;
+  void CloseSession(std::string_view session_id) override;
   DecryptStatus Decrypt(InputBuffer* buffer) override;
 
   bool IsServerCertificateUpdatable() override { return false; }
   void UpdateServerCertificate(int ticket,
-                               const void* certificate,
-                               int certificate_size) override {}
-  const void* GetMetrics(int* size) override;
+                               std::string_view certificate) override {}
+  std::optional<std::string_view> GetMetrics() override;
   // SbDrmSystemPrivate override ends.
 
   const jni_zero::JavaRef<jobject>& GetMediaCrypto() const {
@@ -125,9 +123,6 @@ class DrmSystem : public ::SbDrmSystemPrivate, public MediaDrmBridge::Host {
   void HandlePendingRequests();
   void GenerateSessionUpdateRequest(
       std::unique_ptr<SessionUpdateRequest> request);
-  void UpdateSession(int ticket,
-                     std::string_view key,
-                     std::string_view session_id);
 
   const std::string key_system_;
   const raw_ptr<void> context_;
@@ -138,7 +133,8 @@ class DrmSystem : public ::SbDrmSystemPrivate, public MediaDrmBridge::Host {
   std::vector<std::unique_ptr<SessionUpdateRequest>>
       deferred_session_update_requests_;  // Guarded by |mutex_|.
 
-  std::unordered_map<std::string, std::vector<SbDrmKeyId>> cached_drm_key_ids_;
+  std::map<std::string, std::vector<SbDrmKeyId>, std::less<>>
+      cached_drm_key_ids_;
   bool hdcp_lost_;
   std::atomic_bool created_media_crypto_session_{false};
 

--- a/starboard/android/shared/media_drm_bridge.cc
+++ b/starboard/android/shared/media_drm_bridge.cc
@@ -209,21 +209,19 @@ void MediaDrmBridge::CloseSession(std::string_view session_id) const {
   Java_MediaDrmBridge_closeSession(env, j_media_drm_bridge_, j_session_id);
 }
 
-const void* MediaDrmBridge::GetMetrics(int* size) {
+std::optional<std::string_view> MediaDrmBridge::GetMetrics() {
   JNIEnv* env = AttachCurrentThread();
 
   ScopedJavaLocalRef<jbyteArray> j_metrics =
       Java_MediaDrmBridge_getMetricsInBase64(env, j_media_drm_bridge_);
 
   if (j_metrics.is_null()) {
-    *size = 0;
-    return nullptr;
+    return std::nullopt;
   }
 
   base::android::JavaByteArrayToByteVector(env, j_metrics, &metrics_);
-  *size = static_cast<int>(metrics_.size());
-
-  return metrics_.data();
+  return std::string_view(reinterpret_cast<const char*>(metrics_.data()),
+                          metrics_.size());
 }
 
 void MediaDrmBridge::OnSessionMessage(

--- a/starboard/android/shared/media_drm_bridge.h
+++ b/starboard/android/shared/media_drm_bridge.h
@@ -17,6 +17,7 @@
 
 #include <jni.h>
 
+#include <optional>
 #include <ostream>
 #include <string>
 #include <string_view>
@@ -97,7 +98,7 @@ class MediaDrmBridge {
                                 std::string_view key,
                                 std::string_view session_id) const;
   void CloseSession(std::string_view session_id) const;
-  const void* GetMetrics(int* size);
+  std::optional<std::string_view> GetMetrics();
 
   void OnSessionMessage(JNIEnv* env,
                         jint ticket,

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/drm/drm_system_ocdm.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/drm/drm_system_ocdm.cc
@@ -101,11 +101,10 @@ class Session {
       const SbDrmSessionClosedFunc session_closed_callback);
   ~Session();
   void Close();
-  void GenerateChallenge(const std::string& type,
-                         const void* initialization_data,
-                         int initialization_data_size,
+  void GenerateChallenge(std::string_view type,
+                         std::string_view initialization_data,
                          int ticket);
-  void Update(const void* key, int key_size, int ticket);
+  void Update(std::string_view key, int ticket);
   std::string Id() const { return id_; }
 
   int Decrypt( _GstBuffer* buffer,
@@ -212,9 +211,8 @@ void Session::Close() {
   }
 }
 
-void Session::GenerateChallenge(const std::string& type,
-                                const void* initialization_data,
-                                int initialization_data_size,
+void Session::GenerateChallenge(std::string_view type,
+                                std::string_view initialization_data,
                                 int ticket) {
   SB_DCHECK(thread_checker_.CalledOnValidThread());
   SB_LOG(INFO) << "Generating challenge";
@@ -226,10 +224,11 @@ void Session::GenerateChallenge(const std::string& type,
   }
   OpenCDMSession* session = nullptr;
   if (opencdm_construct_session(
-          ocdm_system_, Temporary, type.c_str(),
-          reinterpret_cast<const uint8_t*>(initialization_data),
-          initialization_data_size, nullptr, 0, &session_callbacks_, this,
-          &session) != ERROR_NONE ||
+          ocdm_system_, Temporary, std::string(type).c_str(),
+          reinterpret_cast<const uint8_t*>(initialization_data.data()),
+          static_cast<uint16_t>(initialization_data.size()),
+          /*cdm_data=*/nullptr, /*cdm_data_size=*/0, &session_callbacks_,
+          /*user_data=*/this, &session) != ERROR_NONE ||
       !session) {
     session_update_request_callback_(drm_system_, context_, ticket,
                                      kSbDrmStatusUnknownError,
@@ -278,7 +277,7 @@ void Session::DispatchPendingKeyUpdates() {
   }
 }
 
-void Session::Update(const void* key, int key_size, int ticket) {
+void Session::Update(std::string_view key, int ticket) {
   SB_DCHECK(thread_checker_.CalledOnValidThread());
   auto id = Id();
   SB_DCHECK(!id.empty());
@@ -288,8 +287,9 @@ void Session::Update(const void* key, int key_size, int ticket) {
     ticket_ = ticket;
     operation_ = Operation::kUpdate;
   }
-  if (opencdm_session_update(session_.get(), static_cast<const uint8_t*>(key),
-                             key_size) != ERROR_NONE) {
+  if (opencdm_session_update(
+          session_.get(), reinterpret_cast<const uint8_t*>(key.data()),
+          static_cast<uint16_t>(key.size())) != ERROR_NONE) {
     session_updated_callback_(drm_system_, context_, ticket,
                               kSbDrmStatusUnknownError, nullptr, id.c_str(),
                               id.size());
@@ -581,17 +581,15 @@ bool DrmSystemOcdm::IsKeySystemSupported(const char* key_system,
 
 void DrmSystemOcdm::GenerateSessionUpdateRequest(
     int ticket,
-    const char* type,
-    const void* initialization_data,
-    int initialization_data_size) {
+    std::string_view type,
+    std::string_view initialization_data) {
   SB_CHECK(ocdm_system_ != nullptr);
   SB_LOG(INFO) << "Generate challenge type: " << type;
   std::unique_ptr<Session> session(
       new Session(this, ocdm_system_, context_,
                   session_update_request_callback_, session_updated_callback_,
                   key_statuses_changed_callback_, session_closed_callback_));
-  session->GenerateChallenge(type, initialization_data,
-                             initialization_data_size, ticket);
+  session->GenerateChallenge(type, initialization_data, ticket);
   Session *session_ptr = session.get();
   std::unique_lock lock(mutex_);
   sessions_.push_back(std::move(session));
@@ -600,31 +598,27 @@ void DrmSystemOcdm::GenerateSessionUpdateRequest(
 }
 
 void DrmSystemOcdm::UpdateSession(int ticket,
-                                  const void* key,
-                                  int key_size,
-                                  const void* session_id,
-                                  int session_id_size) {
-  std::string id = {static_cast<const char*>(session_id), static_cast<std::string::size_type>(session_id_size)};
-  SB_LOG(INFO) << "Update: " << id;
-  auto* session = GetSessionById(id);
+                                  std::string_view key,
+                                  std::string_view session_id) {
+  SB_LOG(INFO) << "Update: " << session_id;
+  auto* session = GetSessionById(session_id);
   if (session)
-    session->Update(key, key_size, ticket);
+    session->Update(key, ticket);
 }
 
-void DrmSystemOcdm::CloseSession(const void* session_id, int session_id_size) {
-  std::string id = {static_cast<const char*>(session_id), static_cast<std::string::size_type>(session_id_size)};
-  SB_LOG(INFO) << "Close: " << id;
-  auto* session = GetSessionById(id);
+void DrmSystemOcdm::CloseSession(std::string_view session_id) {
+  SB_LOG(INFO) << "Close: " << session_id;
+  auto* session = GetSessionById(session_id);
   if (session)
     session->Close();
 }
 
 void DrmSystemOcdm::UpdateServerCertificate(int ticket,
-                                            const void* certificate,
-                                            int certificate_size) {
+                                            std::string_view certificate) {
   SB_CHECK(ocdm_system_ != nullptr);
   auto status = opencdm_system_set_server_certificate(
-      ocdm_system_, static_cast<const uint8_t*>(certificate), certificate_size);
+      ocdm_system_, reinterpret_cast<const uint8_t*>(certificate.data()),
+      static_cast<int>(certificate.size()));
 
   server_certificate_updated_callback_(
       this, context_, ticket,
@@ -637,11 +631,11 @@ SbDrmSystemPrivate::DecryptStatus DrmSystemOcdm::Decrypt(InputBuffer* buffer) {
   return kFailure;
 }
 
-Session* DrmSystemOcdm::GetSessionById(const std::string& id) {
+Session* DrmSystemOcdm::GetSessionById(std::string_view id) {
   std::lock_guard lock(mutex_);
   auto iter = std::find_if(
       sessions_.begin(), sessions_.end(),
-      [&id](const std::unique_ptr<Session>& s) { return id == s->Id(); });
+      [id](const std::unique_ptr<Session>& s) { return id == s->Id(); });
 
   if (iter != sessions_.end())
     return iter->get();
@@ -761,8 +755,7 @@ int DrmSystemOcdm::Decrypt(const std::string& id,
   return session->Decrypt(buffer, sub_sample, sub_sample_count, iv, key, caps);
 }
 
-const void* DrmSystemOcdm::GetMetrics(int* size) {
-
+std::optional<std::string_view> DrmSystemOcdm::GetMetrics() {
   SB_CHECK(ocdm_system_ != nullptr);
 
   const int kMaxRetry = 5;
@@ -809,8 +802,7 @@ const void* DrmSystemOcdm::GetMetrics(int* size) {
     }
   }
 
-  *size = static_cast<int>(metrics_.size());
-  return metrics_.data();
+  return metrics_;
 }
 
 }  // namespace starboard

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/drm/drm_system_ocdm.h
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/drm/drm_system_ocdm.h
@@ -19,8 +19,10 @@
 
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <set>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -66,23 +68,20 @@ class DrmSystemOcdm : public SbDrmSystemPrivate, public RefCountedThreadSafe<Drm
                                    const char* mime_type);
 
   // SbDrmSystemPrivate
-  void GenerateSessionUpdateRequest(int ticket,
-                                    const char* type,
-                                    const void* initialization_data,
-                                    int initialization_data_size) override;
-  void CloseSession(const void* session_id, int session_id_size) override;
+  void GenerateSessionUpdateRequest(
+      int ticket,
+      std::string_view type,
+      std::string_view initialization_data) override;
+  void CloseSession(std::string_view session_id) override;
   void UpdateSession(int ticket,
-                     const void* key,
-                     int key_size,
-                     const void* session_id,
-                     int session_id_size) override;
+                     std::string_view key,
+                     std::string_view session_id) override;
   DecryptStatus Decrypt(InputBuffer* buffer) override;
   bool IsServerCertificateUpdatable() override { return false; }
   void UpdateServerCertificate(int ticket,
-                               const void* certificate,
-                               int certificate_size) override;
+                               std::string_view certificate) override;
 
-  const void* GetMetrics(int* size) override;
+  std::optional<std::string_view> GetMetrics() override;
 
   void AddObserver(Observer* obs);
   void RemoveObserver(Observer* obs);
@@ -104,7 +103,7 @@ class DrmSystemOcdm : public SbDrmSystemPrivate, public RefCountedThreadSafe<Drm
   void Invalidate();
 
  private:
-  Session* GetSessionById(const std::string& id);
+  Session* GetSessionById(std::string_view id);
   void AnnounceKeys();
 
   std::set<std::string> GetReadyKeysUnlocked() const;

--- a/starboard/shared/starboard/drm/drm_close_session.cc
+++ b/starboard/shared/starboard/drm/drm_close_session.cc
@@ -27,5 +27,6 @@ void SbDrmCloseSession(SbDrmSystem drm_system,
     return;
   }
 
-  drm_system->CloseSession(session_id, session_id_size);
+  drm_system->CloseSession(
+      std::string_view(static_cast<const char*>(session_id), session_id_size));
 }

--- a/starboard/shared/starboard/drm/drm_generate_session_update_request.cc
+++ b/starboard/shared/starboard/drm/drm_generate_session_update_request.cc
@@ -34,6 +34,8 @@ void SbDrmGenerateSessionUpdateRequest(SbDrmSystem drm_system,
     return;
   }
 
-  drm_system->GenerateSessionUpdateRequest(ticket, type, initialization_data,
-                                           initialization_data_size);
+  drm_system->GenerateSessionUpdateRequest(
+      ticket, type,
+      std::string_view(static_cast<const char*>(initialization_data),
+                       initialization_data_size));
 }

--- a/starboard/shared/starboard/drm/drm_get_metrics.cc
+++ b/starboard/shared/starboard/drm/drm_get_metrics.cc
@@ -20,17 +20,23 @@
 #include "starboard/shared/starboard/drm/drm_system_internal.h"
 
 const void* SbDrmGetMetrics(SbDrmSystem drm_system, int* size) {
-  if (size == NULL) {
+  if (size == nullptr) {
     SB_DLOG(WARNING) << "|size| cannot be NULL.";
-    return NULL;
+    return nullptr;
   }
 
   *size = 0;
 
   if (!SbDrmSystemIsValid(drm_system)) {
     SB_DLOG(WARNING) << "Invalid drm system";
-    return NULL;
+    return nullptr;
   }
 
-  return drm_system->GetMetrics(size);
+  std::optional<std::string_view> metrics = drm_system->GetMetrics();
+  if (!metrics) {
+    return nullptr;
+  }
+
+  *size = static_cast<int>(metrics->size());
+  return metrics->data();
 }

--- a/starboard/shared/starboard/drm/drm_system_internal.h
+++ b/starboard/shared/starboard/drm/drm_system_internal.h
@@ -15,6 +15,9 @@
 #ifndef STARBOARD_SHARED_STARBOARD_DRM_DRM_SYSTEM_INTERNAL_H_
 #define STARBOARD_SHARED_STARBOARD_DRM_DRM_SYSTEM_INTERNAL_H_
 
+#include <optional>
+#include <string_view>
+
 #include "starboard/drm.h"
 #include "starboard/shared/internal_only.h"
 #include "starboard/shared/starboard/player/input_buffer_internal.h"
@@ -25,28 +28,25 @@ struct SbDrmSystemPrivate {
 
   virtual ~SbDrmSystemPrivate() {}
 
-  virtual void GenerateSessionUpdateRequest(int ticket,
-                                            const char* type,
-                                            const void* initialization_data,
-                                            int initialization_data_size) = 0;
+  virtual void GenerateSessionUpdateRequest(
+      int ticket,
+      std::string_view type,
+      std::string_view initialization_data) = 0;
 
   virtual void UpdateSession(int ticket,
-                             const void* key,
-                             int key_size,
-                             const void* session_id,
-                             int session_id_size) = 0;
+                             std::string_view key,
+                             std::string_view session_id) = 0;
 
-  virtual void CloseSession(const void* session_id, int session_id_size) = 0;
+  virtual void CloseSession(std::string_view session_id) = 0;
 
   virtual DecryptStatus Decrypt(starboard::InputBuffer* buffer) = 0;
 
   virtual bool IsServerCertificateUpdatable() = 0;
 
   virtual void UpdateServerCertificate(int ticket,
-                                       const void* certificate,
-                                       int certificate_size) = 0;
+                                       std::string_view certificate) = 0;
 
-  virtual const void* GetMetrics(int* size) = 0;
+  virtual std::optional<std::string_view> GetMetrics() = 0;
 };
 
 #endif  // STARBOARD_SHARED_STARBOARD_DRM_DRM_SYSTEM_INTERNAL_H_

--- a/starboard/shared/starboard/drm/drm_update_server_certificate.cc
+++ b/starboard/shared/starboard/drm/drm_update_server_certificate.cc
@@ -33,5 +33,7 @@ void SbDrmUpdateServerCertificate(SbDrmSystem drm_system,
     return;
   }
 
-  drm_system->UpdateServerCertificate(ticket, certificate, certificate_size);
+  drm_system->UpdateServerCertificate(
+      ticket, std::string_view(static_cast<const char*>(certificate),
+                               certificate_size));
 }

--- a/starboard/shared/starboard/drm/drm_update_session.cc
+++ b/starboard/shared/starboard/drm/drm_update_session.cc
@@ -30,5 +30,7 @@ void SbDrmUpdateSession(SbDrmSystem drm_system,
     return;
   }
 
-  drm_system->UpdateSession(ticket, key, key_size, session_id, session_id_size);
+  drm_system->UpdateSession(
+      ticket, std::string_view(static_cast<const char*>(key), key_size),
+      std::string_view(static_cast<const char*>(session_id), session_id_size));
 }

--- a/starboard/shared/widevine/drm_system_widevine.cc
+++ b/starboard/shared/widevine/drm_system_widevine.cc
@@ -302,17 +302,15 @@ bool DrmSystemWidevine::IsDrmSystemWidevine(SbDrmSystem drm_system) {
 
 void DrmSystemWidevine::GenerateSessionUpdateRequest(
     int ticket,
-    const char* type,
-    const void* initialization_data,
-    int initialization_data_size) {
+    std::string_view type,
+    std::string_view initialization_data) {
   SB_CHECK(thread_checker_.CalledOnValidThread());
 
-  const std::string init_str(static_cast<const char*>(initialization_data),
-                             initialization_data_size);
+  const std::string init_str(initialization_data);
   wv3cdm::InitDataType init_type = wv3cdm::kWebM;
-  if (strcmp("cenc", type) == 0) {
+  if (type == "cenc") {
     init_type = wv3cdm::kCenc;
-  } else if (strcmp("webm", type) == 0) {
+  } else if (type == "webm") {
     init_type = wv3cdm::kWebM;
   } else {
     SB_NOTREACHED();
@@ -336,45 +334,42 @@ void DrmSystemWidevine::GenerateSessionUpdateRequest(
 }
 
 void DrmSystemWidevine::UpdateSession(int ticket,
-                                      const void* key,
-                                      int key_size,
-                                      const void* sb_drm_session_id,
-                                      int sb_drm_session_id_size) {
+                                      std::string_view key,
+                                      std::string_view sb_drm_session_id) {
   SB_CHECK(thread_checker_.CalledOnValidThread());
-  const std::string str_key(static_cast<const char*>(key), key_size);
+  const std::string str_key(key);
 
   wv3cdm::Status status;
   if (!pending_generate_session_update_requests_.empty()) {
     status = ProcessServerCertificateResponse(str_key);
   } else {
     std::string wvcdm_session_id;
-    bool succeeded = SbDrmSessionIdToWvdmSessionId(
-        sb_drm_session_id, sb_drm_session_id_size, &wvcdm_session_id);
+    bool succeeded =
+        SbDrmSessionIdToWvdmSessionId(sb_drm_session_id, &wvcdm_session_id);
     SB_DCHECK(succeeded);
     status = cdm_->update(wvcdm_session_id, str_key);
     first_update_session_received_.store(true);
   }
   SB_DLOG(INFO) << "Update keys status " << status;
-  session_updated_callback_(this, context_, ticket,
-                            CdmStatusToSbDrmStatus(status), "",
-                            sb_drm_session_id, sb_drm_session_id_size);
+  session_updated_callback_(
+      this, context_, ticket, CdmStatusToSbDrmStatus(status), "",
+      sb_drm_session_id.data(), static_cast<int>(sb_drm_session_id.size()));
 
   // It is possible that |key| actually contains a server certificate, in such
   // case try to process the pending GenerateSessionUpdateRequest() calls.
   TrySendPendingGenerateSessionUpdateRequests();
 }
 
-void DrmSystemWidevine::CloseSession(const void* sb_drm_session_id,
-                                     int sb_drm_session_id_size) {
+void DrmSystemWidevine::CloseSession(std::string_view sb_drm_session_id) {
   SB_CHECK(thread_checker_.CalledOnValidThread());
   std::string wvcdm_session_id;
-  bool succeeded = SbDrmSessionIdToWvdmSessionId(
-      sb_drm_session_id, sb_drm_session_id_size, &wvcdm_session_id);
+  bool succeeded =
+      SbDrmSessionIdToWvdmSessionId(sb_drm_session_id, &wvcdm_session_id);
   if (succeeded) {
     cdm_->close(wvcdm_session_id);
   }
-  session_closed_callback_(this, context_, sb_drm_session_id,
-                           sb_drm_session_id_size);
+  session_closed_callback_(this, context_, sb_drm_session_id.data(),
+                           static_cast<int>(sb_drm_session_id.size()));
 }
 
 void IncrementIv(uint8_t* iv, size_t block_count) {
@@ -537,11 +532,9 @@ SbDrmSystemPrivate::DecryptStatus DrmSystemWidevine::Decrypt(
 }
 
 void DrmSystemWidevine::UpdateServerCertificate(int ticket,
-                                                const void* certificate,
-                                                int certificate_size) {
+                                                std::string_view certificate) {
   SB_CHECK(thread_checker_.CalledOnValidThread());
-  const std::string str_certificate(static_cast<const char*>(certificate),
-                                    certificate_size);
+  const std::string str_certificate(certificate);
   wv3cdm::Status status = cdm_->setServiceCertificate(str_certificate);
 
   is_server_certificate_set_ = (status == wv3cdm::kSuccess);
@@ -714,12 +707,10 @@ std::string DrmSystemWidevine::WvdmSessionIdToSbDrmSessionId(
 }
 
 bool DrmSystemWidevine::SbDrmSessionIdToWvdmSessionId(
-    const void* sb_drm_session_id,
-    int sb_drm_session_id_size,
+    std::string_view sb_drm_session_id,
     std::string* wvcdm_session_id) {
   SB_DCHECK(wvcdm_session_id);
-  const std::string str_sb_drm_session_id(
-      static_cast<const char*>(sb_drm_session_id), sb_drm_session_id_size);
+  const std::string str_sb_drm_session_id(sb_drm_session_id);
   if (str_sb_drm_session_id == kFirstSbDrmSessionId) {
     *wvcdm_session_id = first_wvcdm_session_id_;
     return !first_wvcdm_session_id_.empty();

--- a/starboard/shared/widevine/drm_system_widevine.h
+++ b/starboard/shared/widevine/drm_system_widevine.h
@@ -57,19 +57,16 @@ class DrmSystemWidevine : public SbDrmSystemPrivate,
   static bool IsDrmSystemWidevine(SbDrmSystem drm_system);
 
   // From |SbDrmSystemPrivate|.
-  void GenerateSessionUpdateRequest(int ticket,
-                                    const char* type,
-                                    const void* initialization_data,
-                                    int initialization_data_size) override;
+  void GenerateSessionUpdateRequest(
+      int ticket,
+      std::string_view type,
+      std::string_view initialization_data) override;
 
   void UpdateSession(int ticket,
-                     const void* key,
-                     int key_size,
-                     const void* sb_drm_session_id,
-                     int sb_drm_session_id_size) override;
+                     std::string_view key,
+                     std::string_view sb_drm_session_id) override;
 
-  void CloseSession(const void* sb_drm_session_id,
-                    int sb_drm_session_id_size) override;
+  void CloseSession(std::string_view sb_drm_session_id) override;
 
   DecryptStatus Decrypt(InputBuffer* buffer) override;
 
@@ -82,10 +79,9 @@ class DrmSystemWidevine : public SbDrmSystemPrivate,
   // this function.  Note that it is benign if this function is called in
   // parallel with a server certificate request.
   void UpdateServerCertificate(int ticket,
-                               const void* certificate,
-                               int certificate_size) override;
+                               std::string_view certificate) override;
 
-  const void* GetMetrics(int* size) override { return NULL; }
+  std::optional<std::string_view> GetMetrics() override { return std::nullopt; }
 
  private:
   // Stores the data necessary to call GenerateSessionUpdateRequestInternal().
@@ -133,8 +129,7 @@ class DrmSystemWidevine : public SbDrmSystemPrivate,
   int GetAndResetTicket(const std::string& sb_drm_session_id);
   std::string WvdmSessionIdToSbDrmSessionId(
       const std::string& wvcdm_session_id);
-  bool SbDrmSessionIdToWvdmSessionId(const void* sb_drm_session_id,
-                                     int sb_drm_session_id_size,
+  bool SbDrmSessionIdToWvdmSessionId(std::string_view sb_drm_session_id,
                                      std::string* wvcdm_session_id);
 
   // Generates a special key message to ask for the server certificate.  When

--- a/starboard/tvos/shared/media/drm_close_session.mm
+++ b/starboard/tvos/shared/media/drm_close_session.mm
@@ -40,5 +40,6 @@ void SbDrmCloseSession(SbDrmSystem drm_system,
 
   SB_DCHECK(DrmSystemWidevine::IsDrmSystemWidevine(drm_system) ||
             DrmSystemPlatform::IsSupported(drm_system));
-  drm_system->CloseSession(session_id, session_id_size);
+  drm_system->CloseSession(
+      std::string_view(static_cast<const char*>(session_id), session_id_size));
 }

--- a/starboard/tvos/shared/media/drm_generate_session_update_request.mm
+++ b/starboard/tvos/shared/media/drm_generate_session_update_request.mm
@@ -97,6 +97,8 @@ void SbDrmGenerateSessionUpdateRequest(SbDrmSystem drm_system,
 
   SB_DCHECK(DrmSystemWidevine::IsDrmSystemWidevine(drm_system) ||
             DrmSystemPlatform::IsSupported(drm_system));
-  drm_system->GenerateSessionUpdateRequest(ticket, type, initialization_data,
-                                           initialization_data_size);
+  drm_system->GenerateSessionUpdateRequest(
+      ticket, type,
+      std::string_view(static_cast<const char*>(initialization_data),
+                       initialization_data_size));
 }

--- a/starboard/tvos/shared/media/drm_get_metrics.mm
+++ b/starboard/tvos/shared/media/drm_get_metrics.mm
@@ -12,27 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "starboard/drm.h"
-#include "starboard/shared/widevine/drm_system_widevine.h"
+#include <optional>
+#include <string_view>
 
-using starboard::DrmSystemWidevine;
+#include "starboard/common/log.h"
+#include "starboard/drm.h"
+#include "starboard/shared/starboard/drm/drm_system_internal.h"
 
 const void* SbDrmGetMetrics(SbDrmSystem drm_system, int* size) {
-  if (size == NULL) {
+  if (size == nullptr) {
     SB_DLOG(WARNING) << "|size| cannot be NULL.";
-    return NULL;
+    return nullptr;
   }
 
   *size = 0;
 
   if (!SbDrmSystemIsValid(drm_system)) {
     SB_DLOG(WARNING) << "Invalid drm system";
-    return NULL;
+    return nullptr;
   }
 
-  if (DrmSystemWidevine::IsDrmSystemWidevine(drm_system)) {
-    return drm_system->GetMetrics(size);
+  std::optional<std::string_view> metrics = drm_system->GetMetrics();
+  if (!metrics) {
+    return nullptr;
   }
 
-  return NULL;
+  *size = static_cast<int>(metrics->size());
+  return metrics->data();
 }

--- a/starboard/tvos/shared/media/drm_system_platform.h
+++ b/starboard/tvos/shared/media/drm_system_platform.h
@@ -40,22 +40,19 @@ class DrmSystemPlatform : public SbDrmSystemPrivate {
   static std::string GetKeySystemName();
 
   // SbDrmSystemPrivate overrides
-  void GenerateSessionUpdateRequest(int ticket,
-                                    const char* type,
-                                    const void* initialization_data,
-                                    int initialization_data_size) override = 0;
+  void GenerateSessionUpdateRequest(
+      int ticket,
+      std::string_view type,
+      std::string_view initialization_data) override = 0;
   void UpdateSession(int ticket,
-                     const void* key,
-                     int key_size,
-                     const void* session_id,
-                     int session_id_size) override = 0;
-  void CloseSession(const void* session_id, int session_id_size) override = 0;
+                     std::string_view key,
+                     std::string_view session_id) override = 0;
+  void CloseSession(std::string_view session_id) override = 0;
   DecryptStatus Decrypt(InputBuffer* buffer) override = 0;
   bool IsServerCertificateUpdatable() override = 0;
   void UpdateServerCertificate(int ticket,
-                               const void* certificate,
-                               int certificate_size) override = 0;
-  const void* GetMetrics(int* size) override = 0;
+                               std::string_view certificate) override = 0;
+  std::optional<std::string_view> GetMetrics() override = 0;
 
   virtual AVContentKey* GetContentKey(const uint8_t* key_id, int key_id_size)
       API_AVAILABLE(tvos(14.5)) = 0;

--- a/starboard/tvos/shared/media/drm_update_server_certificate.mm
+++ b/starboard/tvos/shared/media/drm_update_server_certificate.mm
@@ -37,5 +37,7 @@ void SbDrmUpdateServerCertificate(SbDrmSystem drm_system,
 
   SB_DCHECK(DrmSystemWidevine::IsDrmSystemWidevine(drm_system) ||
             DrmSystemPlatform::IsSupported(drm_system));
-  drm_system->UpdateServerCertificate(ticket, certificate, certificate_size);
+  drm_system->UpdateServerCertificate(
+      ticket, std::string_view(static_cast<const char*>(certificate),
+                               certificate_size));
 }

--- a/starboard/tvos/shared/media/drm_update_session.mm
+++ b/starboard/tvos/shared/media/drm_update_session.mm
@@ -59,5 +59,7 @@ void SbDrmUpdateSession(SbDrmSystem drm_system,
 
   SB_DCHECK(DrmSystemWidevine::IsDrmSystemWidevine(drm_system) ||
             DrmSystemPlatform::IsSupported(drm_system));
-  drm_system->UpdateSession(ticket, key, key_size, session_id, session_id_size);
+  drm_system->UpdateSession(
+      ticket, std::string_view(static_cast<const char*>(key), key_size),
+      std::string_view(static_cast<const char*>(session_id), session_id_size));
 }


### PR DESCRIPTION
Update SbDrmSystemPrivate virtual method signatures to take std::string_view instead of pointer and length parameter pairs. Also update GetMetrics() to return std::optional<std::string_view>.

Propagate the signature updates across all SbDrmSystemPrivate implementations (Widevine, Android MediaDrmBridge/DrmSystem, RDK OCDM, and tvOS) and C API wrapper functions.

Issue: 516906963