### PR TITLE
ci: Dynamically resolve workflow filenames in dispatcher

### DIFF
--- a/.github/workflows/workflow_dispatcher.yaml
+++ b/.github/workflows/workflow_dispatcher.yaml
@@ -49,6 +49,7 @@ jobs:
               pr = prResponse.data;
             }
 
+            // TODO: Use commit status from the ci_shepherd to determine which workflows to restart instead.
             const logicalWorkflows = ['android', 'aosp', 'evergreen', 'linux', 'tvos'];
 
             // Get list of workflow files in the base branch

--- a/.github/workflows/workflow_dispatcher.yaml
+++ b/.github/workflows/workflow_dispatcher.yaml
@@ -28,6 +28,7 @@ jobs:
       actions: write
       pull-requests: write
       issues: write
+      contents: read
     steps:
       - name: Check label and trigger PR jobs
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
@@ -48,24 +49,46 @@ jobs:
               pr = prResponse.data;
             }
 
-            const PLATFORM_WORKFLOWS = [
-              'android.yaml',
-              'aosp.yaml',
-              'evergreen.yaml',
-              'linux.yaml',
-              'tvos.yaml'
-            ];
+            const logicalWorkflows = ['android', 'aosp', 'evergreen', 'linux', 'tvos'];
 
-            let workflows = [];
-            if (labelName === 'kokoro:run' || labelName === 'kokoro:force-run') {
-              workflows = ['tvos.yaml'];
-            } else {
-              workflows = PLATFORM_WORKFLOWS;
+            // Get list of workflow files in the base branch
+            const { data: fileList } = await github.rest.repos.getContent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              path: '.github/workflows',
+              ref: pr.base.ref
+            });
+
+            const workflowFiles = fileList.map(f => f.name);
+
+            // Map logical workflows to actual filenames present in the branch
+            const actualWorkflows = [];
+            for (const logical of logicalWorkflows) {
+              const match = workflowFiles.find(name =>
+                name === `${logical}.yaml` ||
+                name === `${logical}.yml` ||
+                (name.startsWith(`${logical}_`) && (name.endsWith('.yaml') || name.endsWith('.yml')))
+              );
+              if (match) {
+                actualWorkflows.push(match);
+              }
             }
 
-            console.log(`Triggering workflows for label ${labelName}:`, workflows);
+            console.log(`Found actual workflows in branch ${pr.base.ref}:`, actualWorkflows);
 
-            await Promise.all(workflows.map(async (workflow) => {
+            let workflowsToTrigger = [];
+            if (labelName === 'kokoro:run' || labelName === 'kokoro:force-run') {
+              const tvosWorkflow = actualWorkflows.find(name => name.startsWith('tvos'));
+              if (tvosWorkflow) {
+                workflowsToTrigger = [tvosWorkflow];
+              }
+            } else {
+              workflowsToTrigger = actualWorkflows;
+            }
+
+            console.log(`Triggering workflows for label ${labelName}:`, workflowsToTrigger);
+
+            await Promise.all(workflowsToTrigger.map(async (workflow) => {
               try {
                 const runs = await github.rest.actions.listWorkflowRuns({
                   owner: context.repo.owner,


### PR DESCRIPTION
Update workflow_dispatcher.yaml to dynamically check which workflow files
exist in the target base branch before triggering them. This fixes the
issue where the dispatcher failed to trigger runs on staging branches
because it was looking for main branch workflow filenames (e.g. linux.yaml
instead of linux_staging.yaml).

Tag: agy
Conv: 88348e0e-b878-461b-ae81-c0864a90bc66
Bug: 546243560
