### PR TITLE
infra: Set owners for the CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
+# Set owners for the CODEOWNERS file itself.
+/.github/CODEOWNERS @youtube/cobalt-starboard-owners
+
 /cobalt/media                               @youtube/cobalt-media
 /media/                                     @youtube/cobalt-media
 /starboard/shared/starboard/audio_sink      @youtube/cobalt-media


### PR DESCRIPTION
Add @youtube/cobalt-starboard-owners to /.github/CODEOWNERS to ensure modifications to repository ownership rules require approval from core Starboard owners.

Otherwise, any 2 engineers can bypass repository CODEOWNERS approval rules by modifying the CODEOWNER file directly.

Issue: 554167057