### PR TITLE
cobalt: Fix startup crash DCHECK and redundant Finch reads in HangWatcher

### DIFF
--- a/base/threading/hang_watcher.cc
+++ b/base/threading/hang_watcher.cc
@@ -286,11 +286,6 @@ constexpr base::FeatureParam<int> kUIThreadLogLevel{
 constexpr base::FeatureParam<int> kThreadPoolLogLevel{
     &kEnableHangWatcher, "threadpool_log_level",
     static_cast<int>(LoggingLevel::kUmaOnly)};
-#if BUILDFLAG(IS_COBALT)
-constexpr base::FeatureParam<int> kBrowserProcessRendererThreadLogLevel{
-    &kEnableHangWatcher, "browser_process_renderer_thread_log_level",
-    static_cast<int>(LoggingLevel::kUmaAndCrash)};
-#endif
 
 // GPU process.
 // Note: Do not use the prepared macro as of no need for a local cache.
@@ -512,11 +507,13 @@ void HangWatcher::UpdateConfiguration() {
 void HangWatcher::InitializeOnMainThread(ProcessType process_type,
                                          bool emit_crashes) {
   DCHECK(!g_use_hang_watcher);
+
+#if !BUILDFLAG(IS_COBALT)
+  // Cobalt manages HangWatcher configuration in UpdateConfiguration()
+  // in addition to this initialization method.
   DCHECK(g_io_thread_log_level == LoggingLevel::kNone);
   DCHECK(g_main_thread_log_level == LoggingLevel::kNone);
   DCHECK(g_threadpool_log_level == LoggingLevel::kNone);
-#if BUILDFLAG(IS_COBALT)
-  DCHECK(g_browser_process_renderer_thread_log_level == LoggingLevel::kNone);
 #endif
 
   bool enable_hang_watcher = base::FeatureList::IsEnabled(kEnableHangWatcher);
@@ -565,12 +562,6 @@ void HangWatcher::InitializeOnMainThread(ProcessType process_type,
     g_threadpool_log_level.store(
         static_cast<LoggingLevel>(kThreadPoolLogLevel.Get()),
         std::memory_order_relaxed);
-#if BUILDFLAG(IS_COBALT)
-    g_browser_process_renderer_thread_log_level.store(
-        static_cast<LoggingLevel>(
-            kBrowserProcessRendererThreadLogLevel.Get()),
-        std::memory_order_relaxed);
-#endif
   } else if (process_type == HangWatcher::ProcessType::kGPUProcess) {
     g_threadpool_log_level.store(
         static_cast<LoggingLevel>(kGPUProcessThreadPoolLogLevel.Get()),
@@ -606,6 +597,12 @@ void HangWatcher::InitializeOnMainThread(ProcessType process_type,
         static_cast<LoggingLevel>(kUtilityProcessMainThreadLogLevel.Get()),
         std::memory_order_relaxed);
   }
+
+#if BUILDFLAG(IS_COBALT)
+  // Apply configured overrides from H5VCC or Finch, if any,
+  // and read Cobalt-specific configuration.
+  UpdateConfiguration();
+#endif
 }
 
 void HangWatcher::UninitializeOnMainThreadForTesting() {


### PR DESCRIPTION
On Android and Starboard platforms, CobaltHangWatcherDelegate is initialized in CobaltMainDelegate::PostEarlyInitialization before InitializeHangWatcher() to install the delegate and load embedder/H5VCC configuration.

1. Guard upstream DCHECKs asserting thread logging levels are kNone in HangWatcher::InitializeOnMainThread() with #if !BUILDFLAG(IS_COBALT), preventing startup aborts when the delegate has already initialized levels.
2. Remove redundant kBrowserProcessRendererThreadLogLevel FeatureParam and write in InitializeOnMainThread(), consolidating thread dump configuration authoritatively within CobaltHangWatcherDelegate and UpdateConfiguration().
3. Invoke UpdateConfiguration() at the end of InitializeOnMainThread() on Cobalt so embedder and Finch delegate overrides cleanly take precedence.

Bug: 517626586