### PR TITLE
Add web API to expose the low memory kill signal

### DIFF
--- a/cobalt/browser/h5vcc_system/h5vcc_system_impl_android.cc
+++ b/cobalt/browser/h5vcc_system/h5vcc_system_impl_android.cc
@@ -120,4 +120,11 @@ void H5vccSystemImpl::HideSplashScreen() {
   StarboardBridge::GetInstance()->HideSplashScreen(env);
 }
 
+void H5vccSystemImpl::GetWasLowMemoryKilled(
+    GetWasLowMemoryKilledCallback callback) {
+  CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  // Stubbed.
+  std::move(callback).Run(false);
+}
+
 }  // namespace h5vcc_system

--- a/cobalt/browser/h5vcc_system/h5vcc_system_impl_base.h
+++ b/cobalt/browser/h5vcc_system/h5vcc_system_impl_base.h
@@ -62,6 +62,7 @@ class H5vccSystemImpl : public content::DocumentService<mojom::H5vccSystem> {
   void GetUserOnExitStrategy(GetUserOnExitStrategyCallback) override;
   void Exit() override;
   void HideSplashScreen() override;
+  void GetWasLowMemoryKilled(GetWasLowMemoryKilledCallback) override;
 
  private:
   H5vccSystemImpl(content::RenderFrameHost& render_frame_host,

--- a/cobalt/browser/h5vcc_system/h5vcc_system_impl_starboard.cc
+++ b/cobalt/browser/h5vcc_system/h5vcc_system_impl_starboard.cc
@@ -18,6 +18,7 @@
 #include "cobalt/browser/h5vcc_system/h5vcc_system_impl_base.h"
 #include "cobalt/configuration/configuration.h"
 #include "starboard/common/system_property.h"
+#include "starboard/extension/low_memory_kill.h"
 #include "starboard/system.h"
 #include "starboard/window.h"
 
@@ -62,6 +63,20 @@ bool GetLimitAdTrackingShared() {
 
 std::string GetTrackingAuthorizationStatusShared() {
   return "NOT_SUPPORTED";
+}
+
+bool GetWasLowMemoryKilledShared() {
+  const auto* low_memory_kill_extension =
+      static_cast<const StarboardExtensionLowMemoryKillApi*>(
+          SbSystemGetExtension(kStarboardExtensionLowMemoryKillName));
+  if (!low_memory_kill_extension ||
+      strcmp(low_memory_kill_extension->name,
+             kStarboardExtensionLowMemoryKillName) != 0 ||
+      low_memory_kill_extension->version < 1 ||
+      !low_memory_kill_extension->WasLowMemoryKilled) {
+    return false;
+  }
+  return low_memory_kill_extension->WasLowMemoryKilled();
 }
 
 }  // namespace
@@ -131,6 +146,12 @@ void H5vccSystemImpl::GetUserOnExitStrategy(
 }
 
 void H5vccSystemImpl::HideSplashScreen() {}
+
+void H5vccSystemImpl::GetWasLowMemoryKilled(
+    GetWasLowMemoryKilledCallback callback) {
+  CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  std::move(callback).Run(GetWasLowMemoryKilledShared());
+}
 
 void H5vccSystemImpl::PerformExitStrategy() {
   auto strategy = GetUserOnExitStrategyInternal();

--- a/cobalt/browser/h5vcc_system/h5vcc_system_impl_starboard.cc
+++ b/cobalt/browser/h5vcc_system/h5vcc_system_impl_starboard.cc
@@ -69,7 +69,7 @@ bool GetWasLowMemoryKilledShared() {
   const auto* low_memory_kill_extension =
       static_cast<const StarboardExtensionLowMemoryKillApi*>(
           SbSystemGetExtension(kStarboardExtensionLowMemoryKillName));
-  if (!low_memory_kill_extension ||
+  if (!low_memory_kill_extension || !low_memory_kill_extension->name ||
       strcmp(low_memory_kill_extension->name,
              kStarboardExtensionLowMemoryKillName) != 0 ||
       low_memory_kill_extension->version < 1 ||

--- a/cobalt/browser/h5vcc_system/h5vcc_system_impl_tvos.mm
+++ b/cobalt/browser/h5vcc_system/h5vcc_system_impl_tvos.mm
@@ -132,6 +132,13 @@ void H5vccSystemImpl::GetUserOnExitStrategy(
 
 void H5vccSystemImpl::HideSplashScreen() {}
 
+void H5vccSystemImpl::GetWasLowMemoryKilled(
+    GetWasLowMemoryKilledCallback callback) {
+  CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  // Stubbed.
+  std::move(callback).Run(false);
+}
+
 void H5vccSystemImpl::PerformExitStrategy() {
   SbSystemRequestConceal();
 }

--- a/cobalt/browser/h5vcc_system/public/mojom/h5vcc_system.mojom
+++ b/cobalt/browser/h5vcc_system/public/mojom/h5vcc_system.mojom
@@ -50,4 +50,9 @@ interface H5vccSystem {
 
   // YouTube request to hide the splash screen.
   HideSplashScreen();
+
+  // Returns true if the previous Cobalt session was killed by the system due to
+  // memory pressure. If the platform does not implement the LowMemoryKill
+  // extension or does not report LMK, this resolves to false.
+  GetWasLowMemoryKilled() => (bool was_low_memory_killed);
 };

--- a/cobalt/browser/h5vcc_system_browsertest.cc
+++ b/cobalt/browser/h5vcc_system_browsertest.cc
@@ -72,4 +72,28 @@ IN_PROC_BROWSER_TEST_F(H5vccSystemBrowserTest, VerifySystemProperties) {
       content::EvalJs(shell()->web_contents(), check_strategy).ExtractBool());
 }
 
+IN_PROC_BROWSER_TEST_F(H5vccSystemBrowserTest, VerifyWasLowMemoryKilled) {
+  ASSERT_TRUE(embedded_test_server()->Start());
+  GURL url = embedded_test_server()->GetURL("/title1.html");
+  ASSERT_TRUE(NavigateToURL(shell()->web_contents(), url));
+
+  // Verify that wasLowMemoryKilled() exists and returns a Promise.
+  EXPECT_TRUE(
+      content::EvalJs(
+          shell()->web_contents(),
+          "typeof window.h5vcc.system.wasLowMemoryKilled === 'function'")
+          .ExtractBool());
+  EXPECT_TRUE(content::EvalJs(
+                  shell()->web_contents(),
+                  "window.h5vcc.system.wasLowMemoryKilled() instanceof Promise")
+                  .ExtractBool());
+
+  // Verify that the promise resolves to a boolean.
+  EXPECT_TRUE(content::EvalJs(
+                  shell()->web_contents(),
+                  "(async () => typeof (await "
+                  "window.h5vcc.system.wasLowMemoryKilled()) === 'boolean')()")
+                  .ExtractBool());
+}
+
 }  // namespace cobalt

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_system/h_5_vcc_system.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_system/h_5_vcc_system.cc
@@ -203,6 +203,27 @@ void H5vccSystem::hideSplashScreen() {
   remote_h5vcc_system_->HideSplashScreen();
 }
 
+ScriptPromise<IDLBoolean> H5vccSystem::wasLowMemoryKilled(
+    ScriptState* script_state,
+    ExceptionState& exception_state) {
+  auto* resolver = MakeGarbageCollected<ScriptPromiseResolver<IDLBoolean>>(
+      script_state, exception_state.GetContext());
+
+  EnsureReceiverIsBound();
+
+  remote_h5vcc_system_->GetWasLowMemoryKilled(
+      WTF::BindOnce(&H5vccSystem::OnGetWasLowMemoryKilled, WrapPersistent(this),
+                    WrapPersistent(resolver)));
+
+  return resolver->Promise();
+}
+
+void H5vccSystem::OnGetWasLowMemoryKilled(
+    ScriptPromiseResolver<IDLBoolean>* resolver,
+    bool result) {
+  resolver->Resolve(result);
+}
+
 void H5vccSystem::EnsureReceiverIsBound() {
   DCHECK(GetExecutionContext());
 

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_system/h_5_vcc_system.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_system/h_5_vcc_system.cc
@@ -204,10 +204,9 @@ void H5vccSystem::hideSplashScreen() {
 }
 
 ScriptPromise<IDLBoolean> H5vccSystem::wasLowMemoryKilled(
-    ScriptState* script_state,
-    ExceptionState& exception_state) {
-  auto* resolver = MakeGarbageCollected<ScriptPromiseResolver<IDLBoolean>>(
-      script_state, exception_state.GetContext());
+    ScriptState* script_state) {
+  auto* resolver =
+      MakeGarbageCollected<ScriptPromiseResolver<IDLBoolean>>(script_state);
 
   EnsureReceiverIsBound();
 

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_system/h_5_vcc_system.h
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_system/h_5_vcc_system.h
@@ -60,7 +60,7 @@ class MODULES_EXPORT H5vccSystem final
   void exit();
   uint32_t userOnExitStrategy();
   void hideSplashScreen();
-  ScriptPromise<IDLBoolean> wasLowMemoryKilled(ScriptState*, ExceptionState&);
+  ScriptPromise<IDLBoolean> wasLowMemoryKilled(ScriptState*);
 
   void Trace(Visitor*) const override;
 

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_system/h_5_vcc_system.h
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_system/h_5_vcc_system.h
@@ -60,6 +60,7 @@ class MODULES_EXPORT H5vccSystem final
   void exit();
   uint32_t userOnExitStrategy();
   void hideSplashScreen();
+  ScriptPromise<IDLBoolean> wasLowMemoryKilled(ScriptState*, ExceptionState&);
 
   void Trace(Visitor*) const override;
 
@@ -72,6 +73,7 @@ class MODULES_EXPORT H5vccSystem final
                                         const String&);
   void OnRequestTrackingAuthorization(ScriptPromiseResolver<IDLUndefined>*,
                                       bool);
+  void OnGetWasLowMemoryKilled(ScriptPromiseResolver<IDLBoolean>*, bool);
   void EnsureReceiverIsBound();
   HeapMojoRemote<h5vcc_system::mojom::blink::H5vccSystem> remote_h5vcc_system_;
 

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_system/h_5_vcc_system.idl
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_system/h_5_vcc_system.idl
@@ -77,4 +77,10 @@ interface H5vccSystem : EventTarget {
 
   // Requests that the system splash screen be hidden on systems that support a splash screen.
   void hideSplashScreen();
+
+  // Returns true if the previous Cobalt session was killed by the system due to
+  // memory pressure. Returns false if the platform does not report LMK or does
+  // not implement the LowMemoryKill extension.
+  [CallWith=ScriptState, RaisesException]
+  Promise<boolean> wasLowMemoryKilled();
 };

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_system/h_5_vcc_system.idl
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_system/h_5_vcc_system.idl
@@ -81,6 +81,6 @@ interface H5vccSystem : EventTarget {
   // Returns true if the previous Cobalt session was killed by the system due to
   // memory pressure. Returns false if the platform does not report LMK or does
   // not implement the LowMemoryKill extension.
-  [CallWith=ScriptState, RaisesException]
+  [CallWith=ScriptState]
   Promise<boolean> wasLowMemoryKilled();
 };

--- a/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-system/h5vcc-system-wasLowMemoryKilled.https.any.js
+++ b/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-system/h5vcc-system-wasLowMemoryKilled.https.any.js
@@ -1,0 +1,13 @@
+// META: global=window
+// META: script=/resources/test-only-api.js
+// META: script=resources/automation.js
+
+h5vcc_system_tests(async (t, mockH5vccSystem) => {
+    assert_implements(window.h5vcc, "window.h5vcc not supported");
+    assert_implements(window.h5vcc.system, "window.h5vcc.system not supported");
+
+    const expected = true;
+    mockH5vccSystem.stubWasLowMemoryKilled(expected);
+    let actual = await window.h5vcc.system.wasLowMemoryKilled();
+    assert_equals(actual, expected);
+}, 'exercises H5vccSystem.wasLowMemoryKilled()');

--- a/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-system/resources/mock-h5vcc-system.js
+++ b/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-system/resources/mock-h5vcc-system.js
@@ -29,6 +29,7 @@ class MockH5vccSystem {
   STUB_KEY_SCREEN_DIAGONAL = 'screenDiagonal';
   STUB_KEY_TRACKING_AUTHORIZATION_STATUS = 'trackingAuthorizationStatus';
   STUB_KEY_USER_ON_EXIT_STRATEGY = 'userOnExitStrategy';
+  STUB_KEY_WAS_LOW_MEMORY_KILLED = 'wasLowMemoryKilled';
 
   incrementExitCallCount() {
     this.callCount_[EXIT_METHOD_NAME] += 1;
@@ -90,6 +91,10 @@ class MockH5vccSystem {
     this.stubResult(this.STUB_KEY_USER_ON_EXIT_STRATEGY, USER_ON_EXIT_STRATEGY_NO_EXIT);
   }
 
+  stubWasLowMemoryKilled(wasLowMemoryKilled) {
+    this.stubResult(this.STUB_KEY_WAS_LOW_MEMORY_KILLED, wasLowMemoryKilled);
+  }
+
   // h5vcc_system.mojom.H5vccSystem impl.
   getAdvertisingId() {
     // VERY IMPORTANT: this should return (a resolved Promise with) a dictionary
@@ -140,6 +145,13 @@ class MockH5vccSystem {
   }
 
   hideSplashScreen() {}
+
+  getWasLowMemoryKilled() {
+    return Promise.resolve({
+      wasLowMemoryKilled:
+          this.stub_result_.get(this.STUB_KEY_WAS_LOW_MEMORY_KILLED) ?? false
+    });
+  }
 }
 
 export const mockH5vccSystem = new MockH5vccSystem();


### PR DESCRIPTION
PR #12106 added a Starboard extension that allows the platform to report if the previous Cobalt instance was killed due to low memory. This PR adds a web API to allow the running app to query that extension.

On platforms that do not implement the LMK extension, the API returns false.

Bug: 544833738