### PR TITLE
tvos: Wire encrypted media event flow for URL player

### DIFF
--- a/media/mojo/clients/starboard/starboard_renderer_client.cc
+++ b/media/mojo/clients/starboard/starboard_renderer_client.cc
@@ -291,6 +291,13 @@ void StarboardRendererClient::GetSbWindowHandle() {
 }
 
 #if BUILDFLAG(IS_IOS_TVOS)
+void StarboardRendererClient::OnEncryptedMediaInitDataEncountered(
+    const std::string& init_data_type,
+    const std::vector<uint8_t>& init_data) {
+  DCHECK(media_task_runner_->RunsTasksInCurrentSequence());
+  // TODO(b/498421484): Forward this to blink so the `encrypted` event fires.
+}
+
 void StarboardRendererClient::OnDurationChange(base::TimeDelta duration) {
   DCHECK(media_task_runner_->RunsTasksInCurrentSequence());
   if (media_resource_) {

--- a/media/mojo/clients/starboard/starboard_renderer_client.h
+++ b/media/mojo/clients/starboard/starboard_renderer_client.h
@@ -16,6 +16,8 @@
 #define MEDIA_MOJO_CLIENTS_STARBOARD_STARBOARD_RENDERER_CLIENT_H_
 
 #include <optional>
+#include <string>
+#include <vector>
 
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
@@ -112,6 +114,9 @@ class MEDIA_EXPORT StarboardRendererClient
   void UpdateStarboardRenderingMode(const StarboardRenderingMode mode) override;
   void GetSbWindowHandle() override;
 #if BUILDFLAG(IS_IOS_TVOS)
+  void OnEncryptedMediaInitDataEncountered(
+      const std::string& init_data_type,
+      const std::vector<uint8_t>& init_data) override;
   void OnDurationChange(base::TimeDelta duration) override;
   void OnBufferedTimeRangesChange(base::TimeDelta start,
                                   base::TimeDelta length) override;

--- a/media/mojo/mojom/renderer_extensions.mojom
+++ b/media/mojo/mojom/renderer_extensions.mojom
@@ -81,6 +81,11 @@ interface StarboardRendererClientExtension {
   GetSbWindowHandle();
 
   [EnableIf=is_ios]
+  // Forward encrypted media init data for DRM key exchange.
+  OnEncryptedMediaInitDataEncountered(string init_data_type,
+                                      array<uint8> init_data);
+
+  [EnableIf=is_ios]
   // URL player duration forwarding.
   OnDurationChange(mojo_base.mojom.TimeDelta duration);
 

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.cc
@@ -254,6 +254,9 @@ void StarboardRendererWrapper::Initialize(MediaResource* media_resource,
   GetRenderer()->SetBufferedRangesCB(
       base::BindRepeating(&StarboardRendererWrapper::OnBufferedTimeRangesChange,
                           weak_factory_.GetWeakPtr()));
+  GetRenderer()->SetEncryptedMediaInitDataCB(
+      base::BindRepeating(&StarboardRendererWrapper::OnEncryptedMediaInitData,
+                          weak_factory_.GetWeakPtr()));
 #endif  // BUILDFLAG(IS_IOS_TVOS)
 
   base::ScopedClosureRunner scoped_init_cb(
@@ -635,6 +638,14 @@ void StarboardRendererWrapper::OnGetSbWindowHandle() {
 }
 
 #if BUILDFLAG(IS_IOS_TVOS)
+void StarboardRendererWrapper::OnEncryptedMediaInitData(
+    const std::string& init_data_type,
+    const std::vector<uint8_t>& init_data) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  client_extension_remote_->OnEncryptedMediaInitDataEncountered(init_data_type,
+                                                                init_data);
+}
+
 void StarboardRendererWrapper::OnDurationChange(base::TimeDelta duration) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
   client_extension_remote_->OnDurationChange(duration);

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.h
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.h
@@ -17,6 +17,7 @@
 
 #include <functional>
 #include <optional>
+#include <string>
 #include <vector>
 
 #include "base/memory/raw_ptr.h"
@@ -141,6 +142,8 @@ class StarboardRendererWrapper
       const StarboardRenderingMode mode);
   void OnGetSbWindowHandle();
 #if BUILDFLAG(IS_IOS_TVOS)
+  void OnEncryptedMediaInitData(const std::string& init_data_type,
+                                const std::vector<uint8_t>& init_data);
   void OnDurationChange(base::TimeDelta duration);
   void OnBufferedTimeRangesChange(base::TimeDelta start,
                                   base::TimeDelta length);

--- a/media/starboard/sbplayer_bridge.cc
+++ b/media/starboard/sbplayer_bridge.cc
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "base/compiler_specific.h"
+#include "base/containers/span.h"
 #include "base/functional/bind.h"
 #include "base/location.h"
 #include "base/logging.h"
@@ -648,10 +649,21 @@ void SbPlayerBridge::EncryptedMediaInitDataEncounteredCB(
     const unsigned char* init_data,
     unsigned int init_data_length) {
   SbPlayerBridge* sbplayer_bridge = static_cast<SbPlayerBridge*>(context);
-  DCHECK(
-      !sbplayer_bridge->on_encrypted_media_init_data_encountered_cb_.is_null());
-  sbplayer_bridge->on_encrypted_media_init_data_encountered_cb_.Run(
-      init_data_type, init_data, init_data_length);
+  auto data_span = base::span(init_data, init_data_length);
+  sbplayer_bridge->task_runner_->PostTask(
+      FROM_HERE,
+      base::BindOnce(&SbPlayerBridge::OnEncryptedMediaInitDataEncountered,
+                     sbplayer_bridge->weak_factory_.GetWeakPtr(),
+                     std::string(init_data_type),
+                     std::vector<uint8_t>(data_span.begin(), data_span.end())));
+}
+
+void SbPlayerBridge::OnEncryptedMediaInitDataEncountered(
+    std::string init_data_type,
+    std::vector<uint8_t> init_data) {
+  DCHECK(task_runner_->RunsTasksInCurrentSequence());
+  DCHECK(!on_encrypted_media_init_data_encountered_cb_.is_null());
+  on_encrypted_media_init_data_encountered_cb_.Run(init_data_type, init_data);
 }
 
 void SbPlayerBridge::CreateUrlPlayer(const std::string& url) {

--- a/media/starboard/sbplayer_bridge.h
+++ b/media/starboard/sbplayer_bridge.h
@@ -80,8 +80,11 @@ class SbPlayerBridge {
       base::RepeatingCallback<SbDecodeTargetGraphicsContextProvider*()>;
 
 #if BUILDFLAG(IS_IOS_TVOS)
-  using OnEncryptedMediaInitDataEncounteredCB = base::RepeatingCallback<
-      void(const char*, const unsigned char*, unsigned)>;
+  // Invoked on |task_runner_| with owned copies, since the static
+  // callback originates from the native Starboard player thread.
+  using OnEncryptedMediaInitDataEncounteredCB =
+      base::RepeatingCallback<void(const std::string& init_data_type,
+                                   const std::vector<uint8_t>& init_data)>;
   // Create an SbPlayerBridge with url-based player.
   SbPlayerBridge(SbPlayerInterface* interface,
                  const scoped_refptr<base::SequencedTaskRunner>& task_runner,
@@ -218,6 +221,9 @@ class SbPlayerBridge {
       const char* init_data_type,
       const unsigned char* init_data,
       unsigned int init_data_length);
+
+  void OnEncryptedMediaInitDataEncountered(std::string init_data_type,
+                                           std::vector<uint8_t> init_data);
 
   void CreateUrlPlayer(const std::string& url);
 #endif  // BUILDFLAG(IS_IOS_TVOS)

--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -640,10 +640,12 @@ void StarboardRenderer::SetSourceUrl(const std::string& source_url) {
 }
 
 void StarboardRenderer::OnEncryptedMediaInitDataEncountered(
-    const char* init_data_type,
-    const unsigned char* init_data,
-    unsigned int init_data_length) {
-  // TODO: Forward encrypted media init data to the EME/DRM layer.
+    const std::string& init_data_type,
+    const std::vector<uint8_t>& init_data) {
+  DCHECK(task_runner_->RunsTasksInCurrentSequence());
+  if (encrypted_media_init_data_cb_) {
+    encrypted_media_init_data_cb_.Run(init_data_type, init_data);
+  }
 }
 #endif  // BUILDFLAG(IS_IOS_TVOS)
 

--- a/media/starboard/starboard_renderer.h
+++ b/media/starboard/starboard_renderer.h
@@ -114,6 +114,9 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
   using BufferedRangesCB =
       base::RepeatingCallback<void(base::TimeDelta start,
                                    base::TimeDelta length)>;
+  using EncryptedMediaInitDataCB =
+      base::RepeatingCallback<void(const std::string& init_data_type,
+                                   const std::vector<uint8_t>& init_data)>;
 
   void SetDurationChangeCB(DurationChangeCB cb) {
     duration_change_cb_ = std::move(cb);
@@ -121,10 +124,10 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
   void SetBufferedRangesCB(BufferedRangesCB cb) {
     buffered_ranges_cb_ = std::move(cb);
   }
+  void SetEncryptedMediaInitDataCB(EncryptedMediaInitDataCB cb) {
+    encrypted_media_init_data_cb_ = std::move(cb);
+  }
   void SetSourceUrl(const std::string& source_url);
-  void OnEncryptedMediaInitDataEncountered(const char* init_data_type,
-                                           const unsigned char* init_data,
-                                           unsigned int init_data_length);
 #endif  // BUILDFLAG(IS_IOS_TVOS)
 
 #if BUILDFLAG(IS_ANDROID)
@@ -174,6 +177,9 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
   void OnUrlPlayerPresenting();
   // Reads and propagates a valid URL-player resolution when it changes.
   void UpdateUrlPlayerVideoResolution();
+  void OnEncryptedMediaInitDataEncountered(
+      const std::string& init_data_type,
+      const std::vector<uint8_t>& init_data);
 #endif  // BUILDFLAG(IS_IOS_TVOS)
 
   void UpdateAudioWriteDuration();
@@ -252,8 +258,10 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
   GetSbWindowHandleCallback get_sb_window_handle_cb_;
 #if BUILDFLAG(IS_IOS_TVOS)
   std::string source_url_;
+
   DurationChangeCB duration_change_cb_;
   BufferedRangesCB buffered_ranges_cb_;
+  EncryptedMediaInitDataCB encrypted_media_init_data_cb_;
 
   // Cached values for change-detection; only notify upstream when they differ.
   TimeDelta last_buffer_start_;


### PR DESCRIPTION
Implement the Mojo IPC chain to forward encrypted media init data
from the GPU process to the renderer process so the JS encrypted
event fires and session.generateRequest() can initiate DRM key
exchange.

Follows the same pattern as the existing duration and buffered
ranges forwarding through StarboardRendererClientExtension.

Bug: 549709375