### PR TITLE
starboard: Fix DecodedAudio moved-from state

### DIFF
--- a/starboard/shared/starboard/player/decoded_audio_internal.cc
+++ b/starboard/shared/starboard/player/decoded_audio_internal.cc
@@ -115,7 +115,7 @@ DecodedAudio::DecodedAudio(DecodedAudio&& other) noexcept
     : channels_(std::exchange(other.channels_, 0)),
       sample_type_(other.sample_type_),
       storage_type_(other.storage_type_),
-      timestamp_(other.timestamp_),
+      timestamp_(std::exchange(other.timestamp_, 0)),
       storage_(std::move(other.storage_)),
       offset_in_bytes_(std::exchange(other.offset_in_bytes_, 0)),
       size_in_bytes_(std::exchange(other.size_in_bytes_, 0)) {}
@@ -127,7 +127,7 @@ DecodedAudio& DecodedAudio::operator=(DecodedAudio&& other) noexcept {
   channels_ = std::exchange(other.channels_, 0);
   sample_type_ = other.sample_type_;
   storage_type_ = other.storage_type_;
-  timestamp_ = other.timestamp_;
+  timestamp_ = std::exchange(other.timestamp_, 0);
   storage_ = std::move(other.storage_);
   offset_in_bytes_ = std::exchange(other.offset_in_bytes_, 0);
   size_in_bytes_ = std::exchange(other.size_in_bytes_, 0);

--- a/starboard/shared/starboard/player/decoded_audio_internal.cc
+++ b/starboard/shared/starboard/player/decoded_audio_internal.cc
@@ -124,6 +124,7 @@ DecodedAudio& DecodedAudio::operator=(DecodedAudio&& other) noexcept {
   if (this == &other) {
     return *this;
   }
+
   channels_ = std::exchange(other.channels_, 0);
   sample_type_ = other.sample_type_;
   storage_type_ = other.storage_type_;
@@ -131,6 +132,7 @@ DecodedAudio& DecodedAudio::operator=(DecodedAudio&& other) noexcept {
   storage_ = std::move(other.storage_);
   offset_in_bytes_ = std::exchange(other.offset_in_bytes_, 0);
   size_in_bytes_ = std::exchange(other.size_in_bytes_, 0);
+
   return *this;
 }
 

--- a/starboard/shared/starboard/player/decoded_audio_internal.cc
+++ b/starboard/shared/starboard/player/decoded_audio_internal.cc
@@ -111,6 +111,36 @@ DecodedAudio::DecodedAudio(int channels,
                0);
 }
 
+DecodedAudio::DecodedAudio(DecodedAudio&& other)
+    : channels_(other.channels_),
+      sample_type_(other.sample_type_),
+      storage_type_(other.storage_type_),
+      timestamp_(other.timestamp_),
+      storage_(std::move(other.storage_)),
+      offset_in_bytes_(other.offset_in_bytes_),
+      size_in_bytes_(other.size_in_bytes_) {
+  other.channels_ = 0;
+  other.size_in_bytes_ = 0;
+  other.offset_in_bytes_ = 0;
+}
+
+DecodedAudio& DecodedAudio::operator=(DecodedAudio&& other) {
+  if (this != &other) {
+    channels_ = other.channels_;
+    sample_type_ = other.sample_type_;
+    storage_type_ = other.storage_type_;
+    timestamp_ = other.timestamp_;
+    storage_ = std::move(other.storage_);
+    offset_in_bytes_ = other.offset_in_bytes_;
+    size_in_bytes_ = other.size_in_bytes_;
+
+    other.channels_ = 0;
+    other.size_in_bytes_ = 0;
+    other.offset_in_bytes_ = 0;
+  }
+  return *this;
+}
+
 void DecodedAudio::EnableSimdBasedAudioFormatSwitching() {
   g_enable_simd_based_audio_format_switching.store(true,
                                                    std::memory_order_release);

--- a/starboard/shared/starboard/player/decoded_audio_internal.cc
+++ b/starboard/shared/starboard/player/decoded_audio_internal.cc
@@ -112,31 +112,23 @@ DecodedAudio::DecodedAudio(int channels,
 }
 
 DecodedAudio::DecodedAudio(DecodedAudio&& other)
-    : channels_(other.channels_),
+    : channels_(std::exchange(other.channels_, 0)),
       sample_type_(other.sample_type_),
       storage_type_(other.storage_type_),
       timestamp_(other.timestamp_),
       storage_(std::move(other.storage_)),
-      offset_in_bytes_(other.offset_in_bytes_),
-      size_in_bytes_(other.size_in_bytes_) {
-  other.channels_ = 0;
-  other.size_in_bytes_ = 0;
-  other.offset_in_bytes_ = 0;
-}
+      offset_in_bytes_(std::exchange(other.offset_in_bytes_, 0)),
+      size_in_bytes_(std::exchange(other.size_in_bytes_, 0)) {}
 
 DecodedAudio& DecodedAudio::operator=(DecodedAudio&& other) {
   if (this != &other) {
-    channels_ = other.channels_;
+    channels_ = std::exchange(other.channels_, 0);
     sample_type_ = other.sample_type_;
     storage_type_ = other.storage_type_;
     timestamp_ = other.timestamp_;
     storage_ = std::move(other.storage_);
-    offset_in_bytes_ = other.offset_in_bytes_;
-    size_in_bytes_ = other.size_in_bytes_;
-
-    other.channels_ = 0;
-    other.size_in_bytes_ = 0;
-    other.offset_in_bytes_ = 0;
+    offset_in_bytes_ = std::exchange(other.offset_in_bytes_, 0);
+    size_in_bytes_ = std::exchange(other.size_in_bytes_, 0);
   }
   return *this;
 }

--- a/starboard/shared/starboard/player/decoded_audio_internal.cc
+++ b/starboard/shared/starboard/player/decoded_audio_internal.cc
@@ -121,15 +121,16 @@ DecodedAudio::DecodedAudio(DecodedAudio&& other) noexcept
       size_in_bytes_(std::exchange(other.size_in_bytes_, 0)) {}
 
 DecodedAudio& DecodedAudio::operator=(DecodedAudio&& other) noexcept {
-  if (this != &other) {
-    channels_ = std::exchange(other.channels_, 0);
-    sample_type_ = other.sample_type_;
-    storage_type_ = other.storage_type_;
-    timestamp_ = other.timestamp_;
-    storage_ = std::move(other.storage_);
-    offset_in_bytes_ = std::exchange(other.offset_in_bytes_, 0);
-    size_in_bytes_ = std::exchange(other.size_in_bytes_, 0);
+  if (this == &other) {
+    return *this;
   }
+  channels_ = std::exchange(other.channels_, 0);
+  sample_type_ = other.sample_type_;
+  storage_type_ = other.storage_type_;
+  timestamp_ = other.timestamp_;
+  storage_ = std::move(other.storage_);
+  offset_in_bytes_ = std::exchange(other.offset_in_bytes_, 0);
+  size_in_bytes_ = std::exchange(other.size_in_bytes_, 0);
   return *this;
 }
 

--- a/starboard/shared/starboard/player/decoded_audio_internal.cc
+++ b/starboard/shared/starboard/player/decoded_audio_internal.cc
@@ -111,7 +111,7 @@ DecodedAudio::DecodedAudio(int channels,
                0);
 }
 
-DecodedAudio::DecodedAudio(DecodedAudio&& other)
+DecodedAudio::DecodedAudio(DecodedAudio&& other) noexcept
     : channels_(std::exchange(other.channels_, 0)),
       sample_type_(other.sample_type_),
       storage_type_(other.storage_type_),
@@ -120,7 +120,7 @@ DecodedAudio::DecodedAudio(DecodedAudio&& other)
       offset_in_bytes_(std::exchange(other.offset_in_bytes_, 0)),
       size_in_bytes_(std::exchange(other.size_in_bytes_, 0)) {}
 
-DecodedAudio& DecodedAudio::operator=(DecodedAudio&& other) {
+DecodedAudio& DecodedAudio::operator=(DecodedAudio&& other) noexcept {
   if (this != &other) {
     channels_ = std::exchange(other.channels_, 0);
     sample_type_ = other.sample_type_;

--- a/starboard/shared/starboard/player/decoded_audio_internal.h
+++ b/starboard/shared/starboard/player/decoded_audio_internal.h
@@ -44,8 +44,8 @@ class DecodedAudio {
                Buffer&& storage);
 
   // Move-only semantics
-  DecodedAudio(DecodedAudio&& other) = default;
-  DecodedAudio& operator=(DecodedAudio&& other) = default;
+  DecodedAudio(DecodedAudio&& other);
+  DecodedAudio& operator=(DecodedAudio&& other);
 
   // Disable copy and assignment.
   DecodedAudio(const DecodedAudio&) = delete;

--- a/starboard/shared/starboard/player/decoded_audio_internal.h
+++ b/starboard/shared/starboard/player/decoded_audio_internal.h
@@ -49,7 +49,7 @@ class DecodedAudio {
 
   // Disable copy and assignment.
   DecodedAudio(const DecodedAudio&) = delete;
-  void operator=(const DecodedAudio&) = delete;
+  DecodedAudio& operator=(const DecodedAudio&) = delete;
 
   static void EnableSimdBasedAudioFormatSwitching();
 

--- a/starboard/shared/starboard/player/decoded_audio_internal.h
+++ b/starboard/shared/starboard/player/decoded_audio_internal.h
@@ -44,8 +44,8 @@ class DecodedAudio {
                Buffer&& storage);
 
   // Move-only semantics
-  DecodedAudio(DecodedAudio&& other);
-  DecodedAudio& operator=(DecodedAudio&& other);
+  DecodedAudio(DecodedAudio&& other) noexcept;
+  DecodedAudio& operator=(DecodedAudio&& other) noexcept;
 
   // Disable copy and assignment.
   DecodedAudio(const DecodedAudio&) = delete;

--- a/starboard/shared/starboard/player/decoded_audio_test_internal.cc
+++ b/starboard/shared/starboard/player/decoded_audio_test_internal.cc
@@ -425,5 +425,62 @@ TEST_F(DecodedAudioNeonTest, SwitchFormatTo_NeonSimdUnaligned) {
                      kSbMediaAudioFrameStorageTypeInterleaved);
 }
 
+TEST(DecodedAudioTest, MoveConstructor) {
+  DecodedAudio original(kChannels, kSampleTypes[0], kStorageTypes[0],
+                        kTimestampUsec, kSizeInBytes);
+  Fill(&original);
+
+  const uint8_t* original_data = original.data();
+  int original_channels = original.channels();
+  auto original_sample_type = original.sample_type();
+  auto original_storage_type = original.storage_type();
+  int64_t original_timestamp = original.timestamp();
+  int original_size = original.size_in_bytes();
+
+  DecodedAudio moved(std::move(original));
+
+  EXPECT_EQ(moved.data(), original_data);
+  EXPECT_EQ(moved.channels(), original_channels);
+  EXPECT_EQ(moved.sample_type(), original_sample_type);
+  EXPECT_EQ(moved.storage_type(), original_storage_type);
+  EXPECT_EQ(moved.timestamp(), original_timestamp);
+  EXPECT_EQ(moved.size_in_bytes(), original_size);
+  Verify(moved);
+
+  EXPECT_TRUE(original.is_end_of_stream());
+  EXPECT_EQ(original.channels(), 0);
+  EXPECT_EQ(original.size_in_bytes(), 0);
+  EXPECT_EQ(original.data(), nullptr);
+}
+
+TEST(DecodedAudioTest, MoveAssignment) {
+  DecodedAudio original(kChannels, kSampleTypes[0], kStorageTypes[0],
+                        kTimestampUsec, kSizeInBytes);
+  Fill(&original);
+
+  const uint8_t* original_data = original.data();
+  int original_channels = original.channels();
+  auto original_sample_type = original.sample_type();
+  auto original_storage_type = original.storage_type();
+  int64_t original_timestamp = original.timestamp();
+  int original_size = original.size_in_bytes();
+
+  DecodedAudio moved = DecodedAudio::CreateEOSBuffer();
+  moved = std::move(original);
+
+  EXPECT_EQ(moved.data(), original_data);
+  EXPECT_EQ(moved.channels(), original_channels);
+  EXPECT_EQ(moved.sample_type(), original_sample_type);
+  EXPECT_EQ(moved.storage_type(), original_storage_type);
+  EXPECT_EQ(moved.timestamp(), original_timestamp);
+  EXPECT_EQ(moved.size_in_bytes(), original_size);
+  Verify(moved);
+
+  EXPECT_TRUE(original.is_end_of_stream());
+  EXPECT_EQ(original.channels(), 0);
+  EXPECT_EQ(original.size_in_bytes(), 0);
+  EXPECT_EQ(original.data(), nullptr);
+}
+
 }  // namespace
 }  // namespace starboard

--- a/starboard/shared/starboard/player/decoded_audio_test_internal.cc
+++ b/starboard/shared/starboard/player/decoded_audio_test_internal.cc
@@ -426,8 +426,8 @@ TEST_F(DecodedAudioNeonTest, SwitchFormatTo_NeonSimdUnaligned) {
 }
 
 TEST(DecodedAudioTest, MoveConstructor) {
-  DecodedAudio original(kChannels, kSampleTypes[0], kStorageTypes[0],
-                        kTimestampUsec, kSizeInBytes);
+  DecodedAudio original(kChannels, kSampleTypes[0], kTimestampUsec,
+                        kSizeInBytes);
   Fill(&original);
 
   const uint8_t* original_data = original.data();
@@ -455,8 +455,8 @@ TEST(DecodedAudioTest, MoveConstructor) {
 }
 
 TEST(DecodedAudioTest, MoveAssignment) {
-  DecodedAudio original(kChannels, kSampleTypes[0], kStorageTypes[0],
-                        kTimestampUsec, kSizeInBytes);
+  DecodedAudio original(kChannels, kSampleTypes[0], kTimestampUsec,
+                        kSizeInBytes);
   Fill(&original);
 
   const uint8_t* original_data = original.data();

--- a/starboard/shared/starboard/player/decoded_audio_test_internal.cc
+++ b/starboard/shared/starboard/player/decoded_audio_test_internal.cc
@@ -450,6 +450,7 @@ TEST(DecodedAudioTest, MoveConstructor) {
   EXPECT_TRUE(original.is_end_of_stream());
   EXPECT_EQ(original.channels(), 0);
   EXPECT_EQ(original.size_in_bytes(), 0);
+  EXPECT_EQ(original.timestamp(), 0);
   EXPECT_EQ(original.data(), nullptr);
 }
 
@@ -479,6 +480,7 @@ TEST(DecodedAudioTest, MoveAssignment) {
   EXPECT_TRUE(original.is_end_of_stream());
   EXPECT_EQ(original.channels(), 0);
   EXPECT_EQ(original.size_in_bytes(), 0);
+  EXPECT_EQ(original.timestamp(), 0);
   EXPECT_EQ(original.data(), nullptr);
 }
 


### PR DESCRIPTION
Implement a custom move constructor and move assignment operator for
DecodedAudio. Previously, these were defaulted, which caused scalar
members like channels, size_in_bytes, and offset_in_bytes to be copied
rather than reset in the moved-from object.

This ensures that moved-from objects maintain valid class invariants and
prevents potential undefined behavior, such as performing pointer
arithmetic on a null pointer.

Bug: 550523546