### PR TITLE
tvos: Enable AV1 video decoder support

### DIFF
--- a/starboard/tvos/shared/media/av_video_sample_buffer_builder.mm
+++ b/starboard/tvos/shared/media/av_video_sample_buffer_builder.mm
@@ -21,7 +21,7 @@
 #import "starboard/tvos/shared/media/vp9_sw_av_video_sample_buffer_builder.h"  // nogncheck
 
 #if defined(COBALT_INTERNAL_BUILD)
-#import "cobalt/internal/starboard/shared/tvos/vp9_hw_av_video_sample_buffer_builder.h"
+#import "cobalt/internal/starboard/shared/tvos/hw_av_video_sample_buffer_builder.h"
 #endif
 
 namespace starboard {
@@ -34,10 +34,16 @@ AVVideoSampleBufferBuilder* AVVideoSampleBufferBuilder::CreateBuilder(
   } else if (video_stream_info.codec == kSbMediaVideoCodecVp9) {
 #if defined(COBALT_INTERNAL_BUILD)
     if (PlaybackCapabilities::IsHwVp9Supported()) {
-      return new Vp9HwAVVideoSampleBufferBuilder(video_stream_info);
+      return new HwAVVideoSampleBufferBuilder(video_stream_info);
     }
 #endif  // defined(COBALT_INTERNAL_BUILD)
     return new Vp9SwAVVideoSampleBufferBuilder(video_stream_info);
+  } else if (video_stream_info.codec == kSbMediaVideoCodecAv1) {
+#if defined(COBALT_INTERNAL_BUILD)
+    if (PlaybackCapabilities::IsHwAv1Supported()) {
+      return new HwAVVideoSampleBufferBuilder(video_stream_info);
+    }
+#endif  // defined(COBALT_INTERNAL_BUILD)
   }
   SB_NOTREACHED();
   return nullptr;

--- a/starboard/tvos/shared/media/player_components_factory.mm
+++ b/starboard/tvos/shared/media/player_components_factory.mm
@@ -246,11 +246,9 @@ bool PlayerComponents::Factory::OutputModeSupported(
     return false;
   }
 
-  if (codec == kSbMediaVideoCodecNone || codec == kSbMediaVideoCodecH264) {
-    return true;
-  }
-
-  if (codec == kSbMediaVideoCodecVp9) {
+  if (codec == kSbMediaVideoCodecNone ||
+      codec == kSbMediaVideoCodecH264 || codec == kSbMediaVideoCodecVp9 ||
+      codec == kSbMediaVideoCodecAv1) {
     return true;
   }
   return false;


### PR DESCRIPTION
Enable AV1 video decoding support on tvOS by updating the player
components factory to accept the codec. The sample buffer builder
now supports hardware-accelerated AV1 playback when capabilities
allow.

Bug: 538663615