### PR TITLE
BACKPORT: [tvOS] base: Do not remove sampling_heap_profiler on iOS when use_allocator_shim is false

### DIFF
--- a/base/BUILD.gn
+++ b/base/BUILD.gn
@@ -2394,14 +2394,6 @@ component("base") {
         "profiler/suspendable_thread_delegate_mac.h",
       ]
     }
-    if (!use_allocator_shim) {
-      sources -= [
-        "sampling_heap_profiler/poisson_allocation_sampler.cc",
-        "sampling_heap_profiler/poisson_allocation_sampler.h",
-        "sampling_heap_profiler/sampling_heap_profiler.cc",
-        "sampling_heap_profiler/sampling_heap_profiler.h",
-      ]
-    }
 
     frameworks += [
       "Foundation.framework",


### PR DESCRIPTION
This is a backport to not remove sampling_heap_profiler on iOS when use_allocator_shim is false. This fixes missing symbol linker errors when Cobalt builds with blaze.

Bug: 554092913

---
Original CL message:

base: Do not remove sampling_heap_profiler on iOS when use_allocator_shim is false

sampling_heap_profiler sources were historically removed on iOS when
use_allocator_shim = false to work around compiler TLS issues in legacy
Cronet iOS builds ([crbug.com/1075702](http://crbug.com/1075702)). Since
base/allocator/dispatcher/tls.h now uses POSIX pthread emulation, these
files compile cleanly on iOS.

Furthermore, with use_blink = true on iOS / tvOS,
blink::InspectorMemoryAgent and content::protocol::MemoryHandler
unconditionally depend on base::SamplingHeapProfiler. Removing this
exclusion allows builds with use_allocator_shim = false to link cleanly
and aligns iOS with macOS, Linux, Android, and Windows.

Bug: [553058307](https://issues.chromium.org/issues/553058307)
Change-Id: [I3c1f5ae55018fe47ba2730e3eb4d45ec284c7448](https://chromium-review.git.corp.google.com/q/I3c1f5ae55018fe47ba2730e3eb4d45ec284c7448)
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8298793
Reviewed-by: Mark Mentovai <[mark@chromium.org](mailto:mark@chromium.org)>
Reviewed-by: Rohit Rao <[rohitrao@chromium.org](mailto:rohitrao@chromium.org)>
Commit-Queue: Rohit Rao <[rohitrao@chromium.org](mailto:rohitrao@chromium.org)>
Cr-Commit-Position: refs/heads/main@{#1687445}