### PR TITLE
infra: Add cobalt-media as co-owners of tvOS media directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,6 @@
 /starboard/shared/starboard/drm             @youtube/cobalt-media
 /starboard/shared/starboard/media           @youtube/cobalt-media
 /starboard/shared/starboard/player          @youtube/cobalt-media
-/starboard/tvos/shared/media                @youtube/cobalt-media
 /third_party/blink/renderer/platform/media/ @youtube/cobalt-media
 
 /cobalt/android  @youtube/cobalt-androidtv
@@ -22,6 +21,7 @@
 
 /cobalt/app/tvos @youtube/cobalt-tvos
 /starboard/tvos  @youtube/cobalt-tvos
+/starboard/tvos/shared/media @youtube/cobalt-tvos @youtube/cobalt-media
 /cobalt/**/*.mm  @youtube/cobalt-tvos
 
 /cobalt/build/gn.py @youtube/cobalt-build


### PR DESCRIPTION
Previously, the media team was set as the owner of /starboard/tvos/shared/media, but it was overridden by the later /starboard/tvos rule for @youtube/cobalt-tvos.

Bug: 554120177