### PR TITLE
ci: Fix deflake workflow cancelling newer runs

### DIFF
--- a/.github/workflows/deflake_tests.yml
+++ b/.github/workflows/deflake_tests.yml
@@ -50,7 +50,6 @@ jobs:
           # retries in on_host_tests and on_device_tests actions.
           MAX_ATTEMPTS=$(jq -r '.deflake_runs | tonumber? // 3' .github/config/infra/deflake.json)
 
-          # Fetch run info (attempt and jobs) in a single call to optimize and ensure consistent attempt context.
           if ! run_info=$(gh run view --repo "${REPO}" "${WORKFLOW}" --json attempt,jobs 2>/dev/null); then
             echo "Failed to fetch run info for ${WORKFLOW}."
             exit 1
@@ -59,7 +58,7 @@ jobs:
           attempt=$(echo "${run_info}" | jq -r '.attempt')
           if [ "${attempt}" -ge "${MAX_ATTEMPTS}" ]; then
             echo "Done retrying ${WORKFLOW_NAME}. It is still failing after ${attempt} attempts."
-            [ -n "${GITHUB_OUTPUT}" ] && echo "rerun_triggered=false" >> "${GITHUB_OUTPUT}"
+            echo "rerun_triggered=false" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
 

--- a/.github/workflows/deflake_tests.yml
+++ b/.github/workflows/deflake_tests.yml
@@ -34,11 +34,12 @@ jobs:
           WORKFLOW: ${{ github.event.workflow_run.id }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
         shell: bash
         run: |
           set +x
           if [ -n "${HEAD_BRANCH}" ]; then
-            current_sha=$(git ls-remote origin "refs/heads/${HEAD_BRANCH}" | cut -f1)
+            current_sha=$(git ls-remote -- "https://github.com/${HEAD_REPO:-${REPO}}.git" "refs/heads/${HEAD_BRANCH}" 2>/dev/null | cut -f1) || true
             if [ -n "${current_sha}" ] && [ "${current_sha}" != "${HEAD_SHA}" ]; then
               echo "A newer commit (${current_sha}) exists on branch ${HEAD_BRANCH} than the run SHA (${HEAD_SHA}). Aborting re-run."
               exit 0

--- a/.github/workflows/deflake_tests.yml
+++ b/.github/workflows/deflake_tests.yml
@@ -58,7 +58,6 @@ jobs:
           attempt=$(echo "${run_info}" | jq -r '.attempt')
           if [ "${attempt}" -ge "${MAX_ATTEMPTS}" ]; then
             echo "Done retrying ${WORKFLOW_NAME}. It is still failing after ${attempt} attempts."
-            echo "rerun_triggered=false" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
 

--- a/.github/workflows/deflake_tests.yml
+++ b/.github/workflows/deflake_tests.yml
@@ -32,9 +32,19 @@ jobs:
           REPO: ${{ github.repository }}
           WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
           WORKFLOW: ${{ github.event.workflow_run.id }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         shell: bash
         run: |
           set +x
+          if [ -n "${HEAD_BRANCH}" ]; then
+            current_sha=$(git ls-remote origin "refs/heads/${HEAD_BRANCH}" | cut -f1)
+            if [ -n "${current_sha}" ] && [ "${current_sha}" != "${HEAD_SHA}" ]; then
+              echo "A newer commit (${current_sha}) exists on branch ${HEAD_BRANCH} than the run SHA (${HEAD_SHA}). Aborting re-run."
+              exit 0
+            fi
+          fi
+
           # Max number of times the tests should run. Must match number of
           # retries in on_host_tests and on_device_tests actions.
           MAX_ATTEMPTS=$(jq -r '.deflake_runs | tonumber? // 3' .github/config/infra/deflake.json)

--- a/.github/workflows/deflake_tests.yml
+++ b/.github/workflows/deflake_tests.yml
@@ -49,15 +49,20 @@ jobs:
           # retries in on_host_tests and on_device_tests actions.
           MAX_ATTEMPTS=$(jq -r '.deflake_runs | tonumber? // 3' .github/config/infra/deflake.json)
 
-          # This call fails until the workflow has run $MAX_ATTEMPTS times.
-          if gh run view --repo "${REPO}" "${WORKFLOW}" --attempt "${MAX_ATTEMPTS}"; then
-            echo "Done retrying ${WORKFLOW_NAME}. It is still failing after ${MAX_ATTEMPTS} attempts."
+          # Fetch run info (attempt and jobs) in a single call to optimize and ensure consistent attempt context.
+          if ! run_info=$(gh run view --repo "${REPO}" "${WORKFLOW}" --json attempt,jobs 2>/dev/null); then
+            echo "Failed to fetch run info for ${WORKFLOW}."
+            exit 1
+          fi
+
+          attempt=$(echo "${run_info}" | jq -r '.attempt')
+          if [ "${attempt}" -ge "${MAX_ATTEMPTS}" ]; then
+            echo "Done retrying ${WORKFLOW_NAME}. It is still failing after ${attempt} attempts."
+            [ -n "${GITHUB_OUTPUT}" ] && echo "rerun_triggered=false" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
 
-          # Fetch failed jobs containing _tests.
-          failed_job_ids=$(gh run view --repo "${REPO}" "${WORKFLOW}" --json jobs --jq '.jobs[] | select(.conclusion=="failure") | select(.name | contains("_tests")) | .databaseId')
-
+          failed_job_ids=$(echo "${run_info}" | jq -r '.jobs[] | select(.conclusion=="failure") | select(.name | contains("_tests")) | .databaseId')
           if [ -z "${failed_job_ids}" ]; then
             echo "No failing '_tests' jobs found to rerun."
             exit 0


### PR DESCRIPTION
This PR fixes a bug in the deflake workflow where it would re-run failed jobs of older workflow runs even after a newer commit had been pushed, causing the newer run's jobs to be cancelled due to concurrency conflicts.

It adds a check to compare the current remote SHA of the branch with the run's head SHA before triggering the re-run.

Bug: 554047886
