### PR TITLE
starboard/ffmpeg: Interleave planar audio directly in audio decoder

### DIFF
--- a/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.cc
@@ -19,7 +19,6 @@
 
 #include <memory>
 #include <string>
-#include <vector>
 
 #include "starboard/audio_sink.h"
 #include "starboard/common/check_op.h"
@@ -36,15 +35,17 @@ void InterleavePlanarAudio(const uint8_t* const* planar_data,
                            int channels,
                            int frames,
                            uint8_t* destination) {
-  auto* dst = reinterpret_cast<SampleType*>(destination);
-  std::vector<const SampleType*> src_channels(channels);
+  constexpr int kMaxChannels = 16;
+  SB_CHECK_LE(channels, kMaxChannels);
+  const SampleType* src_channels[kMaxChannels];
   for (int ch = 0; ch < channels; ++ch) {
     src_channels[ch] = reinterpret_cast<const SampleType*>(planar_data[ch]);
   }
 
+  auto* dst = reinterpret_cast<SampleType*>(destination);
   for (int frame = 0; frame < frames; ++frame) {
-    for (auto& src_channel : src_channels) {
-      *dst++ = *src_channel++;
+    for (int ch = 0; ch < channels; ++ch) {
+      *dst++ = *src_channels[ch]++;
     }
   }
 }

--- a/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.cc
@@ -28,8 +28,22 @@
 #include "starboard/shared/starboard/media/media_util.h"
 
 namespace starboard {
-
 namespace {
+
+template <typename SampleType>
+void InterleavePlanarAudio(const uint8_t* const* planar_data,
+                           int channels,
+                           int frames,
+                           uint8_t* destination) {
+  auto* dst = reinterpret_cast<SampleType*>(destination);
+  for (int frame = 0; frame < frames; ++frame) {
+    for (int ch = 0; ch < channels; ++ch) {
+      const auto* src_channel =
+          reinterpret_cast<const SampleType*>(planar_data[ch]);
+      *dst++ = src_channel[frame];
+    }
+  }
+}
 
 SbMediaAudioSampleType GetSupportedSampleType() {
   if (SbAudioSinkIsAudioSampleTypeSupported(kSbMediaAudioSampleTypeFloat32)) {
@@ -237,23 +251,23 @@ void FfmpegAudioDecoderImpl<FFMPEG>::ProcessDecodedFrame(
     return;
   }
 
+  const SbMediaAudioSampleType sample_type = GetSampleType();
   DecodedAudio decoded_audio(
-      channel_count, GetSampleType(), GetStorageType(),
+      channel_count, sample_type, kSbMediaAudioFrameStorageTypeInterleaved,
       input_buffer.timestamp(),
-      channel_count * av_frame.nb_samples * GetBytesPerSample(GetSampleType()));
-  if (GetStorageType() == kSbMediaAudioFrameStorageTypeInterleaved) {
+      channel_count * av_frame.nb_samples * GetBytesPerSample(sample_type));
+  const bool is_planar = (codec_context_->sample_fmt == AV_SAMPLE_FMT_S16P ||
+                          codec_context_->sample_fmt == AV_SAMPLE_FMT_FLTP);
+  if (!is_planar) {
     memcpy(decoded_audio.data(), *av_frame.extended_data,
            decoded_audio.size_in_bytes());
+  } else if (sample_type == kSbMediaAudioSampleTypeInt16Deprecated) {
+    InterleavePlanarAudio<int16_t>(av_frame.extended_data, channel_count,
+                                   av_frame.nb_samples, decoded_audio.data());
   } else {
-    SB_DCHECK_EQ(GetStorageType(), kSbMediaAudioFrameStorageTypePlanar);
-    const int per_channel_size_in_bytes =
-        decoded_audio.size_in_bytes() / decoded_audio.channels();
-    for (int i = 0; i < decoded_audio.channels(); ++i) {
-      memcpy(decoded_audio.data() + per_channel_size_in_bytes * i,
-             av_frame.extended_data[i], per_channel_size_in_bytes);
-    }
-    decoded_audio = decoded_audio.SwitchFormatTo(
-        GetSampleType(), kSbMediaAudioFrameStorageTypeInterleaved);
+    SB_CHECK_EQ(sample_type, kSbMediaAudioSampleTypeFloat32);
+    InterleavePlanarAudio<float>(av_frame.extended_data, channel_count,
+                                 av_frame.nb_samples, decoded_audio.data());
   }
   decoded_audio.AdjustForDiscardedDurations(
       audio_stream_info_.samples_per_second,
@@ -321,23 +335,6 @@ SbMediaAudioSampleType FfmpegAudioDecoderImpl<FFMPEG>::GetSampleType() const {
   SB_NOTREACHED();
 
   return kSbMediaAudioSampleTypeFloat32;
-}
-
-SbMediaAudioFrameStorageType FfmpegAudioDecoderImpl<FFMPEG>::GetStorageType()
-    const {
-  SB_CHECK(BelongsToCurrentThread());
-
-  if (codec_context_->sample_fmt == AV_SAMPLE_FMT_S16 ||
-      codec_context_->sample_fmt == AV_SAMPLE_FMT_FLT) {
-    return kSbMediaAudioFrameStorageTypeInterleaved;
-  }
-  if (codec_context_->sample_fmt == AV_SAMPLE_FMT_S16P ||
-      codec_context_->sample_fmt == AV_SAMPLE_FMT_FLTP) {
-    return kSbMediaAudioFrameStorageTypePlanar;
-  }
-
-  SB_NOTREACHED();
-  return kSbMediaAudioFrameStorageTypeInterleaved;
 }
 
 bool FfmpegAudioDecoderImpl<FFMPEG>::InitializeCodec() {

--- a/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.cc
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "starboard/audio_sink.h"
 #include "starboard/common/check_op.h"
@@ -36,11 +37,14 @@ void InterleavePlanarAudio(const uint8_t* const* planar_data,
                            int frames,
                            uint8_t* destination) {
   auto* dst = reinterpret_cast<SampleType*>(destination);
+  std::vector<const SampleType*> src_channels(channels);
+  for (int ch = 0; ch < channels; ++ch) {
+    src_channels[ch] = reinterpret_cast<const SampleType*>(planar_data[ch]);
+  }
+
   for (int frame = 0; frame < frames; ++frame) {
-    for (int ch = 0; ch < channels; ++ch) {
-      const auto* src_channel =
-          reinterpret_cast<const SampleType*>(planar_data[ch]);
-      *dst++ = src_channel[frame];
+    for (auto& src_channel : src_channels) {
+      *dst++ = *src_channel++;
     }
   }
 }

--- a/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.h
+++ b/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.h
@@ -62,7 +62,6 @@ class FfmpegAudioDecoderImpl<FFMPEG> : public FfmpegAudioDecoder,
 
  private:
   SbMediaAudioSampleType GetSampleType() const;
-  SbMediaAudioFrameStorageType GetStorageType() const;
 
   bool InitializeCodec();
   void TeardownCodec();


### PR DESCRIPTION
This is part of the effort  to remove kSbMediaAudioFrameStorageTypePlanar from 1P implementation.

When FFmpeg audio decoder outputs planar audio frames, interleave the
channel samples directly into DecodedAudio. This ensures that all
DecodedAudio instances produced by FFmpeg are interleaved upon creation.

This removes the need for GetStorageType and subsequent format
switching, supporting the effort to remove planar audio frame storage
from the implementation.

Bug: 272837615
