### PR TITLE
media: Remove storage_type parameter from DecodedAudio constructors

### DIFF
--- a/starboard/android/shared/audio_decoder_passthrough.h
+++ b/starboard/android/shared/audio_decoder_passthrough.h
@@ -67,8 +67,7 @@ class AudioDecoderPassthrough : public AudioDecoder {
     for (const auto& input_buffer : input_buffers) {
       DecodedAudio decoded_audio(
           kChannels, kSbMediaAudioSampleTypeInt16Deprecated,
-          kSbMediaAudioFrameStorageTypePlanar, input_buffer->timestamp(),
-          input_buffer->size());
+          input_buffer->timestamp(), input_buffer->size());
       memcpy(decoded_audio.data(), input_buffer->data(), input_buffer->size());
       decoded_audios_.push(std::move(decoded_audio));
       output_cb_();

--- a/starboard/android/shared/media_codec_audio_decoder.cc
+++ b/starboard/android/shared/media_codec_audio_decoder.cc
@@ -270,7 +270,6 @@ void MediaCodecAudioDecoder::ProcessOutputBuffer(
 
     DecodedAudio decoded_audio(
         audio_stream_info_.number_of_channels, sample_type_,
-        kSbMediaAudioFrameStorageTypeInterleaved,
         dequeue_output_result.presentation_time_microseconds, size);
 
     memcpy(decoded_audio.data(), data, size);

--- a/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.cc
@@ -258,8 +258,7 @@ void FfmpegAudioDecoderImpl<FFMPEG>::ProcessDecodedFrame(
 
   const SbMediaAudioSampleType sample_type = GetSampleType();
   DecodedAudio decoded_audio(
-      channel_count, sample_type, kSbMediaAudioFrameStorageTypeInterleaved,
-      input_buffer.timestamp(),
+      channel_count, sample_type, input_buffer.timestamp(),
       channel_count * av_frame.nb_samples * GetBytesPerSample(sample_type));
   const bool is_planar = (codec_context_->sample_fmt == AV_SAMPLE_FMT_S16P ||
                           codec_context_->sample_fmt == AV_SAMPLE_FMT_FLTP);

--- a/starboard/shared/libfdkaac/fdk_aac_audio_decoder.cc
+++ b/starboard/shared/libfdkaac/fdk_aac_audio_decoder.cc
@@ -220,7 +220,6 @@ void FdkAacAudioDecoder::TryToOutputDecodedAudio(const uint8_t* data,
       SB_DCHECK_EQ(partially_decoded_audio_data_in_bytes_, 0);
       partially_decoded_audio_ =
           DecodedAudio(num_channels_, kSbMediaAudioSampleTypeInt16Deprecated,
-                       kSbMediaAudioFrameStorageTypeInterleaved,
                        decoding_input_buffers_.front()->timestamp(),
                        decoded_audio_size_in_bytes_);
     }

--- a/starboard/shared/opus/opus_audio_decoder.cc
+++ b/starboard/shared/opus/opus_audio_decoder.cc
@@ -238,11 +238,11 @@ bool OpusAudioDecoder::DecodeInternal(
   SB_DCHECK(output_cb_);
   SB_DCHECK(!stream_ended_ || !pending_audio_buffers_.empty());
 
-  DecodedAudio decoded_audio(
-      audio_stream_info_.number_of_channels, GetSampleType(),
-      kSbMediaAudioFrameStorageTypeInterleaved, input_buffer->timestamp(),
-      audio_stream_info_.number_of_channels * frames_per_au_ *
-          GetBytesPerSample(GetSampleType()));
+  DecodedAudio decoded_audio(audio_stream_info_.number_of_channels,
+                             GetSampleType(), input_buffer->timestamp(),
+                             audio_stream_info_.number_of_channels *
+                                 frames_per_au_ *
+                                 GetBytesPerSample(GetSampleType()));
 
   const char kDecodeFunctionName[] = "opus_multistream_decode_float";
   int decoded_frames = opus_multistream_decode_float(

--- a/starboard/shared/starboard/player/decoded_audio_internal.cc
+++ b/starboard/shared/starboard/player/decoded_audio_internal.cc
@@ -78,12 +78,10 @@ DecodedAudio::DecodedAudio()
 
 DecodedAudio::DecodedAudio(int channels,
                            SbMediaAudioSampleType sample_type,
-                           SbMediaAudioFrameStorageType storage_type,
                            int64_t timestamp,
                            int size_in_bytes)
     : channels_(channels),
       sample_type_(sample_type),
-      storage_type_(storage_type),
       timestamp_(timestamp),
       storage_(size_in_bytes),
       offset_in_bytes_(0),
@@ -98,13 +96,11 @@ DecodedAudio::DecodedAudio(int channels,
 
 DecodedAudio::DecodedAudio(int channels,
                            SbMediaAudioSampleType sample_type,
-                           SbMediaAudioFrameStorageType storage_type,
                            int64_t timestamp,
                            int size_in_bytes,
                            Buffer&& storage)
     : channels_(channels),
       sample_type_(sample_type),
-      storage_type_(storage_type),
       timestamp_(timestamp),
       storage_(std::move(storage)),
       offset_in_bytes_(0),
@@ -244,8 +240,8 @@ DecodedAudio DecodedAudio::SwitchFormatTo(
 
   // Both sample types and storage types are different, use the slowest way.
   int new_size = GetBytesPerSample(new_sample_type) * frames() * channels();
-  DecodedAudio new_decoded_audio(channels(), new_sample_type, new_storage_type,
-                                 timestamp(), new_size);
+  DecodedAudio new_decoded_audio(channels(), new_sample_type, timestamp(),
+                                 new_size);
 
 #if defined(USE_NEON_FOR_AUDIO)
   if (enable_simd && channels() == 2 && IsAligned(frames(), 8)) {
@@ -315,8 +311,7 @@ DecodedAudio DecodedAudio::SwitchFormatTo(
 }
 
 DecodedAudio DecodedAudio::CloneForTesting() const {
-  DecodedAudio copy(channels(), sample_type(), storage_type(), timestamp(),
-                    size_in_bytes());
+  DecodedAudio copy(channels(), sample_type(), timestamp(), size_in_bytes());
 
   if (size_in_bytes() > 0) {
     memcpy(copy.data(), data(), size_in_bytes());
@@ -329,8 +324,8 @@ DecodedAudio DecodedAudio::SwitchSampleTypeTo(
     SbMediaAudioSampleType new_sample_type,
     bool enable_simd) const {
   int new_size = GetBytesPerSample(new_sample_type) * frames() * channels();
-  DecodedAudio new_decoded_audio(channels(), new_sample_type, storage_type(),
-                                 timestamp(), new_size);
+  DecodedAudio new_decoded_audio(channels(), new_sample_type, timestamp(),
+                                 new_size);
 
   if (sample_type_ == kSbMediaAudioSampleTypeInt16Deprecated &&
       new_sample_type == kSbMediaAudioSampleTypeFloat32) {
@@ -371,11 +366,13 @@ DecodedAudio DecodedAudio::SwitchSampleTypeTo(
   return new_decoded_audio;
 }
 
+// TODO: b/272837615 - Remove SwitchStorageTypeTo and planar format switching
+// support once planar audio frame cleanup is completed.
 DecodedAudio DecodedAudio::SwitchStorageTypeTo(
     SbMediaAudioFrameStorageType new_storage_type,
     bool enable_simd) const {
-  DecodedAudio new_decoded_audio(channels(), sample_type(), new_storage_type,
-                                 timestamp(), size_in_bytes());
+  DecodedAudio new_decoded_audio(channels(), sample_type(), timestamp(),
+                                 size_in_bytes());
   int bytes_per_sample = GetBytesPerSample(sample_type());
   const uint8_t* old_samples = this->data();
   uint8_t* new_samples = new_decoded_audio.data();

--- a/starboard/shared/starboard/player/decoded_audio_internal.h
+++ b/starboard/shared/starboard/player/decoded_audio_internal.h
@@ -34,13 +34,11 @@ class DecodedAudio {
   // samples to interleaved on creation.
   DecodedAudio(int channels,
                SbMediaAudioSampleType sample_type,
-               SbMediaAudioFrameStorageType storage_type,
                int64_t timestamp,
                int size_in_bytes);
 
   DecodedAudio(int channels,
                SbMediaAudioSampleType sample_type,
-               SbMediaAudioFrameStorageType storage_type,
                int64_t timestamp,
                int size_in_bytes,
                Buffer&& storage);
@@ -109,6 +107,8 @@ class DecodedAudio {
 
   DecodedAudio SwitchSampleTypeTo(SbMediaAudioSampleType new_sample_type,
                                   bool enable_simd) const;
+  // TODO: b/272837615 - Remove SwitchStorageTypeTo and planar format switching
+  // support once planar audio frame cleanup is completed.
   DecodedAudio SwitchStorageTypeTo(
       SbMediaAudioFrameStorageType new_storage_type,
       bool enable_simd) const;
@@ -127,7 +127,9 @@ class DecodedAudio {
 
   int channels_;
   SbMediaAudioSampleType sample_type_;
-  SbMediaAudioFrameStorageType storage_type_;
+  // TODO: b/272837615 - Remove this member variable once cleanup is completed.
+  SbMediaAudioFrameStorageType storage_type_ =
+      kSbMediaAudioFrameStorageTypeInterleaved;
   // The timestamp of the first audio frame in microseconds.
   int64_t timestamp_;
   Buffer storage_;

--- a/starboard/shared/starboard/player/decoded_audio_test_internal.cc
+++ b/starboard/shared/starboard/player/decoded_audio_test_internal.cc
@@ -32,9 +32,6 @@ constexpr double kPi = 3.1415926535897932384626;
 
 constexpr SbMediaAudioSampleType kSampleTypes[] = {
     kSbMediaAudioSampleTypeInt16Deprecated, kSbMediaAudioSampleTypeFloat32};
-constexpr SbMediaAudioFrameStorageType kStorageTypes[] = {
-    kSbMediaAudioFrameStorageTypeInterleaved,
-    kSbMediaAudioFrameStorageTypePlanar};
 
 // The following two functions fill `data` with audio samples of a sine wave
 // starting from `initial_angle`.  `stride` is the number of samples per group.
@@ -179,22 +176,21 @@ TEST(DecodedAudioTest, CreateEOSBuffer) {
 
 TEST(DecodedAudioTest, CtorWithSize) {
   for (auto sample_type : kSampleTypes) {
-    for (auto storage_type : kStorageTypes) {
-      DecodedAudio decoded_audio(kChannels, sample_type, storage_type,
-                                 kTimestampUsec, kSizeInBytes);
+    DecodedAudio decoded_audio(kChannels, sample_type, kTimestampUsec,
+                               kSizeInBytes);
 
-      EXPECT_FALSE(decoded_audio.is_end_of_stream());
-      EXPECT_EQ(decoded_audio.channels(), kChannels);
-      EXPECT_EQ(decoded_audio.sample_type(), sample_type);
-      EXPECT_EQ(decoded_audio.storage_type(), storage_type);
-      EXPECT_EQ(decoded_audio.size_in_bytes(), kSizeInBytes);
-      EXPECT_EQ(decoded_audio.frames(),
-                kSizeInBytes / GetBytesPerSample(decoded_audio.sample_type()) /
-                    kChannels);
+    EXPECT_FALSE(decoded_audio.is_end_of_stream());
+    EXPECT_EQ(decoded_audio.channels(), kChannels);
+    EXPECT_EQ(decoded_audio.sample_type(), sample_type);
+    EXPECT_EQ(decoded_audio.storage_type(),
+              kSbMediaAudioFrameStorageTypeInterleaved);
+    EXPECT_EQ(decoded_audio.size_in_bytes(), kSizeInBytes);
+    EXPECT_EQ(decoded_audio.frames(),
+              kSizeInBytes / GetBytesPerSample(decoded_audio.sample_type()) /
+                  kChannels);
 
-      Fill(&decoded_audio);
-      Verify(decoded_audio);
-    }
+    Fill(&decoded_audio);
+    Verify(decoded_audio);
   }
 }
 
@@ -204,8 +200,8 @@ TEST(DecodedAudioTest, CtorWithMoveCtor) {
 
   const uint8_t* original_data_pointer = original.data();
 
-  DecodedAudio decoded_audio(kChannels, kSampleTypes[0], kStorageTypes[0],
-                             kTimestampUsec, 128, std::move(original));
+  DecodedAudio decoded_audio(kChannels, kSampleTypes[0], kTimestampUsec, 128,
+                             std::move(original));
   ASSERT_EQ(decoded_audio.size_in_bytes(), 128);
   ASSERT_NE(decoded_audio.data(), nullptr);
   ASSERT_EQ(decoded_audio.data(), original_data_pointer);
@@ -218,9 +214,8 @@ TEST(DecodedAudioTest, CtorWithMoveCtor) {
 TEST(DecodedAudioTest, AdjustForSeekTime) {
   for (int channels = 1; channels <= 6; ++channels) {
     for (auto sample_type : kSampleTypes) {
-      DecodedAudio original_decoded_audio(
-          kChannels, sample_type, kSbMediaAudioFrameStorageTypeInterleaved,
-          kTimestampUsec, kSizeInBytes);
+      DecodedAudio original_decoded_audio(kChannels, sample_type,
+                                          kTimestampUsec, kSizeInBytes);
       Fill(&original_decoded_audio);
 
       DecodedAudio adjusted_decoded_audio =
@@ -273,9 +268,8 @@ TEST(DecodedAudioTest, AdjustForSeekTime) {
 TEST(DecodedAudioTest, AdjustForDiscardedDurations) {
   for (int channels = 1; channels <= 6; ++channels) {
     for (auto sample_type : kSampleTypes) {
-      DecodedAudio original_decoded_audio(
-          kChannels, sample_type, kSbMediaAudioFrameStorageTypeInterleaved,
-          kTimestampUsec, kSizeInBytes);
+      DecodedAudio original_decoded_audio(kChannels, sample_type,
+                                          kTimestampUsec, kSizeInBytes);
       Fill(&original_decoded_audio);
 
       DecodedAudio adjusted_decoded_audio =
@@ -315,34 +309,26 @@ TEST(DecodedAudioTest, AdjustForDiscardedDurations) {
 
 TEST(DecodedAudioTest, SwitchFormatTo) {
   for (auto original_sample_type : kSampleTypes) {
-    for (auto original_storage_type : kStorageTypes) {
-      DecodedAudio original_decoded_audio(kChannels, original_sample_type,
-                                          original_storage_type, kTimestampUsec,
-                                          kSizeInBytes);
+    DecodedAudio original_decoded_audio(kChannels, original_sample_type,
+                                        kTimestampUsec, kSizeInBytes);
 
-      Fill(&original_decoded_audio);
+    Fill(&original_decoded_audio);
 
-      for (auto new_sample_type : kSampleTypes) {
-        for (auto new_storage_type : kStorageTypes) {
-          if (!original_decoded_audio.IsFormat(new_sample_type,
-                                               new_storage_type)) {
-            DecodedAudio new_decoded_audio =
-                original_decoded_audio.SwitchFormatTo(new_sample_type,
-                                                      new_storage_type);
+    for (auto new_sample_type : kSampleTypes) {
+      if (original_decoded_audio.sample_type() != new_sample_type) {
+        DecodedAudio new_decoded_audio = original_decoded_audio.SwitchFormatTo(
+            new_sample_type, kSbMediaAudioFrameStorageTypeInterleaved);
 
-            EXPECT_FALSE(new_decoded_audio.is_end_of_stream());
-            EXPECT_EQ(new_decoded_audio.channels(),
-                      original_decoded_audio.channels());
-            EXPECT_EQ(new_decoded_audio.timestamp(),
-                      original_decoded_audio.timestamp());
-            EXPECT_EQ(new_decoded_audio.frames(),
-                      original_decoded_audio.frames());
-            EXPECT_TRUE(
-                new_decoded_audio.IsFormat(new_sample_type, new_storage_type));
+        EXPECT_FALSE(new_decoded_audio.is_end_of_stream());
+        EXPECT_EQ(new_decoded_audio.channels(),
+                  original_decoded_audio.channels());
+        EXPECT_EQ(new_decoded_audio.timestamp(),
+                  original_decoded_audio.timestamp());
+        EXPECT_EQ(new_decoded_audio.frames(), original_decoded_audio.frames());
+        EXPECT_TRUE(new_decoded_audio.IsFormat(
+            new_sample_type, kSbMediaAudioFrameStorageTypeInterleaved));
 
-            ASSERT_NO_FATAL_FAILURE(Verify(new_decoded_audio));
-          }
-        }
+        ASSERT_NO_FATAL_FAILURE(Verify(new_decoded_audio));
       }
     }
   }
@@ -350,9 +336,8 @@ TEST(DecodedAudioTest, SwitchFormatTo) {
 
 TEST(DecodedAudioTest, Clone) {
   for (auto sample_type : kSampleTypes) {
-    DecodedAudio decoded_audio(kChannels, sample_type,
-                               kSbMediaAudioFrameStorageTypeInterleaved,
-                               kTimestampUsec, kSizeInBytes);
+    DecodedAudio decoded_audio(kChannels, sample_type, kTimestampUsec,
+                               kSizeInBytes);
     Fill(&decoded_audio);
     auto copy = decoded_audio.CloneForTesting();
     ASSERT_EQ(copy, decoded_audio);
@@ -364,11 +349,10 @@ TEST(DecodedAudioTest, Clone) {
 
 class DecodedAudioNeonTest : public ::testing::Test {
  protected:
-  DecodedAudio CreateInt16PlanarRamp(int total_samples) {
+  DecodedAudio CreateInt16InterleavedRamp(int total_samples) {
     int size_in_bytes = total_samples * sizeof(int16_t);
     DecodedAudio base(kChannels, kSbMediaAudioSampleTypeInt16Deprecated,
-                      kSbMediaAudioFrameStorageTypePlanar, kTimestampUsec,
-                      size_in_bytes);
+                      kTimestampUsec, size_in_bytes);
     int16_t* data = base.data_as_int16();
     for (int i = 0; i < total_samples; ++i) {
       data[i] = static_cast<int16_t>(i - 32768);
@@ -378,8 +362,7 @@ class DecodedAudioNeonTest : public ::testing::Test {
 
   DecodedAudio CreateFloat32InterleavedRamp(int total_samples) {
     int size_in_bytes = total_samples * sizeof(float);
-    DecodedAudio base(kChannels, kSbMediaAudioSampleTypeFloat32,
-                      kSbMediaAudioFrameStorageTypeInterleaved, kTimestampUsec,
+    DecodedAudio base(kChannels, kSbMediaAudioSampleTypeFloat32, kTimestampUsec,
                       size_in_bytes);
     float* data = base.data_as_float32();
     for (int i = 0; i < total_samples; ++i) {
@@ -419,93 +402,26 @@ class DecodedAudioNeonTest : public ::testing::Test {
 };
 
 TEST_F(DecodedAudioNeonTest, SwitchFormatTo_NeonSimdExhaustive) {
-  // 1. Test conversions starting from Int16 Planar (65536 samples)
-  auto int16_planar_base = CreateInt16PlanarRamp(65536);
-
-  // Test Case 1: Int16 Planar -> Float32 Interleaved
-  VerifySwitchFormat(int16_planar_base, kSbMediaAudioSampleTypeFloat32,
+  // 1. Test Int16 Interleaved -> Float32 Interleaved
+  auto int16_interleaved = CreateInt16InterleavedRamp(65536);
+  VerifySwitchFormat(int16_interleaved, kSbMediaAudioSampleTypeFloat32,
                      kSbMediaAudioFrameStorageTypeInterleaved);
 
-  // Test Case 2: Int16 Planar -> Float32 Planar
-  VerifySwitchFormat(int16_planar_base, kSbMediaAudioSampleTypeFloat32,
-                     kSbMediaAudioFrameStorageTypePlanar);
-
-  // 2. Test conversions starting from Float32 Interleaved (8000 samples)
-  auto float_interleaved_base = CreateFloat32InterleavedRamp(8000);
-
-  // Test Case 3: Float32 Interleaved -> Int16 Planar
-  VerifySwitchFormat(float_interleaved_base,
-                     kSbMediaAudioSampleTypeInt16Deprecated,
-                     kSbMediaAudioFrameStorageTypePlanar);
-
-  // Test Case 4: Float32 Interleaved -> Int16 Interleaved
-  VerifySwitchFormat(float_interleaved_base,
-                     kSbMediaAudioSampleTypeInt16Deprecated,
-                     kSbMediaAudioFrameStorageTypeInterleaved);
-
-  // Test Case 5: Int16 Planar -> Int16 Interleaved
-  VerifySwitchFormat(int16_planar_base, kSbMediaAudioSampleTypeInt16Deprecated,
-                     kSbMediaAudioFrameStorageTypeInterleaved);
-
-  // Test Case 6: Int16 Interleaved -> Int16 Planar
-  auto int16_interleaved = int16_planar_base.SwitchFormatTo(
-      kSbMediaAudioSampleTypeInt16Deprecated,
-      kSbMediaAudioFrameStorageTypeInterleaved, /*force_simd=*/false);
-  VerifySwitchFormat(int16_interleaved, kSbMediaAudioSampleTypeInt16Deprecated,
-                     kSbMediaAudioFrameStorageTypePlanar);
-
-  // Test Case 7: Float32 Interleaved -> Float32 Planar
-  VerifySwitchFormat(float_interleaved_base, kSbMediaAudioSampleTypeFloat32,
-                     kSbMediaAudioFrameStorageTypePlanar);
-
-  // Test Case 8: Float32 Planar -> Float32 Interleaved
-  auto float_planar = float_interleaved_base.SwitchFormatTo(
-      kSbMediaAudioSampleTypeFloat32, kSbMediaAudioFrameStorageTypePlanar,
-      /*force_simd=*/false);
-  VerifySwitchFormat(float_planar, kSbMediaAudioSampleTypeFloat32,
+  // 2. Test Float32 Interleaved -> Int16 Interleaved
+  auto float_interleaved = CreateFloat32InterleavedRamp(8000);
+  VerifySwitchFormat(float_interleaved, kSbMediaAudioSampleTypeInt16Deprecated,
                      kSbMediaAudioFrameStorageTypeInterleaved);
 }
 
 TEST_F(DecodedAudioNeonTest, SwitchFormatTo_NeonSimdUnaligned) {
   // Test with unaligned sizes (non-multiples of 8/16) to verify C++ scalar
-  // fallbacks. 65536 + 14 is non-multiple of 16 (for Int16 -> Float32)
-  auto int16_planar_base = CreateInt16PlanarRamp(65536 + 14);
-
-  // Int16 Planar -> Float32 Interleaved
-  VerifySwitchFormat(int16_planar_base, kSbMediaAudioSampleTypeFloat32,
+  // fallbacks.
+  auto int16_interleaved = CreateInt16InterleavedRamp(65536 + 14);
+  VerifySwitchFormat(int16_interleaved, kSbMediaAudioSampleTypeFloat32,
                      kSbMediaAudioFrameStorageTypeInterleaved);
 
-  // Float32 Interleaved -> Int16 Planar
-  auto float_interleaved_base = CreateFloat32InterleavedRamp(8000 + 14);
-  VerifySwitchFormat(float_interleaved_base,
-                     kSbMediaAudioSampleTypeInt16Deprecated,
-                     kSbMediaAudioFrameStorageTypePlanar);
-
-  // Float32 Interleaved -> Int16 Interleaved
-  VerifySwitchFormat(float_interleaved_base,
-                     kSbMediaAudioSampleTypeInt16Deprecated,
-                     kSbMediaAudioFrameStorageTypeInterleaved);
-
-  // Int16 Planar -> Int16 Interleaved
-  VerifySwitchFormat(int16_planar_base, kSbMediaAudioSampleTypeInt16Deprecated,
-                     kSbMediaAudioFrameStorageTypeInterleaved);
-
-  // Int16 Interleaved -> Int16 Planar
-  auto int16_interleaved = int16_planar_base.SwitchFormatTo(
-      kSbMediaAudioSampleTypeInt16Deprecated,
-      kSbMediaAudioFrameStorageTypeInterleaved, /*force_simd=*/false);
-  VerifySwitchFormat(int16_interleaved, kSbMediaAudioSampleTypeInt16Deprecated,
-                     kSbMediaAudioFrameStorageTypePlanar);
-
-  // Float32 Interleaved -> Float32 Planar
-  VerifySwitchFormat(float_interleaved_base, kSbMediaAudioSampleTypeFloat32,
-                     kSbMediaAudioFrameStorageTypePlanar);
-
-  // Float32 Planar -> Float32 Interleaved
-  auto float_planar = float_interleaved_base.SwitchFormatTo(
-      kSbMediaAudioSampleTypeFloat32, kSbMediaAudioFrameStorageTypePlanar,
-      /*force_simd=*/false);
-  VerifySwitchFormat(float_planar, kSbMediaAudioSampleTypeFloat32,
+  auto float_interleaved = CreateFloat32InterleavedRamp(8000 + 14);
+  VerifySwitchFormat(float_interleaved, kSbMediaAudioSampleTypeInt16Deprecated,
                      kSbMediaAudioFrameStorageTypeInterleaved);
 }
 

--- a/starboard/shared/starboard/player/filter/audio_channel_layout_mixer_impl.cc
+++ b/starboard/shared/starboard/player/filter/audio_channel_layout_mixer_impl.cc
@@ -255,6 +255,8 @@ class AudioChannelLayoutMixerImpl : public AudioChannelLayoutMixer {
   DecodedAudio MixMonoToStereoOptimized(const DecodedAudio& input);
 
   SbMediaAudioSampleType sample_type_;
+  // TODO: b/272837615 - Remove storage_type_ and planar branches, once
+  // planar storage type cleanup is completed.
   SbMediaAudioFrameStorageType storage_type_;
   int output_channels_;
 };
@@ -334,7 +336,7 @@ DecodedAudio AudioChannelLayoutMixerImpl::Mix(const DecodedAudio& input,
                                               const float* matrix) {
   size_t frames = input.frames();
   DecodedAudio output(
-      output_channels_, sample_type_, storage_type_, input.timestamp(),
+      output_channels_, sample_type_, input.timestamp(),
       frames * output_channels_ * GetBytesPerSample(sample_type_));
   SampleType aux_buffer[8];
   SampleType output_buffer[8];
@@ -353,8 +355,8 @@ DecodedAudio AudioChannelLayoutMixerImpl::MixMonoToStereoOptimized(
   SB_DCHECK_EQ(output_channels_, 2);
   SB_DCHECK_EQ(input.channels(), 1);
 
-  DecodedAudio output(output_channels_, sample_type_, storage_type_,
-                      input.timestamp(), input.size_in_bytes() * 2);
+  DecodedAudio output(output_channels_, sample_type_, input.timestamp(),
+                      input.size_in_bytes() * 2);
   if (storage_type_ == kSbMediaAudioFrameStorageTypeInterleaved) {
     size_t frames_left = input.frames();
     size_t bytes_per_sample = GetBytesPerSample(sample_type_);

--- a/starboard/shared/starboard/player/filter/audio_resampler_impl.cc
+++ b/starboard/shared/starboard/player/filter/audio_resampler_impl.cc
@@ -92,7 +92,6 @@ std::optional<DecodedAudio> AudioResamplerImpl::WriteEndOfStream() {
       int channels = interleaved_resampler_.channels();
       int resampled_audio_size = out_num_of_frames * channels * sizeof(float);
       DecodedAudio resampled_audio(channels, kSbMediaAudioSampleTypeFloat32,
-                                   kSbMediaAudioFrameStorageTypeInterleaved,
                                    audio_inputs_.front().timestamp(),
                                    resampled_audio_size);
 
@@ -144,7 +143,6 @@ std::optional<DecodedAudio> AudioResamplerImpl::Resample(
   if (interleaved_resampler_.HasEnoughData(num_of_output_frames)) {
     int output_audio_size = num_of_output_frames * channels * sizeof(float);
     DecodedAudio output(channels, kSbMediaAudioSampleTypeFloat32,
-                        kSbMediaAudioFrameStorageTypeInterleaved,
                         next_audio_to_output.timestamp(), output_audio_size);
     float* dst = reinterpret_cast<float*>(output.data());
     interleaved_resampler_.Resample(dst, num_of_output_frames);

--- a/starboard/shared/starboard/player/filter/audio_time_stretcher.cc
+++ b/starboard/shared/starboard/player/filter/audio_time_stretcher.cc
@@ -148,21 +148,19 @@ void AudioTimeStretcher::Initialize(SbMediaAudioSampleType sample_type,
   transition_window_.reset(new float[ola_window_size_ * 2]);
   GetPeriodicHanningWindow(2 * ola_window_size_, transition_window_.get());
 
-  wsola_output_ = DecodedAudio(
-      channels_, sample_type_, kSbMediaAudioFrameStorageTypeInterleaved, 0,
-      (ola_window_size_ + ola_hop_size_) * bytes_per_frame_);
+  wsola_output_ =
+      DecodedAudio(channels_, sample_type_, /*timestamp=*/0,
+                   (ola_window_size_ + ola_hop_size_) * bytes_per_frame_);
   // Initialize for overlap-and-add of the first block.
   memset(wsola_output_.data(), 0, wsola_output_.size_in_bytes());
 
   // Auxiliary containers.
-  optimal_block_ = DecodedAudio(channels_, sample_type_,
-                                kSbMediaAudioFrameStorageTypeInterleaved, 0,
+  optimal_block_ = DecodedAudio(channels_, sample_type_, /*timestamp=*/0,
                                 ola_window_size_ * bytes_per_frame_);
   search_block_ = DecodedAudio(
-      channels_, sample_type_, kSbMediaAudioFrameStorageTypeInterleaved, 0,
+      channels_, sample_type_, /*timestamp=*/0,
       (num_candidate_blocks_ + (ola_window_size_ - 1)) * bytes_per_frame_);
-  target_block_ = DecodedAudio(channels_, sample_type_,
-                               kSbMediaAudioFrameStorageTypeInterleaved, 0,
+  target_block_ = DecodedAudio(channels_, sample_type_, /*timestamp=*/0,
                                ola_window_size_ * bytes_per_frame_);
 }
 
@@ -171,8 +169,7 @@ DecodedAudio AudioTimeStretcher::Read(int requested_frames,
   SB_DCHECK_GT(bytes_per_frame_, 0);
   SB_DCHECK_GE(playback_rate, 0);
 
-  DecodedAudio dest(channels_, sample_type_,
-                    kSbMediaAudioFrameStorageTypeInterleaved, 0,
+  DecodedAudio dest(channels_, sample_type_, /*timestamp=*/0,
                     requested_frames * bytes_per_frame_);
 
   if (playback_rate == 0) {

--- a/starboard/shared/starboard/player/filter/stub_audio_decoder.cc
+++ b/starboard/shared/starboard/player/filter/stub_audio_decoder.cc
@@ -56,9 +56,8 @@ DecodedAudio CreateDecodedAudio(int64_t timestamp,
                                 int number_of_channels,
                                 int frames) {
   int sample_size = GetBytesPerSample(sample_type);
-  DecodedAudio decoded_audio(
-      number_of_channels, sample_type, kSbMediaAudioFrameStorageTypeInterleaved,
-      timestamp, sample_size * number_of_channels * frames);
+  DecodedAudio decoded_audio(number_of_channels, sample_type, timestamp,
+                             sample_size * number_of_channels * frames);
 
   for (int j = 0; j < decoded_audio.size_in_bytes() / sample_size; ++j) {
     if (sample_size == 2) {
@@ -216,10 +215,8 @@ void StubAudioDecoder::DecodeOneBuffer(
             decoded_audio.timestamp() +
             AudioDurationToFrames(offset_in_frames, samples_per_second_);
 
-        DecodedAudio current_decoded_audio(
-            number_of_channels_, sample_type_,
-            kSbMediaAudioFrameStorageTypeInterleaved, timestamp,
-            size_in_bytes_of_output);
+        DecodedAudio current_decoded_audio(number_of_channels_, sample_type_,
+                                           timestamp, size_in_bytes_of_output);
         memcpy(current_decoded_audio.data(),
                decoded_audio.data() + offset_in_bytes, size_in_bytes_of_output);
         offset_in_bytes += size_in_bytes_of_output;

--- a/starboard/shared/starboard/player/filter/testing/audio_channel_layout_mixer_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_channel_layout_mixer_test.cc
@@ -81,7 +81,7 @@ class AudioChannelLayoutMixerTest
     }
 
     DecodedAudio decoded_audio(
-        num_of_channels, sample_type_, storage_type_, 0,
+        num_of_channels, sample_type_, /*timestamp=*/0,
         kInputFrames * num_of_channels *
             (sample_type_ == kSbMediaAudioSampleTypeFloat32 ? 4 : 2));
 

--- a/starboard/shared/starboard/player/filter/testing/audio_channel_layout_mixer_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_channel_layout_mixer_test.cc
@@ -28,20 +28,14 @@
 namespace starboard {
 namespace {
 
-using ::testing::Combine;
 using ::testing::Values;
 
 class AudioChannelLayoutMixerTest
-    : public ::testing::TestWithParam<
-          std::tuple<SbMediaAudioSampleType, SbMediaAudioFrameStorageType>> {
+    : public ::testing::TestWithParam<SbMediaAudioSampleType> {
  protected:
-  AudioChannelLayoutMixerTest()
-      : sample_type_(std::get<0>(GetParam())),
-        storage_type_(std::get<1>(GetParam())) {
+  AudioChannelLayoutMixerTest() : sample_type_(GetParam()) {
     SB_DCHECK(sample_type_ == kSbMediaAudioSampleTypeInt16Deprecated ||
               sample_type_ == kSbMediaAudioSampleTypeFloat32);
-    SB_DCHECK(storage_type_ == kSbMediaAudioFrameStorageTypeInterleaved ||
-              storage_type_ == kSbMediaAudioFrameStorageTypePlanar);
   }
 
   DecodedAudio GetTestDecodedAudio(int num_of_channels) {
@@ -88,21 +82,12 @@ class AudioChannelLayoutMixerTest
     if (sample_type_ == kSbMediaAudioSampleTypeFloat32) {
       float* dest_buffer = reinterpret_cast<float*>(decoded_audio.data());
       for (size_t i = 0; i < num_of_channels * kInputFrames; i++) {
-        int src_index = i;
-        if (storage_type_ == kSbMediaAudioFrameStorageTypePlanar) {
-          src_index = i % kInputFrames * num_of_channels + i / kInputFrames;
-        }
-        dest_buffer[i] = data_buffer[src_index];
+        dest_buffer[i] = data_buffer[i];
       }
     } else {
       int16_t* dest_buffer = reinterpret_cast<int16_t*>(decoded_audio.data());
       for (size_t i = 0; i < num_of_channels * kInputFrames; i++) {
-        int src_index = i;
-        if (storage_type_ == kSbMediaAudioFrameStorageTypePlanar) {
-          src_index = i % kInputFrames * num_of_channels + i / kInputFrames;
-        }
-        dest_buffer[i] =
-            data_buffer[src_index] * std::numeric_limits<int16_t>::max();
+        dest_buffer[i] = data_buffer[i] * std::numeric_limits<int16_t>::max();
       }
     }
     return decoded_audio;
@@ -125,18 +110,12 @@ class AudioChannelLayoutMixerTest
       for (size_t i = 0;
            i < static_cast<size_t>(output.frames()) * output_num_of_channels;
            i++) {
-        size_t src_index = i;
-        if (storage_type_ == kSbMediaAudioFrameStorageTypePlanar) {
-          src_index = i % output.frames() * output_num_of_channels +
-                      i / output.frames();
-        }
-        if (expected_output[src_index] >= 1.0f) {
+        if (expected_output[i] >= 1.0f) {
           ASSERT_GE(output_buffer[i], 0.999f);
-        } else if (expected_output[src_index] <= -0.999f) {
+        } else if (expected_output[i] <= -0.999f) {
           ASSERT_LE(output_buffer[i], -1.0f);
         } else {
-          ASSERT_LE(fabs(expected_output[src_index] - output_buffer[i]),
-                    0.001f);
+          ASSERT_LE(fabs(expected_output[i] - output_buffer[i]), 0.001f);
         }
       }
     } else {
@@ -145,13 +124,8 @@ class AudioChannelLayoutMixerTest
       for (size_t i = 0;
            i < static_cast<size_t>(output.frames()) * output_num_of_channels;
            i++) {
-        size_t src_index = i;
-        if (storage_type_ == kSbMediaAudioFrameStorageTypePlanar) {
-          src_index = i % output.frames() * output_num_of_channels +
-                      i / output.frames();
-        }
         ASSERT_LE(
-            fabs(expected_output[src_index] -
+            fabs(expected_output[i] -
                  static_cast<float>(output_buffer[i]) /
                      static_cast<float>(std::numeric_limits<int16_t>::max())),
             0.001f);
@@ -160,23 +134,15 @@ class AudioChannelLayoutMixerTest
   }
 
   SbMediaAudioSampleType sample_type_;
-  SbMediaAudioFrameStorageType storage_type_;
+  SbMediaAudioFrameStorageType storage_type_ =
+      kSbMediaAudioFrameStorageTypeInterleaved;
 };
 
 std::string GetAudioChannelLayoutMixerTestConfigName(
-    ::testing::TestParamInfo<std::tuple<SbMediaAudioSampleType,
-                                        SbMediaAudioFrameStorageType>> info) {
-  SbMediaAudioSampleType sample_type = std::get<0>(info.param);
-  SbMediaAudioFrameStorageType frame_storage_type = std::get<1>(info.param);
-
-  return FormatString(
-      "%s_%s",
-      sample_type == kSbMediaAudioSampleTypeInt16Deprecated
-          ? "SampleTypeInt16"
-          : "SampleTypeFloat32",
-      frame_storage_type == kSbMediaAudioFrameStorageTypeInterleaved
-          ? "StorageTypeInterleaved"
-          : "StorageTypePlanar");
+    ::testing::TestParamInfo<SbMediaAudioSampleType> info) {
+  return info.param == kSbMediaAudioSampleTypeInt16Deprecated
+             ? "SampleTypeInt16"
+             : "SampleTypeFloat32";
 }
 
 TEST_P(AudioChannelLayoutMixerTest, MixToMono) {
@@ -348,14 +314,11 @@ TEST_P(AudioChannelLayoutMixerTest, MixToFivePointOne) {
                                kExpectedFivePointOneToFivePointOneOutput);
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    AudioChannelLayoutMixerTests,
-    AudioChannelLayoutMixerTest,
-    Combine(Values(kSbMediaAudioSampleTypeInt16Deprecated,
-                   kSbMediaAudioSampleTypeFloat32),
-            Values(kSbMediaAudioFrameStorageTypeInterleaved,
-                   kSbMediaAudioFrameStorageTypePlanar)),
-    GetAudioChannelLayoutMixerTestConfigName);
+INSTANTIATE_TEST_SUITE_P(AudioChannelLayoutMixerTests,
+                         AudioChannelLayoutMixerTest,
+                         Values(kSbMediaAudioSampleTypeInt16Deprecated,
+                                kSbMediaAudioSampleTypeFloat32),
+                         GetAudioChannelLayoutMixerTestConfigName);
 
 }  // namespace
 

--- a/starboard/shared/starboard/player/filter/testing/audio_decoder_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_decoder_test.cc
@@ -55,8 +55,8 @@ const int64_t kWaitForNextEventTimeOut = 5'000'000;  // 5 seconds
 DecodedAudio ConsolidateDecodedAudios(
     const std::vector<DecodedAudio>& decoded_audios) {
   if (decoded_audios.empty()) {
-    return DecodedAudio(2, kSbMediaAudioSampleTypeFloat32,
-                        kSbMediaAudioFrameStorageTypeInterleaved, 0, 0);
+    return DecodedAudio(2, kSbMediaAudioSampleTypeFloat32, /*timestamp=*/0,
+                        /*size_in_bytes=*/0);
   }
 
   int total_size_in_bytes = 0;
@@ -71,9 +71,9 @@ DecodedAudio ConsolidateDecodedAudios(
     total_size_in_bytes += decoded_audio.size_in_bytes();
   }
 
-  DecodedAudio consolidated(
-      channels, sample_type, kSbMediaAudioFrameStorageTypeInterleaved,
-      decoded_audios.front().timestamp(), total_size_in_bytes);
+  DecodedAudio consolidated(channels, sample_type,
+                            decoded_audios.front().timestamp(),
+                            total_size_in_bytes);
 
   int offset_in_bytes = 0;
   for (const auto& decoded_audio : decoded_audios) {

--- a/starboard/shared/starboard/player/filter/testing/audio_frame_discarder_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_frame_discarder_test.cc
@@ -40,8 +40,7 @@ class AudioFrameDiscarderTest : public ::testing::TestWithParam<const char*> {
 
 DecodedAudio MakeDecodedAudio(int channels, int64_t timestamp) {
   DecodedAudio decoded_audio(
-      channels, kSbMediaAudioSampleTypeFloat32,
-      kSbMediaAudioFrameStorageTypeInterleaved, timestamp,
+      channels, kSbMediaAudioSampleTypeFloat32, timestamp,
       GetBytesPerSample(kSbMediaAudioSampleTypeFloat32) * channels * 1536);
 
   memset(decoded_audio.data(), timestamp % 256, decoded_audio.size_in_bytes());

--- a/starboard/shared/starboard/player/filter/testing/audio_renderer_internal_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_renderer_internal_test.cc
@@ -215,7 +215,7 @@ class AudioRendererTest : public ::testing::Test {
 
   DecodedAudio CreateDecodedAudio(int64_t timestamp, int frames) {
     DecodedAudio decoded_audio(
-        kDefaultNumberOfChannels, sample_type_, storage_type_, timestamp,
+        kDefaultNumberOfChannels, sample_type_, timestamp,
         frames * kDefaultNumberOfChannels * GetBytesPerSample(sample_type_));
     memset(decoded_audio.data(), 0, decoded_audio.size_in_bytes());
     return decoded_audio;

--- a/starboard/shared/starboard/player/filter/testing/audio_resampler_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_resampler_test.cc
@@ -95,7 +95,7 @@ class AudioResamplerTest
               ? sizeof(int16_t)
               : sizeof(float);
       int audio_size = kSamplesPerInput * channels_ * sample_size;
-      DecodedAudio input(channels_, source_sample_type_, source_storage_type_,
+      DecodedAudio input(channels_, source_sample_type_,
                          1'000'000LL * total_frames / source_sample_rate_,
                          audio_size);
       total_frames += kSamplesPerInput;

--- a/starboard/shared/starboard/player/filter/testing/decoded_audio_benchmark.cc
+++ b/starboard/shared/starboard/player/filter/testing/decoded_audio_benchmark.cc
@@ -23,23 +23,9 @@ constexpr int64_t kTimestampUsec = 1'000'000;
 constexpr int kNumFrames = 2048;  // Realistic audio frame size
 constexpr int kSizeInBytes = kNumFrames * kChannels * sizeof(int16_t);
 
-DecodedAudio CreateInt16PlanarBuffer() {
-  DecodedAudio buffer(kChannels, kSbMediaAudioSampleTypeInt16Deprecated,
-                      kSbMediaAudioFrameStorageTypePlanar, kTimestampUsec,
-                      kSizeInBytes);
-  int16_t* data = buffer.data_as_int16();
-  for (int i = 0; i < kNumFrames * kChannels; ++i) {
-    // Generates a linear ramp covering the full range of int16_t [-32768,
-    // 32767].
-    data[i] = static_cast<int16_t>(i % 65536 - 32768);
-  }
-  return buffer;
-}
-
 DecodedAudio CreateFloatInterleavedBuffer() {
   int float_size = kNumFrames * kChannels * sizeof(float);
-  DecodedAudio buffer(kChannels, kSbMediaAudioSampleTypeFloat32,
-                      kSbMediaAudioFrameStorageTypeInterleaved, kTimestampUsec,
+  DecodedAudio buffer(kChannels, kSbMediaAudioSampleTypeFloat32, kTimestampUsec,
                       float_size);
   float* data = buffer.data_as_float32();
   for (int i = 0; i < kNumFrames * kChannels; ++i) {
@@ -52,8 +38,7 @@ DecodedAudio CreateFloatInterleavedBuffer() {
 
 DecodedAudio CreateInt16InterleavedBuffer() {
   DecodedAudio buffer(kChannels, kSbMediaAudioSampleTypeInt16Deprecated,
-                      kSbMediaAudioFrameStorageTypeInterleaved, kTimestampUsec,
-                      kSizeInBytes);
+                      kTimestampUsec, kSizeInBytes);
   int16_t* data = buffer.data_as_int16();
   for (int i = 0; i < kNumFrames * kChannels; ++i) {
     // Generates a linear ramp covering the full range of int16_t [-32768,
@@ -63,78 +48,11 @@ DecodedAudio CreateInt16InterleavedBuffer() {
   return buffer;
 }
 
-DecodedAudio CreateFloatPlanarBuffer() {
-  int float_size = kNumFrames * kChannels * sizeof(float);
-  DecodedAudio buffer(kChannels, kSbMediaAudioSampleTypeFloat32,
-                      kSbMediaAudioFrameStorageTypePlanar, kTimestampUsec,
-                      float_size);
-  float* data = buffer.data_as_float32();
-  for (int i = 0; i < kNumFrames * kChannels; ++i) {
-    // Generates a linear ramp of float values in [-1.0f, 1.0f] spanning the
-    // full audio range.
-    data[i] = -1.0f + 2.0f * (static_cast<float>(i) / (kNumFrames * kChannels));
-  }
-  return buffer;
-}
-
-void BM_SwitchFormat_Int16PlanarToFloatInterleaved_Cpp(
-    benchmark::State& state) {
-  auto src = CreateInt16PlanarBuffer();
-  for (auto _ : state) {
-    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
-                                  kSbMediaAudioFrameStorageTypeInterleaved,
-                                  /*force_simd=*/false);
-    benchmark::DoNotOptimize(dst);
-  }
-  state.SetItemsProcessed(state.iterations() * kNumFrames);
-}
-BENCHMARK(BM_SwitchFormat_Int16PlanarToFloatInterleaved_Cpp);
-
-void BM_SwitchFormat_Int16PlanarToFloatInterleaved_Neon(
-    benchmark::State& state) {
-  auto src = CreateInt16PlanarBuffer();
-  for (auto _ : state) {
-    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
-                                  kSbMediaAudioFrameStorageTypeInterleaved,
-                                  /*force_simd=*/true);
-    benchmark::DoNotOptimize(dst);
-  }
-  state.SetItemsProcessed(state.iterations() * kNumFrames);
-}
-BENCHMARK(BM_SwitchFormat_Int16PlanarToFloatInterleaved_Neon);
-
-void BM_SwitchFormat_FloatInterleavedToInt16Planar_Cpp(
-    benchmark::State& state) {
-  auto src = CreateFloatInterleavedBuffer();
-  for (auto _ : state) {
-    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeInt16Deprecated,
-                                  kSbMediaAudioFrameStorageTypePlanar,
-                                  /*force_simd=*/false);
-    benchmark::DoNotOptimize(dst);
-  }
-  state.SetItemsProcessed(state.iterations() * kNumFrames);
-}
-BENCHMARK(BM_SwitchFormat_FloatInterleavedToInt16Planar_Cpp);
-
-void BM_SwitchFormat_FloatInterleavedToInt16Planar_Neon(
-    benchmark::State& state) {
-  auto src = CreateFloatInterleavedBuffer();
-  for (auto _ : state) {
-    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeInt16Deprecated,
-                                  kSbMediaAudioFrameStorageTypePlanar,
-                                  /*force_simd=*/true);
-    benchmark::DoNotOptimize(dst);
-  }
-  state.SetItemsProcessed(state.iterations() * kNumFrames);
-}
-BENCHMARK(BM_SwitchFormat_FloatInterleavedToInt16Planar_Neon);
-
 void BM_SwitchSampleType_Int16ToFloat_Cpp(benchmark::State& state) {
-  auto src = CreateInt16PlanarBuffer();  // SwitchSampleTypeTo keeps same
-                                         // storage (planar)
+  auto src = CreateInt16InterleavedBuffer();
   for (auto _ : state) {
     auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
-                                  kSbMediaAudioFrameStorageTypePlanar,
+                                  kSbMediaAudioFrameStorageTypeInterleaved,
                                   /*force_simd=*/false);
     benchmark::DoNotOptimize(dst);
   }
@@ -143,10 +61,10 @@ void BM_SwitchSampleType_Int16ToFloat_Cpp(benchmark::State& state) {
 BENCHMARK(BM_SwitchSampleType_Int16ToFloat_Cpp);
 
 void BM_SwitchSampleType_Int16ToFloat_Neon(benchmark::State& state) {
-  auto src = CreateInt16PlanarBuffer();
+  auto src = CreateInt16InterleavedBuffer();
   for (auto _ : state) {
     auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
-                                  kSbMediaAudioFrameStorageTypePlanar,
+                                  kSbMediaAudioFrameStorageTypeInterleaved,
                                   /*force_simd=*/true);
     benchmark::DoNotOptimize(dst);
   }
@@ -155,7 +73,7 @@ void BM_SwitchSampleType_Int16ToFloat_Neon(benchmark::State& state) {
 BENCHMARK(BM_SwitchSampleType_Int16ToFloat_Neon);
 
 void BM_SwitchSampleType_FloatToInt16_Cpp(benchmark::State& state) {
-  auto src = CreateFloatInterleavedBuffer();  // keeps interleaved
+  auto src = CreateFloatInterleavedBuffer();
   for (auto _ : state) {
     auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeInt16Deprecated,
                                   kSbMediaAudioFrameStorageTypeInterleaved,
@@ -177,110 +95,6 @@ void BM_SwitchSampleType_FloatToInt16_Neon(benchmark::State& state) {
   state.SetItemsProcessed(state.iterations() * kNumFrames);
 }
 BENCHMARK(BM_SwitchSampleType_FloatToInt16_Neon);
-
-void BM_SwitchStorageType_Int16InterleavedToPlanar_Cpp(
-    benchmark::State& state) {
-  auto src = CreateInt16InterleavedBuffer();
-  for (auto _ : state) {
-    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeInt16Deprecated,
-                                  kSbMediaAudioFrameStorageTypePlanar,
-                                  /*force_simd=*/false);
-    benchmark::DoNotOptimize(dst);
-  }
-  state.SetItemsProcessed(state.iterations() * kNumFrames);
-}
-BENCHMARK(BM_SwitchStorageType_Int16InterleavedToPlanar_Cpp);
-
-void BM_SwitchStorageType_Int16InterleavedToPlanar_Neon(
-    benchmark::State& state) {
-  auto src = CreateInt16InterleavedBuffer();
-  for (auto _ : state) {
-    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeInt16Deprecated,
-                                  kSbMediaAudioFrameStorageTypePlanar,
-                                  /*force_simd=*/true);
-    benchmark::DoNotOptimize(dst);
-  }
-  state.SetItemsProcessed(state.iterations() * kNumFrames);
-}
-BENCHMARK(BM_SwitchStorageType_Int16InterleavedToPlanar_Neon);
-
-void BM_SwitchStorageType_Int16PlanarToInterleaved_Cpp(
-    benchmark::State& state) {
-  auto src = CreateInt16PlanarBuffer();
-  for (auto _ : state) {
-    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeInt16Deprecated,
-                                  kSbMediaAudioFrameStorageTypeInterleaved,
-                                  /*force_simd=*/false);
-    benchmark::DoNotOptimize(dst);
-  }
-  state.SetItemsProcessed(state.iterations() * kNumFrames);
-}
-BENCHMARK(BM_SwitchStorageType_Int16PlanarToInterleaved_Cpp);
-
-void BM_SwitchStorageType_Int16PlanarToInterleaved_Neon(
-    benchmark::State& state) {
-  auto src = CreateInt16PlanarBuffer();
-  for (auto _ : state) {
-    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeInt16Deprecated,
-                                  kSbMediaAudioFrameStorageTypeInterleaved,
-                                  /*force_simd=*/true);
-    benchmark::DoNotOptimize(dst);
-  }
-  state.SetItemsProcessed(state.iterations() * kNumFrames);
-}
-BENCHMARK(BM_SwitchStorageType_Int16PlanarToInterleaved_Neon);
-
-void BM_SwitchStorageType_FloatInterleavedToPlanar_Cpp(
-    benchmark::State& state) {
-  auto src = CreateFloatInterleavedBuffer();
-  for (auto _ : state) {
-    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
-                                  kSbMediaAudioFrameStorageTypePlanar,
-                                  /*force_simd=*/false);
-    benchmark::DoNotOptimize(dst);
-  }
-  state.SetItemsProcessed(state.iterations() * kNumFrames);
-}
-BENCHMARK(BM_SwitchStorageType_FloatInterleavedToPlanar_Cpp);
-
-void BM_SwitchStorageType_FloatInterleavedToPlanar_Neon(
-    benchmark::State& state) {
-  auto src = CreateFloatInterleavedBuffer();
-  for (auto _ : state) {
-    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
-                                  kSbMediaAudioFrameStorageTypePlanar,
-                                  /*force_simd=*/true);
-    benchmark::DoNotOptimize(dst);
-  }
-  state.SetItemsProcessed(state.iterations() * kNumFrames);
-}
-BENCHMARK(BM_SwitchStorageType_FloatInterleavedToPlanar_Neon);
-
-void BM_SwitchStorageType_FloatPlanarToInterleaved_Cpp(
-    benchmark::State& state) {
-  auto src = CreateFloatPlanarBuffer();
-  for (auto _ : state) {
-    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
-                                  kSbMediaAudioFrameStorageTypeInterleaved,
-                                  /*force_simd=*/false);
-    benchmark::DoNotOptimize(dst);
-  }
-  state.SetItemsProcessed(state.iterations() * kNumFrames);
-}
-BENCHMARK(BM_SwitchStorageType_FloatPlanarToInterleaved_Cpp);
-
-void BM_SwitchStorageType_FloatPlanarToInterleaved_Neon(
-    benchmark::State& state) {
-  auto src = CreateFloatPlanarBuffer();
-  for (auto _ : state) {
-    auto dst = src.SwitchFormatTo(kSbMediaAudioSampleTypeFloat32,
-                                  kSbMediaAudioFrameStorageTypeInterleaved,
-                                  /*force_simd=*/true);
-    benchmark::DoNotOptimize(dst);
-  }
-  state.SetItemsProcessed(state.iterations() * kNumFrames);
-}
-BENCHMARK(BM_SwitchStorageType_FloatPlanarToInterleaved_Neon);
 
 }  // namespace
 }  // namespace starboard

--- a/starboard/shared/starboard/player/filter/testing/wsola_internal_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/wsola_internal_test.cc
@@ -43,7 +43,7 @@ DecodedAudio CreateTestDecodedAudio(int frames,
   const int kBufferSize = frames * kBytesPerFrame;
 
   DecodedAudio audio(channels, kSbMediaAudioSampleTypeFloat32,
-                     kSbMediaAudioFrameStorageTypeInterleaved, 0, kBufferSize);
+                     /*timestamp=*/0, kBufferSize);
 
   float* data = audio.data_as_float32();
   for (int i = 0; i < frames; ++i) {

--- a/starboard/tvos/shared/media/audio_decoder.mm
+++ b/starboard/tvos/shared/media/audio_decoder.mm
@@ -94,7 +94,6 @@ void TvosAudioDecoder::Decode(const InputBuffers& input_buffers,
 
     DecodedAudio decoded_audio(audio_stream_info_.number_of_channels,
                                kSbMediaAudioSampleTypeFloat32,
-                               kSbMediaAudioFrameStorageTypeInterleaved,
                                input_buffer->timestamp(), output_byte_size);
     audio_buffer_list_.mBuffers[0].mData = decoded_audio.data();
     audio_buffer_list_.mBuffers[0].mDataByteSize = output_byte_size;

--- a/starboard/tvos/shared/media/av_audio_sample_buffer_builder.mm
+++ b/starboard/tvos/shared/media/av_audio_sample_buffer_builder.mm
@@ -187,7 +187,6 @@ class OpusAVSampleBufferBuilder : public AVAudioSampleBufferBuilder {
 
     DecodedAudio decoded_audio(
         audio_stream_info_.number_of_channels, kSbMediaAudioSampleTypeFloat32,
-        kSbMediaAudioFrameStorageTypeInterleaved,
         input_buffer->timestamp() + media_time_offset,
         audio_stream_info_.number_of_channels * frams_size *
             GetBytesPerSample(kSbMediaAudioSampleTypeFloat32));


### PR DESCRIPTION
This is part of the effort to remove kSbMediaAudioFrameStorageTypePlanar from 1P implementation.

DecodedAudio is always created in interleaved format. This change removes the storage_type parameter from DecodedAudio constructors, fixes storage_type_ to interleaved, and updates all constructor call sites across audio decoders, resamplers, mixers, stretchers, and tests.

Bug: 272837615