### PR TITLE
starboard: Add acquire barrier and use strong CAS in EnsureInitialized

### DIFF
--- a/starboard/shared/starboard/lazy_initialization_internal.h
+++ b/starboard/shared/starboard/lazy_initialization_internal.h
@@ -17,6 +17,8 @@
 
 #include <sched.h>
 
+#include <cstdint>
+
 #include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
 #include "starboard/shared/internal_only.h"
@@ -36,13 +38,19 @@ namespace starboard {
 // calling SetInitialized() or else other threads waiting for initialization
 // to complete will wait forever.)
 static inline bool EnsureInitialized(InitializedState* state) {
+  // Fast path: if already initialized, ensure we synchronize with
+  // SetInitialized() via an acquire load so all writes prior to initialization
+  // are visible to this thread.
+  if (state->load(std::memory_order_acquire) == INITIALIZED_STATE_INITIALIZED) {
+    return true;
+  }
+
   // Check what state we're in, and if we find that we are uninitialized,
   // simultaneously mark us as initializing and return to the caller.
-  int original{INITIALIZED_STATE_UNINITIALIZED};
-  state->compare_exchange_weak(original, INITIALIZED_STATE_INITIALIZING,
-                               std::memory_order_release,
-                               std::memory_order_relaxed);
-  if (original == INITIALIZED_STATE_UNINITIALIZED) {
+  // Use compare_exchange_strong to prevent spurious failure on LL/SC (ARM).
+  InitializedState::value_type original{INITIALIZED_STATE_UNINITIALIZED};
+  if (state->compare_exchange_strong(original, INITIALIZED_STATE_INITIALIZING,
+                                     std::memory_order_acquire)) {
     // If we were uninitialized, we are now marked as initializing and so
     // we relay this information to the caller, so that they may initialize.
     return false;
@@ -65,7 +73,8 @@ static inline bool EnsureInitialized(InitializedState* state) {
 // use the outcome of this function to make a decision on whether to initialize
 // or not, use EnsureInitialized() for that.
 static inline bool IsInitialized(InitializedState* state) {
-  return state->load(std::memory_order_relaxed);
+  return state->load(std::memory_order_acquire) ==
+         INITIALIZED_STATE_INITIALIZED;
 }
 
 // Sets the state as being initialized.


### PR DESCRIPTION
EnsureInitialized() fast path previously used compare_exchange_weak with memory_order_relaxed on failure, omitting an acquire barrier when returning on an already-initialized state. On weakly-ordered architectures like ARM, callers could observe INITIALIZED while reading stale or uninitialized protected memory.

In addition, compare_exchange_weak without a retry loop could spuriously fail on LL/SC architectures, leading to potential double-initialization.

This change:
1. Adds an acquire load fast-path check for INITIALIZED_STATE_INITIALIZED to ensure synchronization with SetInitialized()'s release store and avoid unnecessary RMW bus traffic on initialized states.
2. Uses compare_exchange_strong with acquire failure ordering to prevent spurious CAS failures and ensure acquire synchronization on CAS failure.
3. Updates IsInitialized() to explicitly test for INITIALIZED_STATE_INITIALIZED with acquire ordering rather than a relaxed boolean cast.

Bug: 545797349
TAG=agy
CONV=8e207815-eb81-473c-8a8d-8cdcdcf9a9e5