### PR TITLE
cobalt: Release renderer HangWatcher ScopedClosureRunner to prevent shutdown abort

### DIFF
--- a/cobalt/renderer/cobalt_content_renderer_client.cc
+++ b/cobalt/renderer/cobalt_content_renderer_client.cc
@@ -16,9 +16,12 @@
 
 #include <memory>
 #include <string>
+#include <tuple>
 #include <variant>
 
+#include "base/functional/callback_helpers.h"
 #include "base/task/bind_post_task.h"
+#include "base/threading/hang_watcher.h"
 #include "base/time/time.h"
 #include "build/build_config.h"
 #include "cobalt/media/service/mojom/platform_window_provider.mojom.h"
@@ -366,12 +369,18 @@ void CobaltContentRendererClient::PostSandboxInitialized() {
   CHECK(content::RenderThread::IsMainThread());
 
   // Register the current thread (which is the InProcessRendererThread in
-  // single- process mode) for hang watching. Store the ScopedClosureRunner to
-  // keep the registration active until this client object is destroyed.
+  // single-process mode) for hang watching. HangWatcher is a leaky singleton,
+  // and InProcessRendererThread runs for the duration of the web application.
+  // Release the ScopedClosureRunner instead of storing it on
+  // CobaltContentRendererClient (which is destroyed on the main thread during
+  // shutdown), and avoid thread_local ScopedClosureRunner which pulls in
+  // __cxa_thread_atexit_impl (an illegal API leak in Evergreen).
   if (base::HangWatcher::IsEnabled() && base::HangWatcher::GetInstance()) {
     // Use kRendererThread as the type for this in-process renderer thread.
-    unregister_thread_closure = base::HangWatcher::RegisterThread(
-        base::HangWatcher::ThreadType::kRendererThread);
+    base::ScopedClosureRunner unregister_thread_closure =
+        base::HangWatcher::RegisterThread(
+            base::HangWatcher::ThreadType::kRendererThread);
+    std::ignore = unregister_thread_closure.Release();
   }
 }
 

--- a/cobalt/renderer/cobalt_content_renderer_client.h
+++ b/cobalt/renderer/cobalt_content_renderer_client.h
@@ -22,7 +22,6 @@
 #include "base/memory/weak_ptr.h"
 #include "base/synchronization/lock.h"
 #include "base/task/sequenced_task_runner.h"
-#include "base/threading/hang_watcher.h"
 #include "cobalt/browser/mojom/h5vcc_settings.mojom.h"
 #include "cobalt/common/cobalt_thread_checker.h"
 #include "cobalt/media/audio/cobalt_audio_device_factory.h"
@@ -99,8 +98,6 @@ class CobaltContentRendererClient : public content::ContentRendererClient {
   std::unique_ptr<mojo::Remote<cobalt::mojom::H5vccSettings>,
                   base::OnTaskRunnerDeleter>
       h5vcc_settings_remote_;
-
-  base::ScopedClosureRunner unregister_thread_closure;
 
   gfx::Size viewport_size_;
 


### PR DESCRIPTION
In single-process Cobalt, `PostSandboxInitialized` registers the `InProcessRendererThread` with HangWatcher. `HangWatcher::UnregisterThread` queries TLS for the calling thread's `HangWatchState` and asserts that it is currently registered.

Because `CobaltContentRendererClient` is owned by `CobaltMainDelegate` and destroyed on the browser main / Starboard thread during shutdown, storing the `ScopedClosureRunner` on `CobaltContentRendererClient` caused `HangWatcher::UnregisterThread` to execute on the main thread, failing the `CHECK(it != watch_states_.end())` assertion and aborting with SIGABRT.

Note on `thread_local`: Using a `thread_local base::ScopedClosureRunner` causes clang to emit calls to `__cxa_thread_atexit`, pulling in `cxa_thread_atexit.o` from libc++abi and introducing an undefined reference to `__cxa_thread_atexit_impl`. In Evergreen, `__cxa_thread_atexit_impl` is not part of the Starboard ABI and fails the API leak check on all Evergreen targets.

Instead, release the registration `ScopedClosureRunner` in `PostSandboxInitialized`. In production, HangWatcher is an intentional process-lifetime leaky singleton and the in-process renderer thread runs for the duration of the web application. Releasing the closure mirrors Chromium's `ContentMainRunnerImpl` pattern.

Bug: 555199636
TAG=agy
CONV=7c5ca534-a4a4-41b1-a5a3-04155f2d1f12
