### PR TITLE
ci: Use explicit filenames in nightly workflow triggers

### DIFF
--- a/.github/workflows/nightly_trigger_main.yaml
+++ b/.github/workflows/nightly_trigger_main.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Trigger Nightly
         run: |
           set -x
-          gh workflow run android --ref main -f nightly=true --repo "${GITHUB_REPO}"
-          gh workflow run linux --ref main -f nightly=true --repo "${GITHUB_REPO}"
+          gh workflow run android.yaml --ref main -f nightly=true --repo "${GITHUB_REPO}"
+          gh workflow run linux.yaml --ref main -f nightly=true --repo "${GITHUB_REPO}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly_trigger_main.yaml
+++ b/.github/workflows/nightly_trigger_main.yaml
@@ -22,5 +22,7 @@ jobs:
           set -x
           gh workflow run android.yaml --ref main -f nightly=true --repo "${GITHUB_REPO}"
           gh workflow run linux.yaml --ref main -f nightly=true --repo "${GITHUB_REPO}"
+          gh workflow run aosp.yaml --ref main -f nightly=true --repo "${GITHUB_REPO}"
+          gh workflow run evergreen.yaml --ref main -f nightly=true --repo "${GITHUB_REPO}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Update the nightly trigger workflow to use full filenames instead of
ambiguous identifiers when invoking workflows via the GitHub CLI. This
ensures the correct workflow files are targeted and prevents execution
errors caused by naming conflicts.

Bug: 554002499