### PR TITLE
Add uncompressed Evergreen test apps to package.

### DIFF
--- a/cobalt/build/evergreen-arm-hardfp-rdk/package_qa.json
+++ b/cobalt/build/evergreen-arm-hardfp-rdk/package_qa.json
@@ -16,6 +16,12 @@
                 "gen/licenses_cobalt.spdx",
                 "gen/licenses_cobalt.txt",
                 "libcobalt.so",
+                "app/crash_sandbox/lib/libcrash_sandbox.lz4",
+                "app/crash_sandbox/lib/libcrash_sandbox.so",
+                "app/noop_sandbox/lib/libnoop_sandbox.lz4",
+                "app/noop_sandbox/lib/libnoop_sandbox.so",
+                "app/one_app_only_sandbox/lib/libone_app_only_sandbox.lz4",
+                "app/one_app_only_sandbox/lib/libone_app_only_sandbox.so",
                 "libloader_app.so",
                 "native_target/crashpad_handler",
                 {
@@ -51,6 +57,30 @@
                 {
                     "from_file": "gen/licenses_cobalt.txt",
                     "to_file": "licenses_cobalt.txt"
+                },
+                {
+                    "from_file": "app/crash_sandbox/lib/libcrash_sandbox.lz4",
+                    "to_file": "lib/test_apps/tcrash/libcobalt.lz4"
+                },
+                {
+                    "from_file": "app/crash_sandbox/lib/libcrash_sandbox.so",
+                    "to_file": "lib/test_apps/tcrash/libcobalt.so"
+                },
+                {
+                    "from_file": "app/noop_sandbox/lib/libnoop_sandbox.lz4",
+                    "to_file": "lib/test_apps/tnoop/libcobalt.lz4"
+                },
+                {
+                    "from_file": "app/noop_sandbox/lib/libnoop_sandbox.so",
+                    "to_file": "lib/test_apps/tnoop/libcobalt.so"
+                },
+                {
+                    "from_file": "app/one_app_only_sandbox/lib/libone_app_only_sandbox.lz4",
+                    "to_file": "lib/test_apps/t1app/libcobalt.lz4"
+                },
+                {
+                    "from_file": "app/one_app_only_sandbox/lib/libone_app_only_sandbox.so",
+                    "to_file": "lib/test_apps/t1app/libcobalt.so"
                 }
             ],
             "dirs": [

--- a/cobalt/build/evergreen-arm-softfp/package.json
+++ b/cobalt/build/evergreen-arm-softfp/package.json
@@ -15,9 +15,6 @@
                 "gen/licenses_cobalt.spdx",
                 "gen/licenses_cobalt.txt",
                 "libcobalt.so",
-                "app/crash_sandbox/lib/libcrash_sandbox.lz4",
-                "app/noop_sandbox/lib/libnoop_sandbox.lz4",
-                "app/one_app_only_sandbox/lib/libone_app_only_sandbox.lz4",
                 {
                     "from_file": "cobalt_shell.pak",
                     "to_file": "content/cobalt_shell.pak"
@@ -47,18 +44,6 @@
                 {
                     "from_file": "gen/licenses_cobalt.txt",
                     "to_file": "licenses_cobalt.txt"
-                },
-                {
-                    "from_file": "app/crash_sandbox/lib/libcrash_sandbox.lz4",
-                    "to_file": "lib/test_apps/tcrash/libcobalt.lz4"
-                },
-                {
-                    "from_file": "app/noop_sandbox/lib/libnoop_sandbox.lz4",
-                    "to_file": "lib/test_apps/tnoop/libcobalt.lz4"
-                },
-                {
-                    "from_file": "app/one_app_only_sandbox/lib/libone_app_only_sandbox.lz4",
-                    "to_file": "lib/test_apps/t1app/libcobalt.lz4"
                 }
             ],
             "archive_type": "ARCHIVE_TYPE_ZIP"

--- a/cobalt/build/evergreen-arm-softfp/package_qa.json
+++ b/cobalt/build/evergreen-arm-softfp/package_qa.json
@@ -11,13 +11,16 @@
                 "app/cobalt/lib/libcobalt.lz4",
                 "app/cobalt/lib/libcobalt.zst",
                 "cobalt_shell.pak",
-                "fonts/fonts.xml",
                 "gen/build_info.json",
                 "gen/licenses_cobalt.spdx",
                 "gen/licenses_cobalt.txt",
                 "libcobalt.so",
-                "libloader_app.so",
-                "native_target/crashpad_handler",
+                "app/crash_sandbox/lib/libcrash_sandbox.lz4",
+                "app/crash_sandbox/lib/libcrash_sandbox.so",
+                "app/noop_sandbox/lib/libnoop_sandbox.lz4",
+                "app/noop_sandbox/lib/libnoop_sandbox.so",
+                "app/one_app_only_sandbox/lib/libone_app_only_sandbox.lz4",
+                "app/one_app_only_sandbox/lib/libone_app_only_sandbox.so",
                 {
                     "from_file": "cobalt_shell.pak",
                     "to_file": "content/cobalt_shell.pak"
@@ -37,10 +40,6 @@
                     "to_file": "lib/compressed/libcobalt.zst"
                 },
                 {
-                    "from_file": "fonts/fonts.xml",
-                    "to_file": "content/fonts/fonts.xml"
-                },
-                {
                     "from_file": "gen/build_info.json",
                     "to_file": "build_info.json"
                 },
@@ -51,14 +50,30 @@
                 {
                     "from_file": "gen/licenses_cobalt.txt",
                     "to_file": "licenses_cobalt.txt"
-                }
-            ],
-            "dirs": [
-                "app",
-                "fonts",
+                },
                 {
-                    "from_dir": "app/cobalt/content/ssl",
-                    "to_dir": "content/ssl"
+                    "from_file": "app/crash_sandbox/lib/libcrash_sandbox.lz4",
+                    "to_file": "lib/test_apps/tcrash/libcobalt.lz4"
+                },
+                {
+                    "from_file": "app/crash_sandbox/lib/libcrash_sandbox.so",
+                    "to_file": "lib/test_apps/tcrash/libcobalt.so"
+                },
+                {
+                    "from_file": "app/noop_sandbox/lib/libnoop_sandbox.lz4",
+                    "to_file": "lib/test_apps/tnoop/libcobalt.lz4"
+                },
+                {
+                    "from_file": "app/noop_sandbox/lib/libnoop_sandbox.so",
+                    "to_file": "lib/test_apps/tnoop/libcobalt.so"
+                },
+                {
+                    "from_file": "app/one_app_only_sandbox/lib/libone_app_only_sandbox.lz4",
+                    "to_file": "lib/test_apps/t1app/libcobalt.lz4"
+                },
+                {
+                    "from_file": "app/one_app_only_sandbox/lib/libone_app_only_sandbox.so",
+                    "to_file": "lib/test_apps/t1app/libcobalt.so"
                 }
             ],
             "archive_type": "ARCHIVE_TYPE_ZIP"

--- a/cobalt/build/evergreen-arm64/package.json
+++ b/cobalt/build/evergreen-arm64/package.json
@@ -15,9 +15,6 @@
                 "gen/licenses_cobalt.spdx",
                 "gen/licenses_cobalt.txt",
                 "libcobalt.so",
-                "app/crash_sandbox/lib/libcrash_sandbox.lz4",
-                "app/noop_sandbox/lib/libnoop_sandbox.lz4",
-                "app/one_app_only_sandbox/lib/libone_app_only_sandbox.lz4",
                 {
                     "from_file": "cobalt_shell.pak",
                     "to_file": "content/cobalt_shell.pak"
@@ -47,18 +44,6 @@
                 {
                     "from_file": "gen/licenses_cobalt.txt",
                     "to_file": "licenses_cobalt.txt"
-                },
-                {
-                    "from_file": "app/crash_sandbox/lib/libcrash_sandbox.lz4",
-                    "to_file": "lib/test_apps/tcrash/libcobalt.lz4"
-                },
-                {
-                    "from_file": "app/noop_sandbox/lib/libnoop_sandbox.lz4",
-                    "to_file": "lib/test_apps/tnoop/libcobalt.lz4"
-                },
-                {
-                    "from_file": "app/one_app_only_sandbox/lib/libone_app_only_sandbox.lz4",
-                    "to_file": "lib/test_apps/t1app/libcobalt.lz4"
                 }
             ],
             "archive_type": "ARCHIVE_TYPE_ZIP"

--- a/cobalt/build/evergreen-arm64/package_qa.json
+++ b/cobalt/build/evergreen-arm64/package_qa.json
@@ -11,13 +11,16 @@
                 "app/cobalt/lib/libcobalt.lz4",
                 "app/cobalt/lib/libcobalt.zst",
                 "cobalt_shell.pak",
-                "fonts/fonts.xml",
                 "gen/build_info.json",
                 "gen/licenses_cobalt.spdx",
                 "gen/licenses_cobalt.txt",
                 "libcobalt.so",
-                "libloader_app.so",
-                "native_target/crashpad_handler",
+                "app/crash_sandbox/lib/libcrash_sandbox.lz4",
+                "app/crash_sandbox/lib/libcrash_sandbox.so",
+                "app/noop_sandbox/lib/libnoop_sandbox.lz4",
+                "app/noop_sandbox/lib/libnoop_sandbox.so",
+                "app/one_app_only_sandbox/lib/libone_app_only_sandbox.lz4",
+                "app/one_app_only_sandbox/lib/libone_app_only_sandbox.so",
                 {
                     "from_file": "cobalt_shell.pak",
                     "to_file": "content/cobalt_shell.pak"
@@ -37,10 +40,6 @@
                     "to_file": "lib/compressed/libcobalt.zst"
                 },
                 {
-                    "from_file": "fonts/fonts.xml",
-                    "to_file": "content/fonts/fonts.xml"
-                },
-                {
                     "from_file": "gen/build_info.json",
                     "to_file": "build_info.json"
                 },
@@ -51,14 +50,30 @@
                 {
                     "from_file": "gen/licenses_cobalt.txt",
                     "to_file": "licenses_cobalt.txt"
-                }
-            ],
-            "dirs": [
-                "app",
-                "fonts",
+                },
                 {
-                    "from_dir": "app/cobalt/content/ssl",
-                    "to_dir": "content/ssl"
+                    "from_file": "app/crash_sandbox/lib/libcrash_sandbox.lz4",
+                    "to_file": "lib/test_apps/tcrash/libcobalt.lz4"
+                },
+                {
+                    "from_file": "app/crash_sandbox/lib/libcrash_sandbox.so",
+                    "to_file": "lib/test_apps/tcrash/libcobalt.so"
+                },
+                {
+                    "from_file": "app/noop_sandbox/lib/libnoop_sandbox.lz4",
+                    "to_file": "lib/test_apps/tnoop/libcobalt.lz4"
+                },
+                {
+                    "from_file": "app/noop_sandbox/lib/libnoop_sandbox.so",
+                    "to_file": "lib/test_apps/tnoop/libcobalt.so"
+                },
+                {
+                    "from_file": "app/one_app_only_sandbox/lib/libone_app_only_sandbox.lz4",
+                    "to_file": "lib/test_apps/t1app/libcobalt.lz4"
+                },
+                {
+                    "from_file": "app/one_app_only_sandbox/lib/libone_app_only_sandbox.so",
+                    "to_file": "lib/test_apps/t1app/libcobalt.so"
                 }
             ],
             "archive_type": "ARCHIVE_TYPE_ZIP"

--- a/cobalt/build/evergreen-x64/package.json
+++ b/cobalt/build/evergreen-x64/package.json
@@ -16,9 +16,6 @@
                 "gen/licenses_cobalt.spdx",
                 "gen/licenses_cobalt.txt",
                 "libcobalt.so",
-                "app/crash_sandbox/lib/libcrash_sandbox.lz4",
-                "app/noop_sandbox/lib/libnoop_sandbox.lz4",
-                "app/one_app_only_sandbox/lib/libone_app_only_sandbox.lz4",
                 "loader_app",
                 "native_target/crashpad_handler",
                 {
@@ -54,18 +51,6 @@
                 {
                     "from_file": "gen/licenses_cobalt.txt",
                     "to_file": "licenses_cobalt.txt"
-                },
-                {
-                    "from_file": "app/crash_sandbox/lib/libcrash_sandbox.lz4",
-                    "to_file": "lib/test_apps/tcrash/libcobalt.lz4"
-                },
-                {
-                    "from_file": "app/noop_sandbox/lib/libnoop_sandbox.lz4",
-                    "to_file": "lib/test_apps/tnoop/libcobalt.lz4"
-                },
-                {
-                    "from_file": "app/one_app_only_sandbox/lib/libone_app_only_sandbox.lz4",
-                    "to_file": "lib/test_apps/t1app/libcobalt.lz4"
                 }
             ],
             "dirs": [

--- a/cobalt/build/evergreen-x64/package_qa.json
+++ b/cobalt/build/evergreen-x64/package_qa.json
@@ -16,7 +16,13 @@
                 "gen/licenses_cobalt.spdx",
                 "gen/licenses_cobalt.txt",
                 "libcobalt.so",
-                "libloader_app.so",
+                "app/crash_sandbox/lib/libcrash_sandbox.lz4",
+                "app/crash_sandbox/lib/libcrash_sandbox.so",
+                "app/noop_sandbox/lib/libnoop_sandbox.lz4",
+                "app/noop_sandbox/lib/libnoop_sandbox.so",
+                "app/one_app_only_sandbox/lib/libone_app_only_sandbox.lz4",
+                "app/one_app_only_sandbox/lib/libone_app_only_sandbox.so",
+                "loader_app",
                 "native_target/crashpad_handler",
                 {
                     "from_file": "cobalt_shell.pak",
@@ -51,6 +57,30 @@
                 {
                     "from_file": "gen/licenses_cobalt.txt",
                     "to_file": "licenses_cobalt.txt"
+                },
+                {
+                    "from_file": "app/crash_sandbox/lib/libcrash_sandbox.lz4",
+                    "to_file": "lib/test_apps/tcrash/libcobalt.lz4"
+                },
+                {
+                    "from_file": "app/crash_sandbox/lib/libcrash_sandbox.so",
+                    "to_file": "lib/test_apps/tcrash/libcobalt.so"
+                },
+                {
+                    "from_file": "app/noop_sandbox/lib/libnoop_sandbox.lz4",
+                    "to_file": "lib/test_apps/tnoop/libcobalt.lz4"
+                },
+                {
+                    "from_file": "app/noop_sandbox/lib/libnoop_sandbox.so",
+                    "to_file": "lib/test_apps/tnoop/libcobalt.so"
+                },
+                {
+                    "from_file": "app/one_app_only_sandbox/lib/libone_app_only_sandbox.lz4",
+                    "to_file": "lib/test_apps/t1app/libcobalt.lz4"
+                },
+                {
+                    "from_file": "app/one_app_only_sandbox/lib/libone_app_only_sandbox.so",
+                    "to_file": "lib/test_apps/t1app/libcobalt.so"
                 }
             ],
             "dirs": [

--- a/cobalt/devinfra/kokoro/bin/common.sh
+++ b/cobalt/devinfra/kokoro/bin/common.sh
@@ -199,13 +199,20 @@ run_package_release_pipeline () {
       cp "${src_out}/chromedriver" "${dst_out}/chromedriver"
     fi
 
+    # Use config-specific (e.g. package_devel.json) if it exists, otherwise fallback to package.json.
+    local json_path="${WORKSPACE_COBALT}/cobalt/build/${PACKAGE_PLATFORM}/package.json"
+    local config_json_path="${WORKSPACE_COBALT}/cobalt/build/${PACKAGE_PLATFORM}/package_${CONFIG}.json"
+    if [[ -f "${config_json_path}" ]]; then
+      json_path="${config_json_path}"
+    fi
+
     # NOTE: Name is required because the Json recipe is not platform and config
     # specific. GCS upload is also done separately because the Json recipe is
     # not branch, date, and build number specific though this can be added.
     python3 "${WORKSPACE_COBALT}/cobalt/build/packager.py" \
       --print_contents \
       --name="${PLATFORM}_${CONFIG}" \
-      --json_path="${WORKSPACE_COBALT}/cobalt/build/${PACKAGE_PLATFORM}/package.json" \
+      --json_path="${json_path}" \
       --out_dir="${out_dir}" \
       --package_dir="${package_dir}"
 


### PR DESCRIPTION
Adds logic for preferring config specific `package_qa.jsons` (if it exists) over the default `package.json`. Adds uncompressed Evergreen test apps to `package_qa.jsons` and removes all Evergreen test apps from `package.json`. This saves space on g3 by limiting test apps to only the necessary configs.

Bug: 553656624