### PR TITLE
Temporary disable native heap profiler in 3P

### DIFF
--- a/starboard/build/config/modular/BUILD.gn
+++ b/starboard/build/config/modular/BUILD.gn
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import("//build/config/compiler/compiler.gni")
 import("//starboard/build/config/sanitizers.gni")
 
 config("modular") {
@@ -90,12 +89,6 @@ config("modular") {
       #         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
       "-Wno-sign-compare",
     ]
-
-    if (!cobalt_is_release_build || can_unwind_with_frame_pointers) {
-      cflags += [ "-fno-omit-frame-pointer" ]
-    } else {
-      cflags += [ "-fomit-frame-pointer" ]
-    }
   }
 
   if (use_asan) {

--- a/starboard/build/config/modular/arm/BUILD.gn
+++ b/starboard/build/config/modular/arm/BUILD.gn
@@ -26,9 +26,4 @@ config("arm") {
     # Force char to be signed.
     "-fsigned-char",
   ]
-
-  # Force ARM 32-bit mode (-marm) instead of Thumb-2 mode for non-release builds.
-  if (!cobalt_is_release_build) {
-    cflags += [ "-marm" ]
-  }
 }


### PR DESCRIPTION
Will enable the native heap profiler in non_official_build which is devel and debug, when b/[537056801](https://b.corp.google.com/issues/537056801) gets fixed.

Bug: 528397803