### PR TITLE
Don't use fallback asset path on ATV

### DIFF
--- a/starboard/android/shared/file_internal.cc
+++ b/starboard/android/shared/file_internal.cc
@@ -27,6 +27,9 @@
 
 namespace starboard {
 
+#if !BUILDFLAG(IS_STARBOARD)
+const char* g_app_assets_dir = "/cobalt/assets";
+#endif
 // Representing the absolute path to the application-specific directory
 // where persistent files should be stored
 // (Context.getFilesDir().getAbsolutePath()). This path is used

--- a/starboard/android/shared/file_internal.h
+++ b/starboard/android/shared/file_internal.h
@@ -39,7 +39,11 @@ struct SbFilePrivate {
 
 namespace starboard {
 
+#if BUILDFLAG(IS_STARBOARD)
 inline constexpr char g_app_assets_dir[] = "/cobalt/assets";
+#else
+extern const char* g_app_assets_dir;
+#endif
 extern const char* g_app_files_dir;
 extern const char* g_app_cache_dir;
 extern const char* g_app_lib_dir;

--- a/starboard/android/shared/posix_emu/stat.cc
+++ b/starboard/android/shared/posix_emu/stat.cc
@@ -23,7 +23,9 @@
 
 #include "starboard/android/shared/file_internal.h"
 
+#if BUILDFLAG(IS_STARBOARD)
 using starboard::FallbackPath;
+#endif
 using starboard::IsAndroidAssetPath;
 using starboard::OpenAndroidAsset;
 using starboard::OpenAndroidAssetDir;
@@ -88,10 +90,12 @@ int __wrap_fstatat(int dirfd, const char* path, struct stat* info, int flags) {
     return 0;
   }
 
+#if BUILDFLAG(IS_STARBOARD)
   std::string fallback_path = FallbackPath(path);
   if (!fallback_path.empty()) {
     return __real_fstatat(dirfd, fallback_path.c_str(), info, flags);
   }
+#endif
 
   errno = ENOENT;
   return -1;


### PR DESCRIPTION
This keeps font selection behavior separate for AOSP and ATV

Bug: 495203133