### PR TITLE
starboard: Remove storage_type support and always store DecodedAudio in interleaved format

### DIFF
--- a/starboard/android/shared/audio_decoder_passthrough.h
+++ b/starboard/android/shared/audio_decoder_passthrough.h
@@ -67,8 +67,7 @@ class AudioDecoderPassthrough : public AudioDecoder {
     for (const auto& input_buffer : input_buffers) {
       DecodedAudio decoded_audio(
           kChannels, kSbMediaAudioSampleTypeInt16Deprecated,
-          kSbMediaAudioFrameStorageTypePlanar, input_buffer->timestamp(),
-          input_buffer->size());
+          input_buffer->timestamp(), input_buffer->size());
       memcpy(decoded_audio.data(), input_buffer->data(), input_buffer->size());
       decoded_audios_.push(std::move(decoded_audio));
       output_cb_();

--- a/starboard/android/shared/media_codec_audio_decoder.cc
+++ b/starboard/android/shared/media_codec_audio_decoder.cc
@@ -270,7 +270,6 @@ void MediaCodecAudioDecoder::ProcessOutputBuffer(
 
     DecodedAudio decoded_audio(
         audio_stream_info_.number_of_channels, sample_type_,
-        kSbMediaAudioFrameStorageTypeInterleaved,
         dequeue_output_result.presentation_time_microseconds, size);
 
     memcpy(decoded_audio.data(), data, size);

--- a/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.cc
@@ -238,22 +238,34 @@ void FfmpegAudioDecoderImpl<FFMPEG>::ProcessDecodedFrame(
   }
 
   DecodedAudio decoded_audio(
-      channel_count, GetSampleType(), GetStorageType(),
-      input_buffer.timestamp(),
+      channel_count, GetSampleType(), input_buffer.timestamp(),
       channel_count * av_frame.nb_samples * GetBytesPerSample(GetSampleType()));
-  if (GetStorageType() == kSbMediaAudioFrameStorageTypeInterleaved) {
+  bool is_planar = (codec_context_->sample_fmt == AV_SAMPLE_FMT_S16P ||
+                    codec_context_->sample_fmt == AV_SAMPLE_FMT_FLTP);
+  if (!is_planar) {
     memcpy(decoded_audio.data(), *av_frame.extended_data,
            decoded_audio.size_in_bytes());
   } else {
-    SB_DCHECK_EQ(GetStorageType(), kSbMediaAudioFrameStorageTypePlanar);
-    const int per_channel_size_in_bytes =
-        decoded_audio.size_in_bytes() / decoded_audio.channels();
-    for (int i = 0; i < decoded_audio.channels(); ++i) {
-      memcpy(decoded_audio.data() + per_channel_size_in_bytes * i,
-             av_frame.extended_data[i], per_channel_size_in_bytes);
+    if (GetSampleType() == kSbMediaAudioSampleTypeInt16Deprecated) {
+      const int16_t* const* src =
+          reinterpret_cast<const int16_t* const*>(av_frame.extended_data);
+      int16_t* dst = reinterpret_cast<int16_t*>(decoded_audio.data());
+      for (int frame = 0; frame < av_frame.nb_samples; ++frame) {
+        for (int ch = 0; ch < channel_count; ++ch) {
+          *dst++ = src[ch][frame];
+        }
+      }
+    } else {
+      SB_DCHECK_EQ(GetSampleType(), kSbMediaAudioSampleTypeFloat32);
+      const float* const* src =
+          reinterpret_cast<const float* const*>(av_frame.extended_data);
+      float* dst = reinterpret_cast<float*>(decoded_audio.data());
+      for (int frame = 0; frame < av_frame.nb_samples; ++frame) {
+        for (int ch = 0; ch < channel_count; ++ch) {
+          *dst++ = src[ch][frame];
+        }
+      }
     }
-    decoded_audio = decoded_audio.SwitchFormatTo(
-        GetSampleType(), kSbMediaAudioFrameStorageTypeInterleaved);
   }
   decoded_audio.AdjustForDiscardedDurations(
       audio_stream_info_.samples_per_second,
@@ -321,23 +333,6 @@ SbMediaAudioSampleType FfmpegAudioDecoderImpl<FFMPEG>::GetSampleType() const {
   SB_NOTREACHED();
 
   return kSbMediaAudioSampleTypeFloat32;
-}
-
-SbMediaAudioFrameStorageType FfmpegAudioDecoderImpl<FFMPEG>::GetStorageType()
-    const {
-  SB_CHECK(BelongsToCurrentThread());
-
-  if (codec_context_->sample_fmt == AV_SAMPLE_FMT_S16 ||
-      codec_context_->sample_fmt == AV_SAMPLE_FMT_FLT) {
-    return kSbMediaAudioFrameStorageTypeInterleaved;
-  }
-  if (codec_context_->sample_fmt == AV_SAMPLE_FMT_S16P ||
-      codec_context_->sample_fmt == AV_SAMPLE_FMT_FLTP) {
-    return kSbMediaAudioFrameStorageTypePlanar;
-  }
-
-  SB_NOTREACHED();
-  return kSbMediaAudioFrameStorageTypeInterleaved;
 }
 
 bool FfmpegAudioDecoderImpl<FFMPEG>::InitializeCodec() {

--- a/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.h
+++ b/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.h
@@ -62,7 +62,6 @@ class FfmpegAudioDecoderImpl<FFMPEG> : public FfmpegAudioDecoder,
 
  private:
   SbMediaAudioSampleType GetSampleType() const;
-  SbMediaAudioFrameStorageType GetStorageType() const;
 
   bool InitializeCodec();
   void TeardownCodec();

--- a/starboard/shared/libfdkaac/fdk_aac_audio_decoder.cc
+++ b/starboard/shared/libfdkaac/fdk_aac_audio_decoder.cc
@@ -220,7 +220,6 @@ void FdkAacAudioDecoder::TryToOutputDecodedAudio(const uint8_t* data,
       SB_DCHECK_EQ(partially_decoded_audio_data_in_bytes_, 0);
       partially_decoded_audio_ =
           DecodedAudio(num_channels_, kSbMediaAudioSampleTypeInt16Deprecated,
-                       kSbMediaAudioFrameStorageTypeInterleaved,
                        decoding_input_buffers_.front()->timestamp(),
                        decoded_audio_size_in_bytes_);
     }

--- a/starboard/shared/opus/opus_audio_decoder.cc
+++ b/starboard/shared/opus/opus_audio_decoder.cc
@@ -238,11 +238,11 @@ bool OpusAudioDecoder::DecodeInternal(
   SB_DCHECK(output_cb_);
   SB_DCHECK(!stream_ended_ || !pending_audio_buffers_.empty());
 
-  DecodedAudio decoded_audio(
-      audio_stream_info_.number_of_channels, GetSampleType(),
-      kSbMediaAudioFrameStorageTypeInterleaved, input_buffer->timestamp(),
-      audio_stream_info_.number_of_channels * frames_per_au_ *
-          GetBytesPerSample(GetSampleType()));
+  DecodedAudio decoded_audio(audio_stream_info_.number_of_channels,
+                             GetSampleType(), input_buffer->timestamp(),
+                             audio_stream_info_.number_of_channels *
+                                 frames_per_au_ *
+                                 GetBytesPerSample(GetSampleType()));
 
   const char kDecodeFunctionName[] = "opus_multistream_decode_float";
   int decoded_frames = opus_multistream_decode_float(

--- a/starboard/shared/starboard/player/decoded_audio_internal.cc
+++ b/starboard/shared/starboard/player/decoded_audio_internal.cc
@@ -71,40 +71,31 @@ DecodedAudio DecodedAudio::CreateEOSBuffer() {
 DecodedAudio::DecodedAudio()
     : channels_(0),
       sample_type_(kSbMediaAudioSampleTypeInt16Deprecated),
-      storage_type_(kSbMediaAudioFrameStorageTypeInterleaved),
       timestamp_(0),
       offset_in_bytes_(0),
       size_in_bytes_(0) {}
 
 DecodedAudio::DecodedAudio(int channels,
                            SbMediaAudioSampleType sample_type,
-                           SbMediaAudioFrameStorageType storage_type,
                            int64_t timestamp,
                            int size_in_bytes)
     : channels_(channels),
       sample_type_(sample_type),
-      storage_type_(storage_type),
       timestamp_(timestamp),
       storage_(size_in_bytes),
       offset_in_bytes_(0),
       size_in_bytes_(size_in_bytes) {
   SB_DCHECK_GT(channels_, 0);
   SB_DCHECK_GE(size_in_bytes_, 0);
-  // TODO(b/275199195): Enable the SB_DCHECK below.
-  // SB_DCHECK_EQ(size_in_bytes_ % (GetBytesPerSample(sample_type_) *
-  // channels_),
-  //           0);
 }
 
 DecodedAudio::DecodedAudio(int channels,
                            SbMediaAudioSampleType sample_type,
-                           SbMediaAudioFrameStorageType storage_type,
                            int64_t timestamp,
                            int size_in_bytes,
                            Buffer&& storage)
     : channels_(channels),
       sample_type_(sample_type),
-      storage_type_(storage_type),
       timestamp_(timestamp),
       storage_(std::move(storage)),
       offset_in_bytes_(0),
@@ -146,34 +137,12 @@ void DecodedAudio::AdjustForSeekTime(int sample_rate, int64_t seeking_to_time) {
     return;
   }
 
-  const auto bytes_per_sample = GetBytesPerSample(sample_type_);
-  const auto bytes_per_frame = bytes_per_sample * channels();
-
-  if (storage_type_ == kSbMediaAudioFrameStorageTypeInterleaved) {
+  if (frames_to_skip > 0) {
+    int bytes_per_frame = GetBytesPerSample(sample_type_) * channels_;
     offset_in_bytes_ += frames_to_skip * bytes_per_frame;
     size_in_bytes_ -= frames_to_skip * bytes_per_frame;
     timestamp_ += AudioFramesToDuration(frames_to_skip, sample_rate);
-    return;
   }
-
-  SB_DCHECK_EQ(storage_type_, kSbMediaAudioFrameStorageTypePlanar);
-
-  Buffer new_storage(size_in_bytes_ - frames_to_skip * bytes_per_frame);
-  const auto new_frames = frames() - frames_to_skip;
-
-  const uint8_t* source_addr = data();
-  uint8_t* dest_addr = new_storage.data();
-  for (int channel = 0; channel < channels(); ++channel) {
-    memcpy(dest_addr, source_addr + bytes_per_sample * frames_to_skip,
-           new_frames * bytes_per_frame);
-    source_addr += frames() * bytes_per_sample;
-    dest_addr += new_frames * bytes_per_sample;
-  }
-
-  storage_ = std::move(new_storage);
-  timestamp_ += AudioFramesToDuration(frames_to_skip, sample_rate);
-  offset_in_bytes_ = 0;
-  size_in_bytes_ = new_frames * bytes_per_frame;
 }
 
 void DecodedAudio::AdjustForDiscardedDurations(
@@ -190,7 +159,6 @@ void DecodedAudio::AdjustForDiscardedDurations(
                     << discarded_duration_from_back << ". Setting to 0.";
     discarded_duration_from_back = 0;
   }
-  SB_DCHECK_EQ(storage_type(), kSbMediaAudioFrameStorageTypeInterleaved);
 
   if (discarded_duration_from_front == 0 && discarded_duration_from_back == 0) {
     return;
@@ -215,108 +183,27 @@ void DecodedAudio::AdjustForDiscardedDurations(
   size_in_bytes_ -= bytes_per_frame * discarded_frames_from_back;
 }
 
-bool DecodedAudio::IsFormat(SbMediaAudioSampleType sample_type,
-                            SbMediaAudioFrameStorageType storage_type) const {
-  return sample_type_ == sample_type && storage_type_ == storage_type;
+bool DecodedAudio::IsFormat(SbMediaAudioSampleType sample_type) const {
+  return sample_type_ == sample_type;
 }
 
 DecodedAudio DecodedAudio::SwitchFormatTo(
     SbMediaAudioSampleType new_sample_type,
-    SbMediaAudioFrameStorageType new_storage_type,
     std::optional<bool> force_simd) const {
   // The caller should call IsFormat() to check before calling SwitchFormatTo(),
   // as SwitchFormatTo() always copies the whole buffer and is not optimal.
-  SB_DCHECK(new_sample_type != sample_type_ ||
-            new_storage_type != storage_type_);
+  SB_DCHECK(new_sample_type != sample_type_);
 
   bool enable_simd = false;
 #if defined(USE_NEON_FOR_AUDIO)
   enable_simd = force_simd.value_or(GetSimdBasedAudioFormatSwitchingSetting());
 #endif  // defined(USE_NEON_FOR_AUDIO)
 
-  if (new_storage_type == storage_type_) {
-    return SwitchSampleTypeTo(new_sample_type, enable_simd);
-  }
-
-  if (new_sample_type == sample_type_) {
-    return SwitchStorageTypeTo(new_storage_type, enable_simd);
-  }
-
-  // Both sample types and storage types are different, use the slowest way.
-  int new_size = GetBytesPerSample(new_sample_type) * frames() * channels();
-  DecodedAudio new_decoded_audio(channels(), new_sample_type, new_storage_type,
-                                 timestamp(), new_size);
-
-#if defined(USE_NEON_FOR_AUDIO)
-  if (enable_simd && channels() == 2 && IsAligned(frames(), 8)) {
-    if (SwitchFormatTo_NEON(new_sample_type, new_storage_type,
-                            &new_decoded_audio)) {
-      return new_decoded_audio;
-    }
-    SB_LOG(WARNING) << "SIMD format switching requested and aligned, but not "
-                       "implemented in NEON for "
-                    << GetMediaAudioSampleTypeName(sample_type_) << " ("
-                    << GetMediaAudioStorageTypeName(storage_type_) << ") -> "
-                    << GetMediaAudioSampleTypeName(new_sample_type) << " ("
-                    << GetMediaAudioStorageTypeName(new_storage_type)
-                    << "). Falling back to C++ scalar.";
-  }
-#endif  // USE_NEON_FOR_AUDIO
-
-#define InterleavedSampleAddr(start_addr, channel, frame) \
-  (start_addr + (frame * channels() + channel))
-#define PlanarSampleAddr(start_addr, channel, frame) \
-  (start_addr + (channel * frames() + frame))
-#define GetSampleAddr(StorageType, start_addr, channel, frame) \
-  (StorageType##SampleAddr(start_addr, channel, frame))
-#define SwitchTo(OldSampleType, OldStorageType, NewSampleType, NewStorageType) \
-  do {                                                                         \
-    const OldSampleType* old_samples =                                         \
-        reinterpret_cast<const OldSampleType*>(this->data());                  \
-    NewSampleType* new_samples =                                               \
-        reinterpret_cast<NewSampleType*>(new_decoded_audio.data());            \
-                                                                               \
-    for (int channel = 0; channel < channels(); ++channel) {                   \
-      for (int frame = 0; frame < frames(); ++frame) {                         \
-        const OldSampleType* old_sample =                                      \
-            GetSampleAddr(OldStorageType, old_samples, channel, frame);        \
-        NewSampleType* new_sample =                                            \
-            GetSampleAddr(NewStorageType, new_samples, channel, frame);        \
-        ConvertSample(old_sample, new_sample);                                 \
-      }                                                                        \
-    }                                                                          \
-  } while (false)
-
-  if (sample_type_ == kSbMediaAudioSampleTypeInt16Deprecated &&
-      storage_type_ == kSbMediaAudioFrameStorageTypeInterleaved &&
-      new_sample_type == kSbMediaAudioSampleTypeFloat32 &&
-      new_storage_type == kSbMediaAudioFrameStorageTypePlanar) {
-    SwitchTo(int16_t, Interleaved, float, Planar);
-  } else if (sample_type_ == kSbMediaAudioSampleTypeInt16Deprecated &&
-             storage_type_ == kSbMediaAudioFrameStorageTypePlanar &&
-             new_sample_type == kSbMediaAudioSampleTypeFloat32 &&
-             new_storage_type == kSbMediaAudioFrameStorageTypeInterleaved) {
-    SwitchTo(int16_t, Planar, float, Interleaved);
-  } else if (sample_type_ == kSbMediaAudioSampleTypeFloat32 &&
-             storage_type_ == kSbMediaAudioFrameStorageTypeInterleaved &&
-             new_sample_type == kSbMediaAudioSampleTypeInt16Deprecated &&
-             new_storage_type == kSbMediaAudioFrameStorageTypePlanar) {
-    SwitchTo(float, Interleaved, int16_t, Planar);
-  } else if (sample_type_ == kSbMediaAudioSampleTypeFloat32 &&
-             storage_type_ == kSbMediaAudioFrameStorageTypePlanar &&
-             new_sample_type == kSbMediaAudioSampleTypeInt16Deprecated &&
-             new_storage_type == kSbMediaAudioFrameStorageTypeInterleaved) {
-    SwitchTo(float, Planar, int16_t, Interleaved);
-  } else {
-    SB_NOTREACHED();
-  }
-
-  return new_decoded_audio;
+  return SwitchSampleTypeTo(new_sample_type, enable_simd);
 }
 
 DecodedAudio DecodedAudio::CloneForTesting() const {
-  DecodedAudio copy(channels(), sample_type(), storage_type(), timestamp(),
-                    size_in_bytes());
+  DecodedAudio copy(channels(), sample_type(), timestamp(), size_in_bytes());
 
   if (size_in_bytes() > 0) {
     memcpy(copy.data(), data(), size_in_bytes());
@@ -329,8 +216,8 @@ DecodedAudio DecodedAudio::SwitchSampleTypeTo(
     SbMediaAudioSampleType new_sample_type,
     bool enable_simd) const {
   int new_size = GetBytesPerSample(new_sample_type) * frames() * channels();
-  DecodedAudio new_decoded_audio(channels(), new_sample_type, storage_type(),
-                                 timestamp(), new_size);
+  DecodedAudio new_decoded_audio(channels(), new_sample_type, timestamp(),
+                                 new_size);
 
   if (sample_type_ == kSbMediaAudioSampleTypeInt16Deprecated &&
       new_sample_type == kSbMediaAudioSampleTypeFloat32) {
@@ -371,50 +258,6 @@ DecodedAudio DecodedAudio::SwitchSampleTypeTo(
   return new_decoded_audio;
 }
 
-DecodedAudio DecodedAudio::SwitchStorageTypeTo(
-    SbMediaAudioFrameStorageType new_storage_type,
-    bool enable_simd) const {
-  DecodedAudio new_decoded_audio(channels(), sample_type(), new_storage_type,
-                                 timestamp(), size_in_bytes());
-  int bytes_per_sample = GetBytesPerSample(sample_type());
-  const uint8_t* old_samples = this->data();
-  uint8_t* new_samples = new_decoded_audio.data();
-
-#if defined(USE_NEON_FOR_AUDIO)
-  if (enable_simd && channels() == 2 && IsAligned(frames(), 8)) {
-    if (SwitchStorageTypeTo_NEON(new_storage_type, &new_decoded_audio)) {
-      return new_decoded_audio;
-    }
-  }
-#endif  // USE_NEON_FOR_AUDIO
-
-  if (storage_type_ == kSbMediaAudioFrameStorageTypeInterleaved &&
-      new_storage_type == kSbMediaAudioFrameStorageTypePlanar) {
-    for (int channel = 0; channel < channels(); ++channel) {
-      for (int frame = 0; frame < frames(); ++frame) {
-        const uint8_t* old_sample =
-            old_samples + (frame * channels() + channel) * bytes_per_sample;
-        uint8_t* new_sample =
-            new_samples + (channel * frames() + frame) * bytes_per_sample;
-        memcpy(new_sample, old_sample, bytes_per_sample);
-      }
-    }
-  } else if (storage_type_ == kSbMediaAudioFrameStorageTypePlanar &&
-             new_storage_type == kSbMediaAudioFrameStorageTypeInterleaved) {
-    for (int channel = 0; channel < channels(); ++channel) {
-      for (int frame = 0; frame < frames(); ++frame) {
-        const uint8_t* old_sample =
-            old_samples + (channel * frames() + frame) * bytes_per_sample;
-        uint8_t* new_sample =
-            new_samples + (frame * channels() + channel) * bytes_per_sample;
-        memcpy(new_sample, old_sample, bytes_per_sample);
-      }
-    }
-  }
-
-  return new_decoded_audio;
-}
-
 bool operator==(const DecodedAudio& left, const DecodedAudio& right) {
   if (left.is_end_of_stream() && right.is_end_of_stream()) {
     return true;
@@ -426,7 +269,6 @@ bool operator==(const DecodedAudio& left, const DecodedAudio& right) {
   return left.timestamp() == right.timestamp() &&
          left.channels() == right.channels() &&
          left.sample_type() == right.sample_type() &&
-         left.storage_type() == right.storage_type() &&
          left.size_in_bytes() == right.size_in_bytes() &&
          memcmp(left.data(), right.data(), right.size_in_bytes()) == 0;
 }
@@ -442,105 +284,10 @@ std::ostream& operator<<(std::ostream& os, const DecodedAudio& decoded_audio) {
   return os << "timestamp: " << decoded_audio.timestamp()
             << ", channels: " << decoded_audio.channels() << ", sample type: "
             << GetMediaAudioSampleTypeName(decoded_audio.sample_type())
-            << ", storage type: "
-            << GetMediaAudioStorageTypeName(decoded_audio.storage_type())
             << ", frames: " << decoded_audio.frames();
 }
 
 #if defined(USE_NEON_FOR_AUDIO)
-bool DecodedAudio::SwitchFormatTo_NEON(
-    SbMediaAudioSampleType new_sample_type,
-    SbMediaAudioFrameStorageType new_storage_type,
-    DecodedAudio* destination_audio) const {
-  SB_DCHECK_EQ(channels(), 2);
-  SB_DCHECK_EQ(frames() % 8, 0);
-
-  if (sample_type_ == kSbMediaAudioSampleTypeInt16Deprecated &&
-      storage_type_ == kSbMediaAudioFrameStorageTypePlanar &&
-      new_sample_type == kSbMediaAudioSampleTypeFloat32 &&
-      new_storage_type == kSbMediaAudioFrameStorageTypeInterleaved) {
-    const int16_t* left_planar = reinterpret_cast<const int16_t*>(data());
-    const int16_t* right_planar = left_planar + frames();
-    float* interleaved_dst =
-        reinterpret_cast<float*>(destination_audio->data());
-    int num_frames = frames();
-
-    for (int i = 0; i + 7 < num_frames; i += 8) {
-      int16x8_t left_s16 = vld1q_s16(left_planar + i);
-      int16x8_t right_s16 = vld1q_s16(right_planar + i);
-
-      int32x4_t left_low_s32 = vmovl_s16(vget_low_s16(left_s16));
-      int32x4_t left_high_s32 = vmovl_s16(vget_high_s16(left_s16));
-      float32x4_t left_low_f32 = vcvtq_n_f32_s32(left_low_s32, 15);
-      float32x4_t left_high_f32 = vcvtq_n_f32_s32(left_high_s32, 15);
-
-      int32x4_t right_low_s32 = vmovl_s16(vget_low_s16(right_s16));
-      int32x4_t right_high_s32 = vmovl_s16(vget_high_s16(right_s16));
-      float32x4_t right_low_f32 = vcvtq_n_f32_s32(right_low_s32, 15);
-      float32x4_t right_high_f32 = vcvtq_n_f32_s32(right_high_s32, 15);
-
-      float32x4x2_t out_low;
-      out_low.val[0] = left_low_f32;
-      out_low.val[1] = right_low_f32;
-      float32x4x2_t out_high;
-      out_high.val[0] = left_high_f32;
-      out_high.val[1] = right_high_f32;
-
-      vst2q_f32(interleaved_dst + i * 2, out_low);
-      vst2q_f32(interleaved_dst + i * 2 + 8, out_high);
-    }
-    return true;
-  } else if (sample_type_ == kSbMediaAudioSampleTypeFloat32 &&
-             storage_type_ == kSbMediaAudioFrameStorageTypeInterleaved &&
-             new_sample_type == kSbMediaAudioSampleTypeInt16Deprecated &&
-             new_storage_type == kSbMediaAudioFrameStorageTypePlanar) {
-    const float* interleaved_src = reinterpret_cast<const float*>(data());
-    int16_t* left_planar =
-        reinterpret_cast<int16_t*>(destination_audio->data());
-    int16_t* right_planar = left_planar + destination_audio->frames();
-    int num_frames = destination_audio->frames();
-
-    float32x4_t min_val = vdupq_n_f32(-1.0f);
-    float32x4_t max_val = vdupq_n_f32(1.0f);
-    float32x4_t scale = vdupq_n_f32(32767.f);
-    for (int i = 0; i + 7 < num_frames; i += 8) {
-      float32x4x2_t src_low = vld2q_f32(interleaved_src + i * 2);
-      float32x4x2_t src_high = vld2q_f32(interleaved_src + i * 2 + 8);
-
-      float32x4_t left_low_clamp =
-          vminq_f32(vmaxq_f32(src_low.val[0], min_val), max_val);
-      int32x4_t left_low_s32 = vcvtq_s32_f32(vmulq_f32(left_low_clamp, scale));
-
-      float32x4_t left_high_clamp =
-          vminq_f32(vmaxq_f32(src_high.val[0], min_val), max_val);
-      int32x4_t left_high_s32 =
-          vcvtq_s32_f32(vmulq_f32(left_high_clamp, scale));
-
-      int16x4_t left_low_s16 = vqmovn_s32(left_low_s32);
-      int16x4_t left_high_s16 = vqmovn_s32(left_high_s32);
-      int16x8_t left_s16 = vcombine_s16(left_low_s16, left_high_s16);
-      vst1q_s16(left_planar + i, left_s16);
-
-      float32x4_t right_low_clamp =
-          vminq_f32(vmaxq_f32(src_low.val[1], min_val), max_val);
-      int32x4_t right_low_s32 =
-          vcvtq_s32_f32(vmulq_f32(right_low_clamp, scale));
-
-      float32x4_t right_high_clamp =
-          vminq_f32(vmaxq_f32(src_high.val[1], min_val), max_val);
-      int32x4_t right_high_s32 =
-          vcvtq_s32_f32(vmulq_f32(right_high_clamp, scale));
-
-      int16x4_t right_low_s16 = vqmovn_s32(right_low_s32);
-      int16x4_t right_high_s16 = vqmovn_s32(right_high_s32);
-      int16x8_t right_s16 = vcombine_s16(right_low_s16, right_high_s16);
-      vst1q_s16(right_planar + i, right_s16);
-    }
-    return true;
-  }
-  return false;
-}
-
 bool DecodedAudio::SwitchSampleTypeTo_NEON(
     SbMediaAudioSampleType new_sample_type,
     DecodedAudio* destination_audio) const {
@@ -601,81 +348,6 @@ bool DecodedAudio::SwitchSampleTypeTo_NEON(
       vst1q_s16(new_samples + i + 8, vcombine_s16(s2_s16, s3_s16));
     }
     return true;
-  }
-  return false;
-}
-
-bool DecodedAudio::SwitchStorageTypeTo_NEON(
-    SbMediaAudioFrameStorageType new_storage_type,
-    DecodedAudio* destination_audio) const {
-  SB_DCHECK_EQ(channels(), 2);
-  SB_DCHECK_EQ(frames() % 8, 0);
-
-  const uint8_t* old_samples = data();
-  uint8_t* new_samples = destination_audio->data();
-
-  if (storage_type_ == kSbMediaAudioFrameStorageTypeInterleaved &&
-      new_storage_type == kSbMediaAudioFrameStorageTypePlanar) {
-    if (sample_type_ == kSbMediaAudioSampleTypeInt16Deprecated) {
-      const int16_t* interleaved_src =
-          reinterpret_cast<const int16_t*>(old_samples);
-      int16_t* left_planar = reinterpret_cast<int16_t*>(new_samples);
-      int16_t* right_planar = left_planar + frames();
-      int num_frames = frames();
-      for (int i = 0; i + 7 < num_frames; i += 8) {
-        int16x8x2_t src = vld2q_s16(interleaved_src + i * 2);
-        vst1q_s16(left_planar + i, src.val[0]);
-        vst1q_s16(right_planar + i, src.val[1]);
-      }
-      return true;
-    } else if (sample_type_ == kSbMediaAudioSampleTypeFloat32) {
-      const float* interleaved_src =
-          reinterpret_cast<const float*>(old_samples);
-      float* left_planar = reinterpret_cast<float*>(new_samples);
-      float* right_planar = left_planar + frames();
-      int num_frames = frames();
-      for (int i = 0; i + 7 < num_frames; i += 8) {
-        float32x4x2_t src0 = vld2q_f32(interleaved_src + i * 2);
-        float32x4x2_t src1 = vld2q_f32(interleaved_src + i * 2 + 8);
-        vst1q_f32(left_planar + i, src0.val[0]);
-        vst1q_f32(right_planar + i, src0.val[1]);
-        vst1q_f32(left_planar + i + 4, src1.val[0]);
-        vst1q_f32(right_planar + i + 4, src1.val[1]);
-      }
-      return true;
-    }
-  } else if (storage_type_ == kSbMediaAudioFrameStorageTypePlanar &&
-             new_storage_type == kSbMediaAudioFrameStorageTypeInterleaved) {
-    if (sample_type_ == kSbMediaAudioSampleTypeInt16Deprecated) {
-      const int16_t* left_planar =
-          reinterpret_cast<const int16_t*>(old_samples);
-      const int16_t* right_planar = left_planar + frames();
-      int16_t* interleaved_dst = reinterpret_cast<int16_t*>(new_samples);
-      int num_frames = frames();
-      for (int i = 0; i + 7 < num_frames; i += 8) {
-        int16x8x2_t src;
-        src.val[0] = vld1q_s16(left_planar + i);
-        src.val[1] = vld1q_s16(right_planar + i);
-        vst2q_s16(interleaved_dst + i * 2, src);
-      }
-      return true;
-    } else if (sample_type_ == kSbMediaAudioSampleTypeFloat32) {
-      const float* left_planar = reinterpret_cast<const float*>(old_samples);
-      const float* right_planar = left_planar + frames();
-      float* interleaved_dst = reinterpret_cast<float*>(new_samples);
-      int num_frames = frames();
-      for (int i = 0; i + 7 < num_frames; i += 8) {
-        float32x4x2_t src0;
-        src0.val[0] = vld1q_f32(left_planar + i);
-        src0.val[1] = vld1q_f32(right_planar + i);
-        float32x4x2_t src1;
-        src1.val[0] = vld1q_f32(left_planar + i + 4);
-        src1.val[1] = vld1q_f32(right_planar + i + 4);
-        vst2q_f32(interleaved_dst + i * 2, src0);
-        vst2q_f32(interleaved_dst + i * 2 + 8, src1);
-      }
-      return true;
-    }
   }
   return false;
 }

--- a/starboard/shared/starboard/player/decoded_audio_internal.h
+++ b/starboard/shared/starboard/player/decoded_audio_internal.h
@@ -29,18 +29,15 @@ namespace starboard {
 class DecodedAudio {
  public:
   static DecodedAudio CreateEOSBuffer();
-  // TODO(b/272837615): Remove `storage_type` support and always store data in
-  // interleaved. Refactor the places that store sample in planar to convert the
-  // samples to interleaved on creation.
+
+  DecodedAudio();  // Signal an EOS.
   DecodedAudio(int channels,
                SbMediaAudioSampleType sample_type,
-               SbMediaAudioFrameStorageType storage_type,
                int64_t timestamp,
                int size_in_bytes);
 
   DecodedAudio(int channels,
                SbMediaAudioSampleType sample_type,
-               SbMediaAudioFrameStorageType storage_type,
                int64_t timestamp,
                int size_in_bytes,
                Buffer&& storage);
@@ -57,7 +54,6 @@ class DecodedAudio {
 
   int channels() const { return channels_; }
   SbMediaAudioSampleType sample_type() const { return sample_type_; }
-  SbMediaAudioFrameStorageType storage_type() const { return storage_type_; }
 
   bool is_end_of_stream() const { return channels_ == 0; }
   int64_t timestamp() const { return timestamp_; }
@@ -89,45 +85,32 @@ class DecodedAudio {
                                    int64_t discarded_duration_from_front,
                                    int64_t discarded_duration_from_back);
 
-  bool IsFormat(SbMediaAudioSampleType sample_type,
-                SbMediaAudioFrameStorageType storage_type) const;
-  // During format switching, this method can perform the layout/sample type
-  // conversions on-the-fly.
+  bool IsFormat(SbMediaAudioSampleType sample_type) const;
+  // During format switching, this method can perform sample type conversions
+  // on-the-fly.
   // Note: The `force_simd` parameter allows explicitly forcing or disabling
   // the SIMD path, which is primarily intended for unit testing different
   // execution paths. When left as `nullopt` (default), it automatically
   // resolves to the global experimental setting.
   DecodedAudio SwitchFormatTo(SbMediaAudioSampleType new_sample_type,
-                              SbMediaAudioFrameStorageType new_storage_type,
                               std::optional<bool> force_simd =
                                   std::nullopt) const SB_WARN_UNUSED_RESULT;
 
   DecodedAudio CloneForTesting() const;
 
  private:
-  DecodedAudio();
-
   DecodedAudio SwitchSampleTypeTo(SbMediaAudioSampleType new_sample_type,
                                   bool enable_simd) const;
-  DecodedAudio SwitchStorageTypeTo(
-      SbMediaAudioFrameStorageType new_storage_type,
-      bool enable_simd) const;
 
   // These NEON helper methods are always declared to avoid leaking platform-
   // specific preprocessor macros (like USE_NEON_FOR_AUDIO) to this header
   // file. They are only defined and called in the implementation (.cc) file
   // when NEON is enabled on the target platform.
-  bool SwitchFormatTo_NEON(SbMediaAudioSampleType new_sample_type,
-                           SbMediaAudioFrameStorageType new_storage_type,
-                           DecodedAudio* destination_audio) const;
   bool SwitchSampleTypeTo_NEON(SbMediaAudioSampleType new_sample_type,
                                DecodedAudio* destination_audio) const;
-  bool SwitchStorageTypeTo_NEON(SbMediaAudioFrameStorageType new_storage_type,
-                                DecodedAudio* destination_audio) const;
 
   int channels_;
   SbMediaAudioSampleType sample_type_;
-  SbMediaAudioFrameStorageType storage_type_;
   // The timestamp of the first audio frame in microseconds.
   int64_t timestamp_;
   Buffer storage_;

--- a/starboard/shared/starboard/player/decoded_audio_test_internal.cc
+++ b/starboard/shared/starboard/player/decoded_audio_test_internal.cc
@@ -32,9 +32,6 @@ constexpr double kPi = 3.1415926535897932384626;
 
 constexpr SbMediaAudioSampleType kSampleTypes[] = {
     kSbMediaAudioSampleTypeInt16Deprecated, kSbMediaAudioSampleTypeFloat32};
-constexpr SbMediaAudioFrameStorageType kStorageTypes[] = {
-    kSbMediaAudioFrameStorageTypeInterleaved,
-    kSbMediaAudioFrameStorageTypePlanar};
 
 // The following two functions fill `data` with audio samples of a sine wave
 // starting from `initial_angle`.  `stride` is the number of samples per group.
@@ -123,22 +120,14 @@ void Fill(DecodedAudio* decoded_audio) {
 
   bool is_int16 =
       decoded_audio->sample_type() == kSbMediaAudioSampleTypeInt16Deprecated;
-  bool is_interleaved =
-      decoded_audio->storage_type() == kSbMediaAudioFrameStorageTypeInterleaved;
 
   for (int i = 0; i < decoded_audio->channels(); ++i) {
-    if (is_int16 && is_interleaved) {
+    if (is_int16) {
       Fill(decoded_audio->data_as_int16() + i, kPi / 2 * i, kPi / 180,
            decoded_audio->frames(), decoded_audio->channels());
-    } else if (!is_int16 && is_interleaved) {
+    } else {
       Fill(decoded_audio->data_as_float32() + i, kPi / 2 * i, kPi / 180,
            decoded_audio->frames(), decoded_audio->channels());
-    } else if (is_int16 && !is_interleaved) {
-      Fill(decoded_audio->data_as_int16() + decoded_audio->frames() * i,
-           kPi / 2 * i, kPi / 180, decoded_audio->frames(), 1);
-    } else if (!is_int16 && !is_interleaved) {
-      Fill(decoded_audio->data_as_float32() + decoded_audio->frames() * i,
-           kPi / 2 * i, kPi / 180, decoded_audio->frames(), 1);
     }
   }
 }
@@ -148,26 +137,16 @@ void Fill(DecodedAudio* decoded_audio) {
 void Verify(const DecodedAudio& decoded_audio) {
   bool is_int16 =
       decoded_audio.sample_type() == kSbMediaAudioSampleTypeInt16Deprecated;
-  bool is_interleaved =
-      decoded_audio.storage_type() == kSbMediaAudioFrameStorageTypeInterleaved;
 
   for (int i = 0; i < decoded_audio.channels(); ++i) {
-    if (is_int16 && is_interleaved) {
+    if (is_int16) {
       ASSERT_NO_FATAL_FAILURE(
           Verify(decoded_audio.data_as_int16() + i, kPi / 2 * i, kPi / 180,
                  decoded_audio.frames(), decoded_audio.channels()));
-    } else if (!is_int16 && is_interleaved) {
+    } else {
       ASSERT_NO_FATAL_FAILURE(
           Verify(decoded_audio.data_as_float32() + i, kPi / 2 * i, kPi / 180,
                  decoded_audio.frames(), decoded_audio.channels()));
-    } else if (is_int16 && !is_interleaved) {
-      ASSERT_NO_FATAL_FAILURE(
-          Verify(decoded_audio.data_as_int16() + decoded_audio.frames() * i,
-                 kPi / 2 * i, kPi / 180, decoded_audio.frames(), 1));
-    } else if (!is_int16 && !is_interleaved) {
-      ASSERT_NO_FATAL_FAILURE(
-          Verify(decoded_audio.data_as_float32() + decoded_audio.frames() * i,
-                 kPi / 2 * i, kPi / 180, decoded_audio.frames(), 1));
     }
   }
 }
@@ -179,22 +158,19 @@ TEST(DecodedAudioTest, CreateEOSBuffer) {
 
 TEST(DecodedAudioTest, CtorWithSize) {
   for (auto sample_type : kSampleTypes) {
-    for (auto storage_type : kStorageTypes) {
-      DecodedAudio decoded_audio(kChannels, sample_type, storage_type,
-                                 kTimestampUsec, kSizeInBytes);
+    DecodedAudio decoded_audio(kChannels, sample_type, kTimestampUsec,
+                               kSizeInBytes);
 
-      EXPECT_FALSE(decoded_audio.is_end_of_stream());
-      EXPECT_EQ(decoded_audio.channels(), kChannels);
-      EXPECT_EQ(decoded_audio.sample_type(), sample_type);
-      EXPECT_EQ(decoded_audio.storage_type(), storage_type);
-      EXPECT_EQ(decoded_audio.size_in_bytes(), kSizeInBytes);
-      EXPECT_EQ(decoded_audio.frames(),
-                kSizeInBytes / GetBytesPerSample(decoded_audio.sample_type()) /
-                    kChannels);
+    EXPECT_FALSE(decoded_audio.is_end_of_stream());
+    EXPECT_EQ(decoded_audio.channels(), kChannels);
+    EXPECT_EQ(decoded_audio.sample_type(), sample_type);
+    EXPECT_EQ(decoded_audio.size_in_bytes(), kSizeInBytes);
+    EXPECT_EQ(decoded_audio.frames(),
+              kSizeInBytes / GetBytesPerSample(decoded_audio.sample_type()) /
+                  kChannels);
 
-      Fill(&decoded_audio);
-      Verify(decoded_audio);
-    }
+    Fill(&decoded_audio);
+    Verify(decoded_audio);
   }
 }
 
@@ -204,8 +180,8 @@ TEST(DecodedAudioTest, CtorWithMoveCtor) {
 
   const uint8_t* original_data_pointer = original.data();
 
-  DecodedAudio decoded_audio(kChannels, kSampleTypes[0], kStorageTypes[0],
-                             kTimestampUsec, 128, std::move(original));
+  DecodedAudio decoded_audio(kChannels, kSampleTypes[0], kTimestampUsec, 128,
+                             std::move(original));
   ASSERT_EQ(decoded_audio.size_in_bytes(), 128);
   ASSERT_NE(decoded_audio.data(), nullptr);
   ASSERT_EQ(decoded_audio.data(), original_data_pointer);
@@ -218,9 +194,8 @@ TEST(DecodedAudioTest, CtorWithMoveCtor) {
 TEST(DecodedAudioTest, AdjustForSeekTime) {
   for (int channels = 1; channels <= 6; ++channels) {
     for (auto sample_type : kSampleTypes) {
-      DecodedAudio original_decoded_audio(
-          kChannels, sample_type, kSbMediaAudioFrameStorageTypeInterleaved,
-          kTimestampUsec, kSizeInBytes);
+      DecodedAudio original_decoded_audio(kChannels, sample_type,
+                                          kTimestampUsec, kSizeInBytes);
       Fill(&original_decoded_audio);
 
       DecodedAudio adjusted_decoded_audio =
@@ -273,9 +248,8 @@ TEST(DecodedAudioTest, AdjustForSeekTime) {
 TEST(DecodedAudioTest, AdjustForDiscardedDurations) {
   for (int channels = 1; channels <= 6; ++channels) {
     for (auto sample_type : kSampleTypes) {
-      DecodedAudio original_decoded_audio(
-          kChannels, sample_type, kSbMediaAudioFrameStorageTypeInterleaved,
-          kTimestampUsec, kSizeInBytes);
+      DecodedAudio original_decoded_audio(kChannels, sample_type,
+                                          kTimestampUsec, kSizeInBytes);
       Fill(&original_decoded_audio);
 
       DecodedAudio adjusted_decoded_audio =
@@ -315,34 +289,25 @@ TEST(DecodedAudioTest, AdjustForDiscardedDurations) {
 
 TEST(DecodedAudioTest, SwitchFormatTo) {
   for (auto original_sample_type : kSampleTypes) {
-    for (auto original_storage_type : kStorageTypes) {
-      DecodedAudio original_decoded_audio(kChannels, original_sample_type,
-                                          original_storage_type, kTimestampUsec,
-                                          kSizeInBytes);
+    DecodedAudio original_decoded_audio(kChannels, original_sample_type,
+                                        kTimestampUsec, kSizeInBytes);
 
-      Fill(&original_decoded_audio);
+    Fill(&original_decoded_audio);
 
-      for (auto new_sample_type : kSampleTypes) {
-        for (auto new_storage_type : kStorageTypes) {
-          if (!original_decoded_audio.IsFormat(new_sample_type,
-                                               new_storage_type)) {
-            DecodedAudio new_decoded_audio =
-                original_decoded_audio.SwitchFormatTo(new_sample_type,
-                                                      new_storage_type);
+    for (auto new_sample_type : kSampleTypes) {
+      if (!original_decoded_audio.IsFormat(new_sample_type)) {
+        DecodedAudio new_decoded_audio =
+            original_decoded_audio.SwitchFormatTo(new_sample_type);
 
-            EXPECT_FALSE(new_decoded_audio.is_end_of_stream());
-            EXPECT_EQ(new_decoded_audio.channels(),
-                      original_decoded_audio.channels());
-            EXPECT_EQ(new_decoded_audio.timestamp(),
-                      original_decoded_audio.timestamp());
-            EXPECT_EQ(new_decoded_audio.frames(),
-                      original_decoded_audio.frames());
-            EXPECT_TRUE(
-                new_decoded_audio.IsFormat(new_sample_type, new_storage_type));
+        EXPECT_FALSE(new_decoded_audio.is_end_of_stream());
+        EXPECT_EQ(new_decoded_audio.channels(),
+                  original_decoded_audio.channels());
+        EXPECT_EQ(new_decoded_audio.timestamp(),
+                  original_decoded_audio.timestamp());
+        EXPECT_EQ(new_decoded_audio.frames(), original_decoded_audio.frames());
+        EXPECT_TRUE(new_decoded_audio.IsFormat(new_sample_type));
 
-            ASSERT_NO_FATAL_FAILURE(Verify(new_decoded_audio));
-          }
-        }
+        ASSERT_NO_FATAL_FAILURE(Verify(new_decoded_audio));
       }
     }
   }
@@ -350,9 +315,8 @@ TEST(DecodedAudioTest, SwitchFormatTo) {
 
 TEST(DecodedAudioTest, Clone) {
   for (auto sample_type : kSampleTypes) {
-    DecodedAudio decoded_audio(kChannels, sample_type,
-                               kSbMediaAudioFrameStorageTypeInterleaved,
-                               kTimestampUsec, kSizeInBytes);
+    DecodedAudio decoded_audio(kChannels, sample_type, kTimestampUsec,
+                               kSizeInBytes);
     Fill(&decoded_audio);
     auto copy = decoded_audio.CloneForTesting();
     ASSERT_EQ(copy, decoded_audio);
@@ -364,11 +328,10 @@ TEST(DecodedAudioTest, Clone) {
 
 class DecodedAudioNeonTest : public ::testing::Test {
  protected:
-  DecodedAudio CreateInt16PlanarRamp(int total_samples) {
+  DecodedAudio CreateInt16Ramp(int total_samples) {
     int size_in_bytes = total_samples * sizeof(int16_t);
     DecodedAudio base(kChannels, kSbMediaAudioSampleTypeInt16Deprecated,
-                      kSbMediaAudioFrameStorageTypePlanar, kTimestampUsec,
-                      size_in_bytes);
+                      kTimestampUsec, size_in_bytes);
     int16_t* data = base.data_as_int16();
     for (int i = 0; i < total_samples; ++i) {
       data[i] = static_cast<int16_t>(i - 32768);
@@ -376,10 +339,9 @@ class DecodedAudioNeonTest : public ::testing::Test {
     return base;
   }
 
-  DecodedAudio CreateFloat32InterleavedRamp(int total_samples) {
+  DecodedAudio CreateFloat32Ramp(int total_samples) {
     int size_in_bytes = total_samples * sizeof(float);
-    DecodedAudio base(kChannels, kSbMediaAudioSampleTypeFloat32,
-                      kSbMediaAudioFrameStorageTypeInterleaved, kTimestampUsec,
+    DecodedAudio base(kChannels, kSbMediaAudioSampleTypeFloat32, kTimestampUsec,
                       size_in_bytes);
     float* data = base.data_as_float32();
     for (int i = 0; i < total_samples; ++i) {
@@ -408,105 +370,34 @@ class DecodedAudioNeonTest : public ::testing::Test {
   }
 
   void VerifySwitchFormat(const DecodedAudio& base_audio,
-                          SbMediaAudioSampleType target_sample_type,
-                          SbMediaAudioFrameStorageType target_storage_type) {
-    DecodedAudio ref = base_audio.SwitchFormatTo(
-        target_sample_type, target_storage_type, /*force_simd=*/false);
-    DecodedAudio simd = base_audio.SwitchFormatTo(
-        target_sample_type, target_storage_type, /*force_simd=*/true);
+                          SbMediaAudioSampleType target_sample_type) {
+    DecodedAudio ref = base_audio.SwitchFormatTo(target_sample_type,
+                                                 /*force_simd=*/false);
+    DecodedAudio simd = base_audio.SwitchFormatTo(target_sample_type,
+                                                  /*force_simd=*/true);
     VerifyContent(ref, simd);
   }
 };
 
 TEST_F(DecodedAudioNeonTest, SwitchFormatTo_NeonSimdExhaustive) {
-  // 1. Test conversions starting from Int16 Planar (65536 samples)
-  auto int16_planar_base = CreateInt16PlanarRamp(65536);
+  // Test Int16 -> Float32
+  auto int16_base = CreateInt16Ramp(65536);
+  VerifySwitchFormat(int16_base, kSbMediaAudioSampleTypeFloat32);
 
-  // Test Case 1: Int16 Planar -> Float32 Interleaved
-  VerifySwitchFormat(int16_planar_base, kSbMediaAudioSampleTypeFloat32,
-                     kSbMediaAudioFrameStorageTypeInterleaved);
-
-  // Test Case 2: Int16 Planar -> Float32 Planar
-  VerifySwitchFormat(int16_planar_base, kSbMediaAudioSampleTypeFloat32,
-                     kSbMediaAudioFrameStorageTypePlanar);
-
-  // 2. Test conversions starting from Float32 Interleaved (8000 samples)
-  auto float_interleaved_base = CreateFloat32InterleavedRamp(8000);
-
-  // Test Case 3: Float32 Interleaved -> Int16 Planar
-  VerifySwitchFormat(float_interleaved_base,
-                     kSbMediaAudioSampleTypeInt16Deprecated,
-                     kSbMediaAudioFrameStorageTypePlanar);
-
-  // Test Case 4: Float32 Interleaved -> Int16 Interleaved
-  VerifySwitchFormat(float_interleaved_base,
-                     kSbMediaAudioSampleTypeInt16Deprecated,
-                     kSbMediaAudioFrameStorageTypeInterleaved);
-
-  // Test Case 5: Int16 Planar -> Int16 Interleaved
-  VerifySwitchFormat(int16_planar_base, kSbMediaAudioSampleTypeInt16Deprecated,
-                     kSbMediaAudioFrameStorageTypeInterleaved);
-
-  // Test Case 6: Int16 Interleaved -> Int16 Planar
-  auto int16_interleaved = int16_planar_base.SwitchFormatTo(
-      kSbMediaAudioSampleTypeInt16Deprecated,
-      kSbMediaAudioFrameStorageTypeInterleaved, /*force_simd=*/false);
-  VerifySwitchFormat(int16_interleaved, kSbMediaAudioSampleTypeInt16Deprecated,
-                     kSbMediaAudioFrameStorageTypePlanar);
-
-  // Test Case 7: Float32 Interleaved -> Float32 Planar
-  VerifySwitchFormat(float_interleaved_base, kSbMediaAudioSampleTypeFloat32,
-                     kSbMediaAudioFrameStorageTypePlanar);
-
-  // Test Case 8: Float32 Planar -> Float32 Interleaved
-  auto float_planar = float_interleaved_base.SwitchFormatTo(
-      kSbMediaAudioSampleTypeFloat32, kSbMediaAudioFrameStorageTypePlanar,
-      /*force_simd=*/false);
-  VerifySwitchFormat(float_planar, kSbMediaAudioSampleTypeFloat32,
-                     kSbMediaAudioFrameStorageTypeInterleaved);
+  // Test Float32 -> Int16
+  auto float_base = CreateFloat32Ramp(8000);
+  VerifySwitchFormat(float_base, kSbMediaAudioSampleTypeInt16Deprecated);
 }
 
 TEST_F(DecodedAudioNeonTest, SwitchFormatTo_NeonSimdUnaligned) {
   // Test with unaligned sizes (non-multiples of 8/16) to verify C++ scalar
   // fallbacks. 65536 + 14 is non-multiple of 16 (for Int16 -> Float32)
-  auto int16_planar_base = CreateInt16PlanarRamp(65536 + 14);
+  auto int16_base = CreateInt16Ramp(65536 + 14);
+  VerifySwitchFormat(int16_base, kSbMediaAudioSampleTypeFloat32);
 
-  // Int16 Planar -> Float32 Interleaved
-  VerifySwitchFormat(int16_planar_base, kSbMediaAudioSampleTypeFloat32,
-                     kSbMediaAudioFrameStorageTypeInterleaved);
-
-  // Float32 Interleaved -> Int16 Planar
-  auto float_interleaved_base = CreateFloat32InterleavedRamp(8000 + 14);
-  VerifySwitchFormat(float_interleaved_base,
-                     kSbMediaAudioSampleTypeInt16Deprecated,
-                     kSbMediaAudioFrameStorageTypePlanar);
-
-  // Float32 Interleaved -> Int16 Interleaved
-  VerifySwitchFormat(float_interleaved_base,
-                     kSbMediaAudioSampleTypeInt16Deprecated,
-                     kSbMediaAudioFrameStorageTypeInterleaved);
-
-  // Int16 Planar -> Int16 Interleaved
-  VerifySwitchFormat(int16_planar_base, kSbMediaAudioSampleTypeInt16Deprecated,
-                     kSbMediaAudioFrameStorageTypeInterleaved);
-
-  // Int16 Interleaved -> Int16 Planar
-  auto int16_interleaved = int16_planar_base.SwitchFormatTo(
-      kSbMediaAudioSampleTypeInt16Deprecated,
-      kSbMediaAudioFrameStorageTypeInterleaved, /*force_simd=*/false);
-  VerifySwitchFormat(int16_interleaved, kSbMediaAudioSampleTypeInt16Deprecated,
-                     kSbMediaAudioFrameStorageTypePlanar);
-
-  // Float32 Interleaved -> Float32 Planar
-  VerifySwitchFormat(float_interleaved_base, kSbMediaAudioSampleTypeFloat32,
-                     kSbMediaAudioFrameStorageTypePlanar);
-
-  // Float32 Planar -> Float32 Interleaved
-  auto float_planar = float_interleaved_base.SwitchFormatTo(
-      kSbMediaAudioSampleTypeFloat32, kSbMediaAudioFrameStorageTypePlanar,
-      /*force_simd=*/false);
-  VerifySwitchFormat(float_planar, kSbMediaAudioSampleTypeFloat32,
-                     kSbMediaAudioFrameStorageTypeInterleaved);
+  // Float32 -> Int16 with unaligned size
+  auto float_base = CreateFloat32Ramp(8000 + 14);
+  VerifySwitchFormat(float_base, kSbMediaAudioSampleTypeInt16Deprecated);
 }
 
 }  // namespace

--- a/starboard/shared/starboard/player/filter/adaptive_audio_decoder_internal.cc
+++ b/starboard/shared/starboard/player/filter/adaptive_audio_decoder_internal.cc
@@ -162,8 +162,6 @@ std::optional<DecodedAudio> AdaptiveAudioDecoder::Read(
   SB_DCHECK(ret->is_end_of_stream() ||
             ret->sample_type() == output_sample_type_);
   SB_DCHECK(ret->is_end_of_stream() ||
-            ret->storage_type() == output_storage_type_);
-  SB_DCHECK(ret->is_end_of_stream() ||
             ret->channels() == output_number_of_channels_);
 
   SB_DCHECK(first_output_received_ || ret->is_end_of_stream());
@@ -237,10 +235,9 @@ void AdaptiveAudioDecoder::OnDecoderOutput() {
   if (!first_output_received_) {
     first_output_received_ = true;
     output_sample_type_ = decoded_audio->sample_type();
-    output_storage_type_ = decoded_audio->storage_type();
     output_samples_per_second_ = decoded_sample_rate;
     if (output_adjustment_callback_) {
-      output_adjustment_callback_(&output_sample_type_, &output_storage_type_,
+      output_adjustment_callback_(&output_sample_type_,
                                   &output_samples_per_second_,
                                   &output_number_of_channels_);
     }
@@ -280,19 +277,16 @@ void AdaptiveAudioDecoder::OnDecoderOutput() {
     SB_DCHECK(!channel_mixer_);
     output_format_checked_ = true;
     if (output_sample_type_ != decoded_audio->sample_type() ||
-        output_storage_type_ != decoded_audio->storage_type() ||
         output_samples_per_second_ != decoded_sample_rate) {
       resampler_ = AudioResampler::Create(
-          decoded_audio->sample_type(), decoded_audio->storage_type(),
-          decoded_sample_rate, output_sample_type_, output_storage_type_,
-          output_samples_per_second_,
+          decoded_audio->sample_type(), decoded_sample_rate,
+          output_sample_type_, output_samples_per_second_,
           input_audio_stream_info_.number_of_channels);
     }
     if (input_audio_stream_info_.number_of_channels !=
         output_number_of_channels_) {
       channel_mixer_ = AudioChannelLayoutMixer::Create(
-          output_sample_type_, output_storage_type_,
-          output_number_of_channels_);
+          output_sample_type_, output_number_of_channels_);
     }
   }
   if (resampler_) {

--- a/starboard/shared/starboard/player/filter/adaptive_audio_decoder_internal.h
+++ b/starboard/shared/starboard/player/filter/adaptive_audio_decoder_internal.h
@@ -37,7 +37,6 @@ class AdaptiveAudioDecoder : public AudioDecoder, private JobQueue::JobOwner {
       AudioDecoderCreator;
 
   typedef std::function<void(SbMediaAudioSampleType* output_sample_type,
-                             SbMediaAudioFrameStorageType* output_storage_type,
                              int* output_samples_per_second,
                              int* output_number_of_channels)>
       OutputFormatAdjustmentCallback;
@@ -75,7 +74,6 @@ class AdaptiveAudioDecoder : public AudioDecoder, private JobQueue::JobOwner {
   const AudioDecoderCreator audio_decoder_creator_;
   const OutputFormatAdjustmentCallback output_adjustment_callback_;
   SbMediaAudioSampleType output_sample_type_;
-  SbMediaAudioFrameStorageType output_storage_type_;
   int output_samples_per_second_;
   int output_number_of_channels_;
   AudioStreamInfo input_audio_stream_info_;

--- a/starboard/shared/starboard/player/filter/audio_channel_layout_mixer.h
+++ b/starboard/shared/starboard/player/filter/audio_channel_layout_mixer.h
@@ -32,7 +32,6 @@ class AudioChannelLayoutMixer {
 
   static std::unique_ptr<AudioChannelLayoutMixer> Create(
       SbMediaAudioSampleType sample_type,
-      SbMediaAudioFrameStorageType storage_type,
       int output_channels);
 };
 

--- a/starboard/shared/starboard/player/filter/audio_channel_layout_mixer_impl.cc
+++ b/starboard/shared/starboard/player/filter/audio_channel_layout_mixer_impl.cc
@@ -157,49 +157,6 @@ const float kFivePointOneToQuadMatrix[] = {
     1.0f,
 };
 
-// Get the samples of frames at |frame_index|.  If |input| is already
-// interleaved, the return pointer points to the buffer contained inside
-// |input|. If |input| is planar, it will copy all samples into |aux_buffer| and
-// return |aux_buffer| instead.  Note that |aux_buffer| should be large enough
-// to hold samples from all channels of the frame.
-template <typename SampleType>
-const SampleType* GetInterleavedSamplesOfFrame(const DecodedAudio& input,
-                                               int frame_index,
-                                               SampleType* aux_buffer) {
-  const SampleType* input_buffer =
-      reinterpret_cast<const SampleType*>(input.data());
-  if (input.storage_type() == kSbMediaAudioFrameStorageTypeInterleaved) {
-    return input_buffer + frame_index * input.channels();
-  }
-  SB_DCHECK_EQ(input.storage_type(), kSbMediaAudioFrameStorageTypePlanar);
-  for (int channel_index = 0; channel_index < input.channels();
-       channel_index++) {
-    aux_buffer[channel_index] =
-        input_buffer[channel_index * input.frames() + frame_index];
-  }
-  return aux_buffer;
-}
-
-template <typename SampleType>
-void StoreInterleavedSamplesOfFrame(const SampleType* samples,
-                                    DecodedAudio* destination,
-                                    int frame_index) {
-  SampleType* dest_buffer = reinterpret_cast<SampleType*>(destination->data());
-  for (int channel_index = 0; channel_index < destination->channels();
-       channel_index++) {
-    if (destination->storage_type() ==
-        kSbMediaAudioFrameStorageTypeInterleaved) {
-      dest_buffer[frame_index * destination->channels() + channel_index] =
-          samples[channel_index];
-    } else {
-      SB_DCHECK_EQ(destination->storage_type(),
-                   kSbMediaAudioFrameStorageTypePlanar);
-      dest_buffer[channel_index * destination->frames() + frame_index] =
-          samples[channel_index];
-    }
-  }
-}
-
 template <typename SampleType>
 SampleType ClipSample(float sample);
 
@@ -243,7 +200,6 @@ void MixFrameWithMatrix(const SampleType* input_frame,
 class AudioChannelLayoutMixerImpl : public AudioChannelLayoutMixer {
  public:
   AudioChannelLayoutMixerImpl(SbMediaAudioSampleType sample_type,
-                              SbMediaAudioFrameStorageType storage_type,
                               int output_channels);
 
   DecodedAudio Mix(DecodedAudio input) override;
@@ -255,21 +211,16 @@ class AudioChannelLayoutMixerImpl : public AudioChannelLayoutMixer {
   DecodedAudio MixMonoToStereoOptimized(const DecodedAudio& input);
 
   SbMediaAudioSampleType sample_type_;
-  SbMediaAudioFrameStorageType storage_type_;
   int output_channels_;
 };
 
 AudioChannelLayoutMixerImpl::AudioChannelLayoutMixerImpl(
     SbMediaAudioSampleType sample_type,
-    SbMediaAudioFrameStorageType storage_type,
     int output_channels)
-    : sample_type_(sample_type),
-      storage_type_(storage_type),
-      output_channels_(output_channels) {}
+    : sample_type_(sample_type), output_channels_(output_channels) {}
 
 DecodedAudio AudioChannelLayoutMixerImpl::Mix(DecodedAudio input) {
   SB_DCHECK_EQ(input.sample_type(), sample_type_);
-  SB_DCHECK_EQ(input.storage_type(), storage_type_);
 
   if (input.channels() == output_channels_) {
     return input;
@@ -334,16 +285,17 @@ DecodedAudio AudioChannelLayoutMixerImpl::Mix(const DecodedAudio& input,
                                               const float* matrix) {
   size_t frames = input.frames();
   DecodedAudio output(
-      output_channels_, sample_type_, storage_type_, input.timestamp(),
+      output_channels_, sample_type_, input.timestamp(),
       frames * output_channels_ * GetBytesPerSample(sample_type_));
-  SampleType aux_buffer[8];
-  SampleType output_buffer[8];
+  const SampleType* input_buffer =
+      reinterpret_cast<const SampleType*>(input.data());
+  SampleType* output_buffer = reinterpret_cast<SampleType*>(output.data());
   for (size_t frame_index = 0; frame_index < frames; frame_index++) {
-    const SampleType* interleavedSamplesOfFrame =
-        GetInterleavedSamplesOfFrame(input, frame_index, aux_buffer);
-    MixFrameWithMatrix(interleavedSamplesOfFrame, input.channels(), matrix,
-                       output_buffer, output_channels_);
-    StoreInterleavedSamplesOfFrame(output_buffer, &output, frame_index);
+    const SampleType* input_frame =
+        input_buffer + frame_index * input.channels();
+    SampleType* output_frame = output_buffer + frame_index * output_channels_;
+    MixFrameWithMatrix(input_frame, input.channels(), matrix, output_frame,
+                       output_channels_);
   }
   return output;
 }
@@ -353,26 +305,19 @@ DecodedAudio AudioChannelLayoutMixerImpl::MixMonoToStereoOptimized(
   SB_DCHECK_EQ(output_channels_, 2);
   SB_DCHECK_EQ(input.channels(), 1);
 
-  DecodedAudio output(output_channels_, sample_type_, storage_type_,
-                      input.timestamp(), input.size_in_bytes() * 2);
-  if (storage_type_ == kSbMediaAudioFrameStorageTypeInterleaved) {
-    size_t frames_left = input.frames();
-    size_t bytes_per_sample = GetBytesPerSample(sample_type_);
-    const uint8_t* src_buffer_ptr = input.data();
-    uint8_t* dest_buffer_ptr = output.data();
-    while (frames_left > 0) {
-      memcpy(dest_buffer_ptr, src_buffer_ptr, bytes_per_sample);
-      dest_buffer_ptr += bytes_per_sample;
-      memcpy(dest_buffer_ptr, src_buffer_ptr, bytes_per_sample);
-      dest_buffer_ptr += bytes_per_sample;
-      src_buffer_ptr += bytes_per_sample;
-      frames_left--;
-    }
-  } else {
-    SB_DCHECK_EQ(storage_type_, kSbMediaAudioFrameStorageTypePlanar);
-    memcpy(output.data(), input.data(), input.size_in_bytes());
-    memcpy(output.data() + input.size_in_bytes(), input.data(),
-           input.size_in_bytes());
+  DecodedAudio output(output_channels_, sample_type_, input.timestamp(),
+                      input.size_in_bytes() * 2);
+  size_t frames_left = input.frames();
+  size_t bytes_per_sample = GetBytesPerSample(sample_type_);
+  const uint8_t* src_buffer_ptr = input.data();
+  uint8_t* dest_buffer_ptr = output.data();
+  while (frames_left > 0) {
+    memcpy(dest_buffer_ptr, src_buffer_ptr, bytes_per_sample);
+    dest_buffer_ptr += bytes_per_sample;
+    memcpy(dest_buffer_ptr, src_buffer_ptr, bytes_per_sample);
+    dest_buffer_ptr += bytes_per_sample;
+    src_buffer_ptr += bytes_per_sample;
+    frames_left--;
   }
   return output;
 }
@@ -382,11 +327,9 @@ DecodedAudio AudioChannelLayoutMixerImpl::MixMonoToStereoOptimized(
 // static
 std::unique_ptr<AudioChannelLayoutMixer> AudioChannelLayoutMixer::Create(
     SbMediaAudioSampleType sample_type,
-    SbMediaAudioFrameStorageType storage_type,
     int output_channels) {
   return std::unique_ptr<AudioChannelLayoutMixer>(
-      new AudioChannelLayoutMixerImpl(sample_type, storage_type,
-                                      output_channels));
+      new AudioChannelLayoutMixerImpl(sample_type, output_channels));
 }
 
 }  // namespace starboard

--- a/starboard/shared/starboard/player/filter/audio_renderer_pcm_internal.cc
+++ b/starboard/shared/starboard/player/filter/audio_renderer_pcm_internal.cc
@@ -568,7 +568,6 @@ void AudioRendererPcm::UpdateVariablesOnSinkThread_Locked(
 
 void AudioRendererPcm::OnFirstOutput(
     const SbMediaAudioSampleType decoded_sample_type,
-    const SbMediaAudioFrameStorageType decoded_storage_type,
     const int decoded_sample_rate) {
   SB_CHECK(BelongsToCurrentThread());
   SB_DCHECK(!decoder_sample_rate_);
@@ -582,17 +581,14 @@ void AudioRendererPcm::OnFirstOutput(
   buffered_frames_to_start_ = std::min(
       destination_sample_rate / 5, max_cached_frames_ - min_frames_per_append_);
 
-  // |time_stretcher_| only supports kSbMediaAudioSampleTypeFloat32 and
-  // kSbMediaAudioFrameStorageTypeInterleaved, so we resample the audio to that
-  // format to avoid unnecessary extra conversion.
+  // |time_stretcher_| only supports kSbMediaAudioSampleTypeFloat32,
+  // so we resample the audio to that format to avoid unnecessary extra
+  // conversion.
   if (decoded_sample_rate != destination_sample_rate ||
-      decoded_sample_type != kSbMediaAudioSampleTypeFloat32 ||
-      decoded_storage_type != kSbMediaAudioFrameStorageTypeInterleaved) {
+      decoded_sample_type != kSbMediaAudioSampleTypeFloat32) {
     resampler_ = AudioResampler::Create(
-        decoded_sample_type, decoded_storage_type, decoded_sample_rate,
-        kSbMediaAudioSampleTypeFloat32,
-        kSbMediaAudioFrameStorageTypeInterleaved, destination_sample_rate,
-        channels_);
+        decoded_sample_type, decoded_sample_rate,
+        kSbMediaAudioSampleTypeFloat32, destination_sample_rate, channels_);
     SB_DCHECK(resampler_);
   } else {
     resampler_.reset(new IdentityAudioResampler);
@@ -670,8 +666,7 @@ void AudioRendererPcm::ProcessAudioData() {
         decoded_audio->AdjustForSeekTime(decoded_audio_sample_rate,
                                          seeking_to_time_);
       }
-      OnFirstOutput(decoded_audio->sample_type(), decoded_audio->storage_type(),
-                    decoded_audio_sample_rate);
+      OnFirstOutput(decoded_audio->sample_type(), decoded_audio_sample_rate);
     }
     SB_DCHECK(resampler_);
 
@@ -702,14 +697,10 @@ void AudioRendererPcm::ProcessAudioData() {
     }
 
     if (resampled_audio && resampled_audio->size_in_bytes() > 0) {
-      // |time_stretcher_| only support kSbMediaAudioSampleTypeFloat32 and
-      // kSbMediaAudioFrameStorageTypeInterleaved.
-      if (!resampled_audio->IsFormat(
-              kSbMediaAudioSampleTypeFloat32,
-              kSbMediaAudioFrameStorageTypeInterleaved)) {
-        resampled_audio = resampled_audio->SwitchFormatTo(
-            kSbMediaAudioSampleTypeFloat32,
-            kSbMediaAudioFrameStorageTypeInterleaved);
+      // |time_stretcher_| only supports kSbMediaAudioSampleTypeFloat32.
+      if (!resampled_audio->IsFormat(kSbMediaAudioSampleTypeFloat32)) {
+        resampled_audio =
+            resampled_audio->SwitchFormatTo(kSbMediaAudioSampleTypeFloat32);
       }
       time_stretcher_.EnqueueBuffer(std::move(*resampled_audio));
     }
@@ -784,12 +775,8 @@ bool AudioRendererPcm::AppendAudioToFrameBuffer(bool* is_frame_buffer_full) {
                                    adjusted_playback_rate);
   }
 
-  // |time_stretcher_| only support kSbMediaAudioSampleTypeFloat32 and
-  // kSbMediaAudioFrameStorageTypeInterleaved.
-  if (!decoded_audio.IsFormat(sink_sample_type_,
-                              kSbMediaAudioFrameStorageTypeInterleaved)) {
-    decoded_audio = decoded_audio.SwitchFormatTo(
-        sink_sample_type_, kSbMediaAudioFrameStorageTypeInterleaved);
+  if (!decoded_audio.IsFormat(sink_sample_type_)) {
+    decoded_audio = decoded_audio.SwitchFormatTo(sink_sample_type_);
   }
   const uint8_t* source_buffer = decoded_audio.data();
   int frames_to_append = decoded_audio.frames();

--- a/starboard/shared/starboard/player/filter/audio_renderer_pcm_internal.h
+++ b/starboard/shared/starboard/player/filter/audio_renderer_pcm_internal.h
@@ -149,7 +149,6 @@ class AudioRendererPcm : public AudioRenderer,
       int64_t system_time_on_consume_frames);
 
   void OnFirstOutput(const SbMediaAudioSampleType decoded_sample_type,
-                     const SbMediaAudioFrameStorageType decoded_storage_type,
                      const int decoded_sample_rate);
   bool IsEndOfStreamPlayed_Locked() const;
 

--- a/starboard/shared/starboard/player/filter/audio_resampler.h
+++ b/starboard/shared/starboard/player/filter/audio_resampler.h
@@ -53,10 +53,8 @@ class AudioResampler {
   // AudioResampler can call Read() to read the next chunk of resampled data.
   static std::unique_ptr<AudioResampler> Create(
       SbMediaAudioSampleType source_sample_type,
-      SbMediaAudioFrameStorageType source_storage_type,
       int source_sample_rate,
       SbMediaAudioSampleType destination_sample_type,
-      SbMediaAudioFrameStorageType destination_storage_type,
       int destination_sample_rate,
       int channels);
 };

--- a/starboard/shared/starboard/player/filter/audio_resampler_impl.cc
+++ b/starboard/shared/starboard/player/filter/audio_resampler_impl.cc
@@ -33,14 +33,11 @@ namespace {
 class AudioResamplerImpl : public AudioResampler {
  public:
   AudioResamplerImpl(SbMediaAudioSampleType source_sample_type,
-                     SbMediaAudioFrameStorageType source_storage_type,
                      int source_sample_rate,
                      SbMediaAudioSampleType destination_sample_type,
-                     SbMediaAudioFrameStorageType destination_storage_type,
                      int destination_sample_rate,
                      int channels)
       : destination_sample_type_(destination_sample_type),
-        destination_storage_type_(destination_storage_type),
         interleaved_resampler_(static_cast<double>(source_sample_rate) /
                                    static_cast<double>(destination_sample_rate),
                                channels) {}
@@ -51,7 +48,6 @@ class AudioResamplerImpl : public AudioResampler {
 
  private:
   const SbMediaAudioSampleType destination_sample_type_;
-  const SbMediaAudioFrameStorageType destination_storage_type_;
 
   InterleavedSincResampler interleaved_resampler_;
 
@@ -67,15 +63,12 @@ class AudioResamplerImpl : public AudioResampler {
 // static
 std::unique_ptr<AudioResampler> AudioResampler::Create(
     SbMediaAudioSampleType source_sample_type,
-    SbMediaAudioFrameStorageType source_storage_type,
     int source_sample_rate,
     SbMediaAudioSampleType destination_sample_type,
-    SbMediaAudioFrameStorageType destination_storage_type,
     int destination_sample_rate,
     int channels) {
   return std::unique_ptr<AudioResampler>(new AudioResamplerImpl(
-      source_sample_type, source_storage_type, source_sample_rate,
-      destination_sample_type, destination_storage_type,
+      source_sample_type, source_sample_rate, destination_sample_type,
       destination_sample_rate, channels));
 }
 
@@ -92,17 +85,15 @@ std::optional<DecodedAudio> AudioResamplerImpl::WriteEndOfStream() {
       int channels = interleaved_resampler_.channels();
       int resampled_audio_size = out_num_of_frames * channels * sizeof(float);
       DecodedAudio resampled_audio(channels, kSbMediaAudioSampleTypeFloat32,
-                                   kSbMediaAudioFrameStorageTypeInterleaved,
                                    audio_inputs_.front().timestamp(),
                                    resampled_audio_size);
 
       float* dst = reinterpret_cast<float*>(resampled_audio.data());
       interleaved_resampler_.Resample(dst, out_num_of_frames);
 
-      if (!resampled_audio.IsFormat(destination_sample_type_,
-                                    destination_storage_type_)) {
-        resampled_audio = resampled_audio.SwitchFormatTo(
-            destination_sample_type_, destination_storage_type_);
+      if (!resampled_audio.IsFormat(destination_sample_type_)) {
+        resampled_audio =
+            resampled_audio.SwitchFormatTo(destination_sample_type_);
       }
       return resampled_audio;
     }
@@ -115,13 +106,9 @@ std::optional<DecodedAudio> AudioResamplerImpl::Resample(
     DecodedAudio audio_input) {
   SB_DCHECK_EQ(audio_input.channels(), interleaved_resampler_.channels());
 
-  // It does nothing if source sample type is float and source storage type is
-  // interleaved.
-  if (!audio_input.IsFormat(kSbMediaAudioSampleTypeFloat32,
-                            kSbMediaAudioFrameStorageTypeInterleaved)) {
-    audio_input =
-        audio_input.SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
-                                   kSbMediaAudioFrameStorageTypeInterleaved);
+  // It does nothing if source sample type is float.
+  if (!audio_input.IsFormat(kSbMediaAudioSampleTypeFloat32)) {
+    audio_input = audio_input.SwitchFormatTo(kSbMediaAudioSampleTypeFloat32);
   }
 
   int num_of_input_frames = audio_input.frames();
@@ -144,16 +131,14 @@ std::optional<DecodedAudio> AudioResamplerImpl::Resample(
   if (interleaved_resampler_.HasEnoughData(num_of_output_frames)) {
     int output_audio_size = num_of_output_frames * channels * sizeof(float);
     DecodedAudio output(channels, kSbMediaAudioSampleTypeFloat32,
-                        kSbMediaAudioFrameStorageTypeInterleaved,
                         next_audio_to_output.timestamp(), output_audio_size);
     float* dst = reinterpret_cast<float*>(output.data());
     interleaved_resampler_.Resample(dst, num_of_output_frames);
     frames_resampled_ += next_audio_to_output.frames();
     frames_outputted_ += num_of_output_frames;
 
-    if (!output.IsFormat(destination_sample_type_, destination_storage_type_)) {
-      output = output.SwitchFormatTo(destination_sample_type_,
-                                     destination_storage_type_);
+    if (!output.IsFormat(destination_sample_type_)) {
+      output = output.SwitchFormatTo(destination_sample_type_);
     }
     resampled_audio = std::move(output);
 

--- a/starboard/shared/starboard/player/filter/audio_time_stretcher.cc
+++ b/starboard/shared/starboard/player/filter/audio_time_stretcher.cc
@@ -148,21 +148,19 @@ void AudioTimeStretcher::Initialize(SbMediaAudioSampleType sample_type,
   transition_window_.reset(new float[ola_window_size_ * 2]);
   GetPeriodicHanningWindow(2 * ola_window_size_, transition_window_.get());
 
-  wsola_output_ = DecodedAudio(
-      channels_, sample_type_, kSbMediaAudioFrameStorageTypeInterleaved, 0,
-      (ola_window_size_ + ola_hop_size_) * bytes_per_frame_);
+  wsola_output_ =
+      DecodedAudio(channels_, sample_type_, 0,
+                   (ola_window_size_ + ola_hop_size_) * bytes_per_frame_);
   // Initialize for overlap-and-add of the first block.
   memset(wsola_output_.data(), 0, wsola_output_.size_in_bytes());
 
   // Auxiliary containers.
-  optimal_block_ = DecodedAudio(channels_, sample_type_,
-                                kSbMediaAudioFrameStorageTypeInterleaved, 0,
+  optimal_block_ = DecodedAudio(channels_, sample_type_, 0,
                                 ola_window_size_ * bytes_per_frame_);
   search_block_ = DecodedAudio(
-      channels_, sample_type_, kSbMediaAudioFrameStorageTypeInterleaved, 0,
+      channels_, sample_type_, 0,
       (num_candidate_blocks_ + (ola_window_size_ - 1)) * bytes_per_frame_);
-  target_block_ = DecodedAudio(channels_, sample_type_,
-                               kSbMediaAudioFrameStorageTypeInterleaved, 0,
+  target_block_ = DecodedAudio(channels_, sample_type_, 0,
                                ola_window_size_ * bytes_per_frame_);
 }
 
@@ -171,8 +169,7 @@ DecodedAudio AudioTimeStretcher::Read(int requested_frames,
   SB_DCHECK_GT(bytes_per_frame_, 0);
   SB_DCHECK_GE(playback_rate, 0);
 
-  DecodedAudio dest(channels_, sample_type_,
-                    kSbMediaAudioFrameStorageTypeInterleaved, 0,
+  DecodedAudio dest(channels_, sample_type_, 0,
                     requested_frames * bytes_per_frame_);
 
   if (playback_rate == 0) {
@@ -277,9 +274,8 @@ void AudioTimeStretcher::GetOptimalBlock() {
 
     // |optimal_index| is in frames and it is relative to the beginning of the
     // |search_block_|.
-    optimal_index = OptimalIndex(&search_block_, &target_block_,
-                                 kSbMediaAudioFrameStorageTypeInterleaved,
-                                 exclude_interval);
+    optimal_index =
+        OptimalIndex(&search_block_, &target_block_, exclude_interval);
 
     // Translate |index| w.r.t. the beginning of |audio_buffer_| and extract the
     // optimal block.

--- a/starboard/shared/starboard/player/filter/decoded_audio_queue.cc
+++ b/starboard/shared/starboard/player/filter/decoded_audio_queue.cc
@@ -39,8 +39,6 @@ void DecodedAudioQueue::Clear() {
 }
 
 void DecodedAudioQueue::Append(DecodedAudio&& decoded_audio) {
-  SB_DCHECK_EQ(decoded_audio.storage_type(),
-               kSbMediaAudioFrameStorageTypeInterleaved);
   // Update the |frames_| counter since we have added frames.
   frames_ += decoded_audio.frames();
   SB_CHECK_GT(frames_, 0);  // make sure it doesn't overflow.

--- a/starboard/shared/starboard/player/filter/mock_audio_decoder.h
+++ b/starboard/shared/starboard/player/filter/mock_audio_decoder.h
@@ -29,9 +29,8 @@ namespace starboard {
 
 class MockAudioDecoder : public AudioDecoder {
  public:
-  MockAudioDecoder(SbMediaAudioSampleType sample_type,
-                   SbMediaAudioFrameStorageType storage_type,
-                   int samples_per_second) {}
+  MockAudioDecoder(SbMediaAudioSampleType sample_type, int samples_per_second) {
+  }
 
   MOCK_METHOD2(Initialize, void(const OutputCB&, const ErrorCB&));
   MOCK_METHOD2(Decode, void(const InputBuffers&, const ConsumedCB&));

--- a/starboard/shared/starboard/player/filter/stub_audio_decoder.cc
+++ b/starboard/shared/starboard/player/filter/stub_audio_decoder.cc
@@ -56,9 +56,8 @@ DecodedAudio CreateDecodedAudio(int64_t timestamp,
                                 int number_of_channels,
                                 int frames) {
   int sample_size = GetBytesPerSample(sample_type);
-  DecodedAudio decoded_audio(
-      number_of_channels, sample_type, kSbMediaAudioFrameStorageTypeInterleaved,
-      timestamp, sample_size * number_of_channels * frames);
+  DecodedAudio decoded_audio(number_of_channels, sample_type, timestamp,
+                             sample_size * number_of_channels * frames);
 
   for (int j = 0; j < decoded_audio.size_in_bytes() / sample_size; ++j) {
     if (sample_size == 2) {
@@ -216,10 +215,8 @@ void StubAudioDecoder::DecodeOneBuffer(
             decoded_audio.timestamp() +
             AudioDurationToFrames(offset_in_frames, samples_per_second_);
 
-        DecodedAudio current_decoded_audio(
-            number_of_channels_, sample_type_,
-            kSbMediaAudioFrameStorageTypeInterleaved, timestamp,
-            size_in_bytes_of_output);
+        DecodedAudio current_decoded_audio(number_of_channels_, sample_type_,
+                                           timestamp, size_in_bytes_of_output);
         memcpy(current_decoded_audio.data(),
                decoded_audio.data() + offset_in_bytes, size_in_bytes_of_output);
         offset_in_bytes += size_in_bytes_of_output;

--- a/starboard/shared/starboard/player/filter/testing/audio_channel_layout_mixer_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_channel_layout_mixer_test.cc
@@ -32,16 +32,11 @@ using ::testing::Combine;
 using ::testing::Values;
 
 class AudioChannelLayoutMixerTest
-    : public ::testing::TestWithParam<
-          std::tuple<SbMediaAudioSampleType, SbMediaAudioFrameStorageType>> {
+    : public ::testing::TestWithParam<SbMediaAudioSampleType> {
  protected:
-  AudioChannelLayoutMixerTest()
-      : sample_type_(std::get<0>(GetParam())),
-        storage_type_(std::get<1>(GetParam())) {
+  AudioChannelLayoutMixerTest() : sample_type_(GetParam()) {
     SB_DCHECK(sample_type_ == kSbMediaAudioSampleTypeInt16Deprecated ||
               sample_type_ == kSbMediaAudioSampleTypeFloat32);
-    SB_DCHECK(storage_type_ == kSbMediaAudioFrameStorageTypeInterleaved ||
-              storage_type_ == kSbMediaAudioFrameStorageTypePlanar);
   }
 
   DecodedAudio GetTestDecodedAudio(int num_of_channels) {
@@ -81,28 +76,19 @@ class AudioChannelLayoutMixerTest
     }
 
     DecodedAudio decoded_audio(
-        num_of_channels, sample_type_, storage_type_, 0,
+        num_of_channels, sample_type_, 0,
         kInputFrames * num_of_channels *
             (sample_type_ == kSbMediaAudioSampleTypeFloat32 ? 4 : 2));
 
     if (sample_type_ == kSbMediaAudioSampleTypeFloat32) {
       float* dest_buffer = reinterpret_cast<float*>(decoded_audio.data());
       for (size_t i = 0; i < num_of_channels * kInputFrames; i++) {
-        int src_index = i;
-        if (storage_type_ == kSbMediaAudioFrameStorageTypePlanar) {
-          src_index = i % kInputFrames * num_of_channels + i / kInputFrames;
-        }
-        dest_buffer[i] = data_buffer[src_index];
+        dest_buffer[i] = data_buffer[i];
       }
     } else {
       int16_t* dest_buffer = reinterpret_cast<int16_t*>(decoded_audio.data());
       for (size_t i = 0; i < num_of_channels * kInputFrames; i++) {
-        int src_index = i;
-        if (storage_type_ == kSbMediaAudioFrameStorageTypePlanar) {
-          src_index = i % kInputFrames * num_of_channels + i / kInputFrames;
-        }
-        dest_buffer[i] =
-            data_buffer[src_index] * std::numeric_limits<int16_t>::max();
+        dest_buffer[i] = data_buffer[i] * std::numeric_limits<int16_t>::max();
       }
     }
     return decoded_audio;
@@ -114,7 +100,6 @@ class AudioChannelLayoutMixerTest
                                     const float* expected_output) {
     ASSERT_EQ(output_num_of_channels, output.channels());
     ASSERT_EQ(input.sample_type(), output.sample_type());
-    ASSERT_EQ(input.storage_type(), output.storage_type());
     ASSERT_EQ(input.timestamp(), output.timestamp());
     ASSERT_EQ(input.size_in_bytes() * output.channels(),
               output.size_in_bytes() * input.channels());
@@ -125,18 +110,12 @@ class AudioChannelLayoutMixerTest
       for (size_t i = 0;
            i < static_cast<size_t>(output.frames()) * output_num_of_channels;
            i++) {
-        size_t src_index = i;
-        if (storage_type_ == kSbMediaAudioFrameStorageTypePlanar) {
-          src_index = i % output.frames() * output_num_of_channels +
-                      i / output.frames();
-        }
-        if (expected_output[src_index] >= 1.0f) {
+        if (expected_output[i] >= 1.0f) {
           ASSERT_GE(output_buffer[i], 0.999f);
-        } else if (expected_output[src_index] <= -0.999f) {
+        } else if (expected_output[i] <= -0.999f) {
           ASSERT_LE(output_buffer[i], -1.0f);
         } else {
-          ASSERT_LE(fabs(expected_output[src_index] - output_buffer[i]),
-                    0.001f);
+          ASSERT_LE(fabs(expected_output[i] - output_buffer[i]), 0.001f);
         }
       }
     } else {
@@ -145,13 +124,8 @@ class AudioChannelLayoutMixerTest
       for (size_t i = 0;
            i < static_cast<size_t>(output.frames()) * output_num_of_channels;
            i++) {
-        size_t src_index = i;
-        if (storage_type_ == kSbMediaAudioFrameStorageTypePlanar) {
-          src_index = i % output.frames() * output_num_of_channels +
-                      i / output.frames();
-        }
         ASSERT_LE(
-            fabs(expected_output[src_index] -
+            fabs(expected_output[i] -
                  static_cast<float>(output_buffer[i]) /
                      static_cast<float>(std::numeric_limits<int16_t>::max())),
             0.001f);
@@ -160,28 +134,21 @@ class AudioChannelLayoutMixerTest
   }
 
   SbMediaAudioSampleType sample_type_;
-  SbMediaAudioFrameStorageType storage_type_;
 };
 
 std::string GetAudioChannelLayoutMixerTestConfigName(
-    ::testing::TestParamInfo<std::tuple<SbMediaAudioSampleType,
-                                        SbMediaAudioFrameStorageType>> info) {
-  SbMediaAudioSampleType sample_type = std::get<0>(info.param);
-  SbMediaAudioFrameStorageType frame_storage_type = std::get<1>(info.param);
+    ::testing::TestParamInfo<SbMediaAudioSampleType> info) {
+  SbMediaAudioSampleType sample_type = info.param;
 
-  return FormatString(
-      "%s_%s",
-      sample_type == kSbMediaAudioSampleTypeInt16Deprecated
-          ? "SampleTypeInt16"
-          : "SampleTypeFloat32",
-      frame_storage_type == kSbMediaAudioFrameStorageTypeInterleaved
-          ? "StorageTypeInterleaved"
-          : "StorageTypePlanar");
+  return FormatString("%s",
+                      sample_type == kSbMediaAudioSampleTypeInt16Deprecated
+                          ? "SampleTypeInt16"
+                          : "SampleTypeFloat32");
 }
 
 TEST_P(AudioChannelLayoutMixerTest, MixToMono) {
   std::unique_ptr<AudioChannelLayoutMixer> mixer =
-      AudioChannelLayoutMixer::Create(sample_type_, storage_type_, 1);
+      AudioChannelLayoutMixer::Create(sample_type_, 1);
   ASSERT_TRUE(mixer);
 
   const float kExpectedMonoToMonoOutput[] = {
@@ -220,7 +187,7 @@ TEST_P(AudioChannelLayoutMixerTest, MixToMono) {
 
 TEST_P(AudioChannelLayoutMixerTest, MixToStereo) {
   std::unique_ptr<AudioChannelLayoutMixer> mixer =
-      AudioChannelLayoutMixer::Create(sample_type_, storage_type_, 2);
+      AudioChannelLayoutMixer::Create(sample_type_, 2);
   ASSERT_TRUE(mixer);
 
   const float kExpectedMonoToStereoOutput[] = {
@@ -259,7 +226,7 @@ TEST_P(AudioChannelLayoutMixerTest, MixToStereo) {
 
 TEST_P(AudioChannelLayoutMixerTest, MixToQuad) {
   std::unique_ptr<AudioChannelLayoutMixer> mixer =
-      AudioChannelLayoutMixer::Create(sample_type_, storage_type_, 4);
+      AudioChannelLayoutMixer::Create(sample_type_, 4);
   ASSERT_TRUE(mixer);
 
   const float kExpectedMonoToQuadOutput[] = {
@@ -303,7 +270,7 @@ TEST_P(AudioChannelLayoutMixerTest, MixToQuad) {
 
 TEST_P(AudioChannelLayoutMixerTest, MixToFivePointOne) {
   std::unique_ptr<AudioChannelLayoutMixer> mixer =
-      AudioChannelLayoutMixer::Create(sample_type_, storage_type_, 6);
+      AudioChannelLayoutMixer::Create(sample_type_, 6);
   ASSERT_TRUE(mixer);
 
   const float kExpectedMonoToFivePointOneOutput[] = {
@@ -348,14 +315,11 @@ TEST_P(AudioChannelLayoutMixerTest, MixToFivePointOne) {
                                kExpectedFivePointOneToFivePointOneOutput);
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    AudioChannelLayoutMixerTests,
-    AudioChannelLayoutMixerTest,
-    Combine(Values(kSbMediaAudioSampleTypeInt16Deprecated,
-                   kSbMediaAudioSampleTypeFloat32),
-            Values(kSbMediaAudioFrameStorageTypeInterleaved,
-                   kSbMediaAudioFrameStorageTypePlanar)),
-    GetAudioChannelLayoutMixerTestConfigName);
+INSTANTIATE_TEST_SUITE_P(AudioChannelLayoutMixerTests,
+                         AudioChannelLayoutMixerTest,
+                         Values(kSbMediaAudioSampleTypeInt16Deprecated,
+                                kSbMediaAudioSampleTypeFloat32),
+                         GetAudioChannelLayoutMixerTestConfigName);
 
 }  // namespace
 

--- a/starboard/shared/starboard/player/filter/testing/audio_decoder_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_decoder_test.cc
@@ -55,8 +55,7 @@ const int64_t kWaitForNextEventTimeOut = 5'000'000;  // 5 seconds
 DecodedAudio ConsolidateDecodedAudios(
     const std::vector<DecodedAudio>& decoded_audios) {
   if (decoded_audios.empty()) {
-    return DecodedAudio(2, kSbMediaAudioSampleTypeFloat32,
-                        kSbMediaAudioFrameStorageTypeInterleaved, 0, 0);
+    return DecodedAudio(2, kSbMediaAudioSampleTypeFloat32, 0, 0);
   }
 
   int total_size_in_bytes = 0;
@@ -66,14 +65,12 @@ DecodedAudio ConsolidateDecodedAudios(
   for (const auto& decoded_audio : decoded_audios) {
     SB_DCHECK_EQ(decoded_audio.channels(), channels);
     SB_DCHECK_EQ(decoded_audio.sample_type(), sample_type);
-    SB_DCHECK_EQ(decoded_audio.storage_type(),
-                 kSbMediaAudioFrameStorageTypeInterleaved);
     total_size_in_bytes += decoded_audio.size_in_bytes();
   }
 
-  DecodedAudio consolidated(
-      channels, sample_type, kSbMediaAudioFrameStorageTypeInterleaved,
-      decoded_audios.front().timestamp(), total_size_in_bytes);
+  DecodedAudio consolidated(channels, sample_type,
+                            decoded_audios.front().timestamp(),
+                            total_size_in_bytes);
 
   int offset_in_bytes = 0;
   for (const auto& decoded_audio : decoded_audios) {
@@ -826,8 +823,6 @@ TEST_P(AudioDecoderTest, PartialAudio) {
 
     ASSERT_EQ(reference_decoded_audio.sample_type(),
               partial_decoded_audio.sample_type());
-    ASSERT_EQ(reference_decoded_audio.storage_type(),
-              partial_decoded_audio.storage_type());
     ASSERT_GT(reference_decoded_audio.frames(), partial_decoded_audio.frames());
 
     auto bytes_per_frame = reference_decoded_audio.size_in_bytes() /

--- a/starboard/shared/starboard/player/filter/testing/audio_frame_discarder_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_frame_discarder_test.cc
@@ -40,8 +40,7 @@ class AudioFrameDiscarderTest : public ::testing::TestWithParam<const char*> {
 
 DecodedAudio MakeDecodedAudio(int channels, int64_t timestamp) {
   DecodedAudio decoded_audio(
-      channels, kSbMediaAudioSampleTypeFloat32,
-      kSbMediaAudioFrameStorageTypeInterleaved, timestamp,
+      channels, kSbMediaAudioSampleTypeFloat32, timestamp,
       GetBytesPerSample(kSbMediaAudioSampleTypeFloat32) * channels * 1536);
 
   memset(decoded_audio.data(), timestamp % 256, decoded_audio.size_in_bytes());

--- a/starboard/shared/starboard/player/filter/testing/audio_renderer_internal_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_renderer_internal_test.cc
@@ -52,21 +52,16 @@ class AudioRendererTest : public ::testing::Test {
   static const SbMediaAudioFrameStorageType kDefaultAudioFrameStorageType =
       kSbMediaAudioFrameStorageTypeInterleaved;
 
-  AudioRendererTest() {
-    ResetToFormat(kSbMediaAudioSampleTypeFloat32,
-                  kSbMediaAudioFrameStorageTypeInterleaved);
-  }
+  AudioRendererTest() { ResetToFormat(kSbMediaAudioSampleTypeFloat32); }
 
   // This function should be called in the fixture before any other functions
   // to set the desired format of the decoder.
-  void ResetToFormat(SbMediaAudioSampleType sample_type,
-                     SbMediaAudioFrameStorageType storage_type) {
+  void ResetToFormat(SbMediaAudioSampleType sample_type) {
     audio_renderer_.reset(NULL);
     sample_type_ = sample_type;
-    storage_type_ = storage_type;
     audio_renderer_sink_ = new ::testing::StrictMock<MockAudioRendererSink>;
-    audio_decoder_ = new MockAudioDecoder(sample_type_, storage_type_,
-                                          kDefaultSamplesPerSecond);
+    audio_decoder_ =
+        new MockAudioDecoder(sample_type_, kDefaultSamplesPerSecond);
 
     ON_CALL(*audio_decoder_, Read(_))
         .WillByDefault(DoAll(SetArgPointee<0>(kDefaultSamplesPerSecond),
@@ -215,7 +210,7 @@ class AudioRendererTest : public ::testing::Test {
 
   DecodedAudio CreateDecodedAudio(int64_t timestamp, int frames) {
     DecodedAudio decoded_audio(
-        kDefaultNumberOfChannels, sample_type_, storage_type_, timestamp,
+        kDefaultNumberOfChannels, sample_type_, timestamp,
         frames * kDefaultNumberOfChannels * GetBytesPerSample(sample_type_));
     memset(decoded_audio.data(), 0, decoded_audio.size_in_bytes());
     return decoded_audio;
@@ -229,7 +224,6 @@ class AudioRendererTest : public ::testing::Test {
   void OnEnded() {}
 
   SbMediaAudioSampleType sample_type_;
-  SbMediaAudioFrameStorageType storage_type_;
 
   JobQueue job_queue_;
   std::set<const void*> buffers_in_decoder_;
@@ -394,8 +388,7 @@ TEST_F(AudioRendererTest, SunnyDayWithDoublePlaybackRateAndInt16Samples) {
 
   // Resets |audio_renderer_sink_|, so all the gtest codes need to be below
   // this line.
-  ResetToFormat(kSbMediaAudioSampleTypeInt16Deprecated,
-                kSbMediaAudioFrameStorageTypeInterleaved);
+  ResetToFormat(kSbMediaAudioSampleTypeInt16Deprecated);
 
   {
     ::testing::InSequence seq;

--- a/starboard/shared/starboard/player/filter/testing/audio_resampler_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_resampler_test.cc
@@ -27,22 +27,13 @@ namespace {
 using ::testing::Combine;
 using ::testing::ValuesIn;
 
-typedef ::testing::tuple<SbMediaAudioSampleType,
-                         SbMediaAudioFrameStorageType,
-                         int,
-                         SbMediaAudioSampleType,
-                         SbMediaAudioFrameStorageType,
-                         int,
-                         int>
-    AudioResamplerTestParam;
+typedef ::testing::
+    tuple<SbMediaAudioSampleType, int, SbMediaAudioSampleType, int, int>
+        AudioResamplerTestParam;
 
 SbMediaAudioSampleType kSampleTypesToTest[] = {
     kSbMediaAudioSampleTypeInt16Deprecated,
     kSbMediaAudioSampleTypeFloat32,
-};
-SbMediaAudioFrameStorageType kStorageTypesToTest[] = {
-    kSbMediaAudioFrameStorageTypeInterleaved,
-    kSbMediaAudioFrameStorageTypePlanar,
 };
 int kSampleRatesToTest[] = {22050, 44100, 48000};
 int kChannelsToTest[] = {1, 2, 6};
@@ -57,29 +48,16 @@ const char* ConvertSampleTypeToString(SbMediaAudioSampleType sample_type) {
   return "";
 }
 
-const char* ConvertStorageTypeToString(
-    SbMediaAudioFrameStorageType storage_type) {
-  if (storage_type == kSbMediaAudioFrameStorageTypeInterleaved) {
-    return "interleaved";
-  } else if (storage_type == kSbMediaAudioFrameStorageTypePlanar) {
-    return "planar";
-  }
-  SB_NOTREACHED();
-  return "";
-}
-
 class AudioResamplerTest
     : public ::testing::TestWithParam<AudioResamplerTestParam> {
  protected:
   AudioResamplerTest() {
     const AudioResamplerTestParam& param = GetParam();
     source_sample_type_ = std::get<0>(param);
-    source_storage_type_ = std::get<1>(param);
-    source_sample_rate_ = std::get<2>(param);
-    destination_sample_type_ = std::get<3>(param);
-    destination_storage_type_ = std::get<4>(param);
-    destination_sample_rate_ = std::get<5>(param);
-    channels_ = std::get<6>(param);
+    source_sample_rate_ = std::get<1>(param);
+    destination_sample_type_ = std::get<2>(param);
+    destination_sample_rate_ = std::get<3>(param);
+    channels_ = std::get<4>(param);
 
     GenerateAudioInputs();
   }
@@ -95,7 +73,7 @@ class AudioResamplerTest
               ? sizeof(int16_t)
               : sizeof(float);
       int audio_size = kSamplesPerInput * channels_ * sample_size;
-      DecodedAudio input(channels_, source_sample_type_, source_storage_type_,
+      DecodedAudio input(channels_, source_sample_type_,
                          1'000'000LL * total_frames / source_sample_rate_,
                          audio_size);
       total_frames += kSamplesPerInput;
@@ -104,10 +82,8 @@ class AudioResamplerTest
   }
 
   SbMediaAudioSampleType source_sample_type_;
-  SbMediaAudioFrameStorageType source_storage_type_;
   int source_sample_rate_;
   SbMediaAudioSampleType destination_sample_type_;
-  SbMediaAudioFrameStorageType destination_storage_type_;
   int destination_sample_rate_;
   int channels_;
 
@@ -116,8 +92,7 @@ class AudioResamplerTest
 
 TEST_P(AudioResamplerTest, SunnyDay) {
   std::unique_ptr<AudioResampler> resampler = AudioResampler::Create(
-      source_sample_type_, source_storage_type_, source_sample_rate_,
-      destination_sample_type_, destination_storage_type_,
+      source_sample_type_, source_sample_rate_, destination_sample_type_,
       destination_sample_rate_, channels_);
 
   int total_input_frames = 0;
@@ -157,18 +132,14 @@ std::string GetTestConfigName(
     ::testing::TestParamInfo<AudioResamplerTestParam> info) {
   const AudioResamplerTestParam& param = info.param;
   SbMediaAudioSampleType source_sample_type = std::get<0>(param);
-  SbMediaAudioFrameStorageType source_storage_type = std::get<1>(param);
-  int source_sample_rate = std::get<2>(param);
-  SbMediaAudioSampleType destination_sample_type = std::get<3>(param);
-  SbMediaAudioFrameStorageType destination_storage_type = std::get<4>(param);
-  int destination_sample_rate = std::get<5>(param);
-  int channels = std::get<6>(param);
+  int source_sample_rate = std::get<1>(param);
+  SbMediaAudioSampleType destination_sample_type = std::get<2>(param);
+  int destination_sample_rate = std::get<3>(param);
+  int channels = std::get<4>(param);
   std::string name = FormatString(
-      "%s_%s_%d_to_%s_%s_%d_channels_%d",
-      ConvertSampleTypeToString(source_sample_type),
-      ConvertStorageTypeToString(source_storage_type), source_sample_rate,
+      "%s_%d_to_%s_%d_channels_%d",
+      ConvertSampleTypeToString(source_sample_type), source_sample_rate,
       ConvertSampleTypeToString(destination_sample_type),
-      ConvertStorageTypeToString(destination_storage_type),
       destination_sample_rate, channels);
   return name;
 }
@@ -176,10 +147,8 @@ std::string GetTestConfigName(
 INSTANTIATE_TEST_SUITE_P(AudioResamplerTests,
                          AudioResamplerTest,
                          Combine(ValuesIn(kSampleTypesToTest),
-                                 ValuesIn(kStorageTypesToTest),
                                  ValuesIn(kSampleRatesToTest),
                                  ValuesIn(kSampleTypesToTest),
-                                 ValuesIn(kStorageTypesToTest),
                                  ValuesIn(kSampleRatesToTest),
                                  ValuesIn(kChannelsToTest)),
                          GetTestConfigName);

--- a/starboard/shared/starboard/player/filter/testing/decoded_audio_benchmark.cc
+++ b/starboard/shared/starboard/player/filter/testing/decoded_audio_benchmark.cc
@@ -23,23 +23,9 @@ constexpr int64_t kTimestampUsec = 1'000'000;
 constexpr int kNumFrames = 2048;  // Realistic audio frame size
 constexpr int kSizeInBytes = kNumFrames * kChannels * sizeof(int16_t);
 
-DecodedAudio CreateInt16PlanarBuffer() {
-  DecodedAudio buffer(kChannels, kSbMediaAudioSampleTypeInt16Deprecated,
-                      kSbMediaAudioFrameStorageTypePlanar, kTimestampUsec,
-                      kSizeInBytes);
-  int16_t* data = buffer.data_as_int16();
-  for (int i = 0; i < kNumFrames * kChannels; ++i) {
-    // Generates a linear ramp covering the full range of int16_t [-32768,
-    // 32767].
-    data[i] = static_cast<int16_t>(i % 65536 - 32768);
-  }
-  return buffer;
-}
-
 DecodedAudio CreateFloatInterleavedBuffer() {
   int float_size = kNumFrames * kChannels * sizeof(float);
-  DecodedAudio buffer(kChannels, kSbMediaAudioSampleTypeFloat32,
-                      kSbMediaAudioFrameStorageTypeInterleaved, kTimestampUsec,
+  DecodedAudio buffer(kChannels, kSbMediaAudioSampleTypeFloat32, kTimestampUsec,
                       float_size);
   float* data = buffer.data_as_float32();
   for (int i = 0; i < kNumFrames * kChannels; ++i) {
@@ -52,8 +38,7 @@ DecodedAudio CreateFloatInterleavedBuffer() {
 
 DecodedAudio CreateInt16InterleavedBuffer() {
   DecodedAudio buffer(kChannels, kSbMediaAudioSampleTypeInt16Deprecated,
-                      kSbMediaAudioFrameStorageTypeInterleaved, kTimestampUsec,
-                      kSizeInBytes);
+                      kTimestampUsec, kSizeInBytes);
   int16_t* data = buffer.data_as_int16();
   for (int i = 0; i < kNumFrames * kChannels; ++i) {
     // Generates a linear ramp covering the full range of int16_t [-32768,
@@ -63,78 +48,10 @@ DecodedAudio CreateInt16InterleavedBuffer() {
   return buffer;
 }
 
-DecodedAudio CreateFloatPlanarBuffer() {
-  int float_size = kNumFrames * kChannels * sizeof(float);
-  DecodedAudio buffer(kChannels, kSbMediaAudioSampleTypeFloat32,
-                      kSbMediaAudioFrameStorageTypePlanar, kTimestampUsec,
-                      float_size);
-  float* data = buffer.data_as_float32();
-  for (int i = 0; i < kNumFrames * kChannels; ++i) {
-    // Generates a linear ramp of float values in [-1.0f, 1.0f] spanning the
-    // full audio range.
-    data[i] = -1.0f + 2.0f * (static_cast<float>(i) / (kNumFrames * kChannels));
-  }
-  return buffer;
-}
-
-void BM_SwitchFormat_Int16PlanarToFloatInterleaved_Cpp(
-    benchmark::State& state) {
-  auto src = CreateInt16PlanarBuffer();
-  for (auto _ : state) {
-    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
-                                  kSbMediaAudioFrameStorageTypeInterleaved,
-                                  /*force_simd=*/false);
-    benchmark::DoNotOptimize(dst);
-  }
-  state.SetItemsProcessed(state.iterations() * kNumFrames);
-}
-BENCHMARK(BM_SwitchFormat_Int16PlanarToFloatInterleaved_Cpp);
-
-void BM_SwitchFormat_Int16PlanarToFloatInterleaved_Neon(
-    benchmark::State& state) {
-  auto src = CreateInt16PlanarBuffer();
-  for (auto _ : state) {
-    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
-                                  kSbMediaAudioFrameStorageTypeInterleaved,
-                                  /*force_simd=*/true);
-    benchmark::DoNotOptimize(dst);
-  }
-  state.SetItemsProcessed(state.iterations() * kNumFrames);
-}
-BENCHMARK(BM_SwitchFormat_Int16PlanarToFloatInterleaved_Neon);
-
-void BM_SwitchFormat_FloatInterleavedToInt16Planar_Cpp(
-    benchmark::State& state) {
-  auto src = CreateFloatInterleavedBuffer();
-  for (auto _ : state) {
-    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeInt16Deprecated,
-                                  kSbMediaAudioFrameStorageTypePlanar,
-                                  /*force_simd=*/false);
-    benchmark::DoNotOptimize(dst);
-  }
-  state.SetItemsProcessed(state.iterations() * kNumFrames);
-}
-BENCHMARK(BM_SwitchFormat_FloatInterleavedToInt16Planar_Cpp);
-
-void BM_SwitchFormat_FloatInterleavedToInt16Planar_Neon(
-    benchmark::State& state) {
-  auto src = CreateFloatInterleavedBuffer();
-  for (auto _ : state) {
-    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeInt16Deprecated,
-                                  kSbMediaAudioFrameStorageTypePlanar,
-                                  /*force_simd=*/true);
-    benchmark::DoNotOptimize(dst);
-  }
-  state.SetItemsProcessed(state.iterations() * kNumFrames);
-}
-BENCHMARK(BM_SwitchFormat_FloatInterleavedToInt16Planar_Neon);
-
 void BM_SwitchSampleType_Int16ToFloat_Cpp(benchmark::State& state) {
-  auto src = CreateInt16PlanarBuffer();  // SwitchSampleTypeTo keeps same
-                                         // storage (planar)
+  auto src = CreateInt16InterleavedBuffer();
   for (auto _ : state) {
     auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
-                                  kSbMediaAudioFrameStorageTypePlanar,
                                   /*force_simd=*/false);
     benchmark::DoNotOptimize(dst);
   }
@@ -143,10 +60,9 @@ void BM_SwitchSampleType_Int16ToFloat_Cpp(benchmark::State& state) {
 BENCHMARK(BM_SwitchSampleType_Int16ToFloat_Cpp);
 
 void BM_SwitchSampleType_Int16ToFloat_Neon(benchmark::State& state) {
-  auto src = CreateInt16PlanarBuffer();
+  auto src = CreateInt16InterleavedBuffer();
   for (auto _ : state) {
     auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
-                                  kSbMediaAudioFrameStorageTypePlanar,
                                   /*force_simd=*/true);
     benchmark::DoNotOptimize(dst);
   }
@@ -155,10 +71,9 @@ void BM_SwitchSampleType_Int16ToFloat_Neon(benchmark::State& state) {
 BENCHMARK(BM_SwitchSampleType_Int16ToFloat_Neon);
 
 void BM_SwitchSampleType_FloatToInt16_Cpp(benchmark::State& state) {
-  auto src = CreateFloatInterleavedBuffer();  // keeps interleaved
+  auto src = CreateFloatInterleavedBuffer();
   for (auto _ : state) {
     auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeInt16Deprecated,
-                                  kSbMediaAudioFrameStorageTypeInterleaved,
                                   /*force_simd=*/false);
     benchmark::DoNotOptimize(dst);
   }
@@ -170,117 +85,12 @@ void BM_SwitchSampleType_FloatToInt16_Neon(benchmark::State& state) {
   auto src = CreateFloatInterleavedBuffer();
   for (auto _ : state) {
     auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeInt16Deprecated,
-                                  kSbMediaAudioFrameStorageTypeInterleaved,
                                   /*force_simd=*/true);
     benchmark::DoNotOptimize(dst);
   }
   state.SetItemsProcessed(state.iterations() * kNumFrames);
 }
 BENCHMARK(BM_SwitchSampleType_FloatToInt16_Neon);
-
-void BM_SwitchStorageType_Int16InterleavedToPlanar_Cpp(
-    benchmark::State& state) {
-  auto src = CreateInt16InterleavedBuffer();
-  for (auto _ : state) {
-    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeInt16Deprecated,
-                                  kSbMediaAudioFrameStorageTypePlanar,
-                                  /*force_simd=*/false);
-    benchmark::DoNotOptimize(dst);
-  }
-  state.SetItemsProcessed(state.iterations() * kNumFrames);
-}
-BENCHMARK(BM_SwitchStorageType_Int16InterleavedToPlanar_Cpp);
-
-void BM_SwitchStorageType_Int16InterleavedToPlanar_Neon(
-    benchmark::State& state) {
-  auto src = CreateInt16InterleavedBuffer();
-  for (auto _ : state) {
-    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeInt16Deprecated,
-                                  kSbMediaAudioFrameStorageTypePlanar,
-                                  /*force_simd=*/true);
-    benchmark::DoNotOptimize(dst);
-  }
-  state.SetItemsProcessed(state.iterations() * kNumFrames);
-}
-BENCHMARK(BM_SwitchStorageType_Int16InterleavedToPlanar_Neon);
-
-void BM_SwitchStorageType_Int16PlanarToInterleaved_Cpp(
-    benchmark::State& state) {
-  auto src = CreateInt16PlanarBuffer();
-  for (auto _ : state) {
-    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeInt16Deprecated,
-                                  kSbMediaAudioFrameStorageTypeInterleaved,
-                                  /*force_simd=*/false);
-    benchmark::DoNotOptimize(dst);
-  }
-  state.SetItemsProcessed(state.iterations() * kNumFrames);
-}
-BENCHMARK(BM_SwitchStorageType_Int16PlanarToInterleaved_Cpp);
-
-void BM_SwitchStorageType_Int16PlanarToInterleaved_Neon(
-    benchmark::State& state) {
-  auto src = CreateInt16PlanarBuffer();
-  for (auto _ : state) {
-    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeInt16Deprecated,
-                                  kSbMediaAudioFrameStorageTypeInterleaved,
-                                  /*force_simd=*/true);
-    benchmark::DoNotOptimize(dst);
-  }
-  state.SetItemsProcessed(state.iterations() * kNumFrames);
-}
-BENCHMARK(BM_SwitchStorageType_Int16PlanarToInterleaved_Neon);
-
-void BM_SwitchStorageType_FloatInterleavedToPlanar_Cpp(
-    benchmark::State& state) {
-  auto src = CreateFloatInterleavedBuffer();
-  for (auto _ : state) {
-    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
-                                  kSbMediaAudioFrameStorageTypePlanar,
-                                  /*force_simd=*/false);
-    benchmark::DoNotOptimize(dst);
-  }
-  state.SetItemsProcessed(state.iterations() * kNumFrames);
-}
-BENCHMARK(BM_SwitchStorageType_FloatInterleavedToPlanar_Cpp);
-
-void BM_SwitchStorageType_FloatInterleavedToPlanar_Neon(
-    benchmark::State& state) {
-  auto src = CreateFloatInterleavedBuffer();
-  for (auto _ : state) {
-    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
-                                  kSbMediaAudioFrameStorageTypePlanar,
-                                  /*force_simd=*/true);
-    benchmark::DoNotOptimize(dst);
-  }
-  state.SetItemsProcessed(state.iterations() * kNumFrames);
-}
-BENCHMARK(BM_SwitchStorageType_FloatInterleavedToPlanar_Neon);
-
-void BM_SwitchStorageType_FloatPlanarToInterleaved_Cpp(
-    benchmark::State& state) {
-  auto src = CreateFloatPlanarBuffer();
-  for (auto _ : state) {
-    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
-                                  kSbMediaAudioFrameStorageTypeInterleaved,
-                                  /*force_simd=*/false);
-    benchmark::DoNotOptimize(dst);
-  }
-  state.SetItemsProcessed(state.iterations() * kNumFrames);
-}
-BENCHMARK(BM_SwitchStorageType_FloatPlanarToInterleaved_Cpp);
-
-void BM_SwitchStorageType_FloatPlanarToInterleaved_Neon(
-    benchmark::State& state) {
-  auto src = CreateFloatPlanarBuffer();
-  for (auto _ : state) {
-    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
-                                  kSbMediaAudioFrameStorageTypeInterleaved,
-                                  /*force_simd=*/true);
-    benchmark::DoNotOptimize(dst);
-  }
-  state.SetItemsProcessed(state.iterations() * kNumFrames);
-}
-BENCHMARK(BM_SwitchStorageType_FloatPlanarToInterleaved_Neon);
 
 }  // namespace
 }  // namespace starboard

--- a/starboard/shared/starboard/player/filter/testing/wsola_internal_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/wsola_internal_test.cc
@@ -42,8 +42,7 @@ DecodedAudio CreateTestDecodedAudio(int frames,
   const int kBytesPerFrame = channels * sizeof(float);
   const int kBufferSize = frames * kBytesPerFrame;
 
-  DecodedAudio audio(channels, kSbMediaAudioSampleTypeFloat32,
-                     kSbMediaAudioFrameStorageTypeInterleaved, 0, kBufferSize);
+  DecodedAudio audio(channels, kSbMediaAudioSampleTypeFloat32, 0, kBufferSize);
 
   float* data = audio.data_as_float32();
   for (int i = 0; i < frames; ++i) {
@@ -74,8 +73,7 @@ TEST(WsolaInternalTest, OptimalIndex_ExactMatch) {
   Interval exclude_interval = {-1, -1};  // No exclusion
 
   int optimal_index =
-      OptimalIndex(&search_block, &target_block,
-                   kSbMediaAudioFrameStorageTypeInterleaved, exclude_interval);
+      OptimalIndex(&search_block, &target_block, exclude_interval);
   // Due to floating point precision and quadratic interpolation, it might not
   // be exactly 25, but should be very close. We test for a small range.
   EXPECT_NEAR(optimal_index, 25, 1);
@@ -93,8 +91,7 @@ TEST(WsolaInternalTest, OptimalIndex_NoMatch) {
   Interval exclude_interval = {-1, -1};  // No exclusion
 
   int optimal_index =
-      OptimalIndex(&search_block, &target_block,
-                   kSbMediaAudioFrameStorageTypeInterleaved, exclude_interval);
+      OptimalIndex(&search_block, &target_block, exclude_interval);
   // With no clear match, the result is less predictable, but it shouldn't crash
   // and should return a valid index within the search range.
   EXPECT_GE(optimal_index, 0);
@@ -124,8 +121,7 @@ TEST(WsolaInternalTest, OptimalIndex_ExcludeInterval) {
   Interval exclude_interval = {5, 15};  // Exclude indices from 5 to 15
 
   int optimal_index =
-      OptimalIndex(&search_block, &target_block,
-                   kSbMediaAudioFrameStorageTypeInterleaved, exclude_interval);
+      OptimalIndex(&search_block, &target_block, exclude_interval);
 
   // The match at 10 should be excluded, so it should find the match at 50.
   EXPECT_EQ(optimal_index, 50);
@@ -148,8 +144,7 @@ TEST(WsolaInternalTest, OptimalIndex_SmallBlocks) {
   Interval exclude_interval = {-1, -1};
 
   int optimal_index =
-      OptimalIndex(&search_block, &target_block,
-                   kSbMediaAudioFrameStorageTypeInterleaved, exclude_interval);
+      OptimalIndex(&search_block, &target_block, exclude_interval);
   EXPECT_NEAR(optimal_index, 10, 1);
 }
 

--- a/starboard/shared/starboard/player/filter/wsola_internal.cc
+++ b/starboard/shared/starboard/player/filter/wsola_internal.cc
@@ -300,11 +300,9 @@ int FullSearch(int low_limit,
 
 int OptimalIndex(const DecodedAudio* search_block,
                  const DecodedAudio* target_block,
-                 SbMediaAudioFrameStorageType storage_type,
                  Interval exclude_interval) {
   int channels = search_block->channels();
   SB_DCHECK_EQ(channels, target_block->channels());
-  SB_DCHECK_EQ(storage_type, kSbMediaAudioFrameStorageTypeInterleaved);
 
   int target_size = target_block->frames();
   int num_candidate_blocks = search_block->frames() - (target_size - 1);

--- a/starboard/shared/starboard/player/filter/wsola_internal.h
+++ b/starboard/shared/starboard/player/filter/wsola_internal.h
@@ -38,7 +38,6 @@ typedef std::pair<int, int> Interval;
 // |exclude_interval| is an interval that is excluded from the search.
 int OptimalIndex(const DecodedAudio* search_block,
                  const DecodedAudio* target_block,
-                 SbMediaAudioFrameStorageType storage_type,
                  Interval exclude_interval);
 
 // Return a "periodic" Hann window(https://en.wikipedia.org/wiki/Hann_function).

--- a/starboard/tvos/shared/media/audio_decoder.mm
+++ b/starboard/tvos/shared/media/audio_decoder.mm
@@ -94,7 +94,6 @@ void TvosAudioDecoder::Decode(const InputBuffers& input_buffers,
 
     DecodedAudio decoded_audio(audio_stream_info_.number_of_channels,
                                kSbMediaAudioSampleTypeFloat32,
-                               kSbMediaAudioFrameStorageTypeInterleaved,
                                input_buffer->timestamp(), output_byte_size);
     audio_buffer_list_.mBuffers[0].mData = decoded_audio.data();
     audio_buffer_list_.mBuffers[0].mDataByteSize = output_byte_size;


### PR DESCRIPTION
Refactor DecodedAudio to always store audio samples in interleaved format across all channels, removing planar storage type support from DecodedAudio, decoders, filters, mixers, and resamplers.

When decoders produce planar frames (such as FFmpeg), they now convert and interleave samples directly upon writing into DecodedAudio. This simplifies buffer calculations, seeking math, format conversions, and SIMD routines.

Bug: 272837615