### PR TITLE
cobalt/metrics: Add 512KB Persistent Allocator for startup stability metrics

### DIFF
--- a/cobalt/browser/cobalt_browser_main_parts.cc
+++ b/cobalt/browser/cobalt_browser_main_parts.cc
@@ -16,8 +16,12 @@
 
 #include <memory>
 
+#include "base/base_paths.h"
 #include "base/check.h"
 #include "base/command_line.h"
+#include "base/files/file_util.h"
+#include "base/metrics/histogram_functions.h"
+#include "base/metrics/persistent_histogram_allocator.h"
 #include "base/no_destructor.h"
 #include "base/path_service.h"
 #include "base/run_loop.h"
@@ -37,9 +41,12 @@
 #include "cobalt/shell/browser/shell_content_browser_client.h"
 #include "cobalt/shell/common/shell_paths.h"
 #include "components/metrics/metrics_service.h"
+#include "components/metrics/persistent_histograms.h"
+#include "components/metrics/persistent_system_profile.h"
 #include "components/metrics_services_manager/metrics_services_manager.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/resource_coordinator_service.h"
+#include "content/public/common/result_codes.h"
 
 #if BUILDFLAG(USE_EVERGREEN)
 #include "starboard/extension/native_stability.h"
@@ -174,7 +181,96 @@ void InitializeCobaltHeapProfiler() {
 }
 #endif  // !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
 
+constexpr char kBrowserStabilityMetricsName[] = "BrowserStabilityMetrics";
+constexpr size_t kStabilityMetricsAllocSize = 512 * 1024;  // 512 KiB limit
+constexpr uint32_t kStabilityMetricsAllocId = 0x53544142;  // "STAB"
+
+void LogStabilityMetricsCapacity(const char* stage_label) {
+  auto* allocator = base::GlobalHistogramAllocator::Get();
+  if (!allocator) {
+    return;
+  }
+  auto* mem_allocator = allocator->memory_allocator();
+  if (!mem_allocator) {
+    return;
+  }
+
+  size_t used = mem_allocator->used();
+  size_t total = mem_allocator->size();
+  int percent_full = total > 0 ? static_cast<int>((used * 100) / total) : 0;
+
+  base::UmaHistogramPercentage("Cobalt.StabilityMetrics.PercentFull",
+                               percent_full);
+  base::UmaHistogramCounts1000("Cobalt.StabilityMetrics.UsedKilobytes",
+                               static_cast<int>(used / 1024));
+
+  bool is_near_capacity = mem_allocator->IsFull() || percent_full >= 90;
+  base::UmaHistogramBoolean("Cobalt.StabilityMetrics.IsNearCapacity",
+                            is_near_capacity);
+
+  if (is_near_capacity) {
+    LOG(WARNING) << "Cobalt Stability Metrics PMA approaching capacity at "
+                 << stage_label << "! Used: " << (used / 1024) << "KB / "
+                 << (total / 1024) << "KB (" << percent_full << "% full)";
+  }
+}
+
 }  // namespace
+
+int CobaltBrowserMainParts::PreEarlyInitialization() {
+  if (!base::GlobalHistogramAllocator::Get()) {
+    base::FilePath base_dir;
+    bool path_ok = false;
+#if BUILDFLAG(IS_ANDROID)
+    path_ok = base::PathService::Get(base::DIR_ANDROID_APP_DATA, &base_dir);
+#else
+    path_ok = base::PathService::Get(base::DIR_TEMP, &base_dir);
+#endif
+    if (!path_ok) {
+      LOG(WARNING) << "Failed to get base directory for "
+                   << kBrowserStabilityMetricsName
+                   << ", falling back to 512 KB local memory.";
+      base::GlobalHistogramAllocator::CreateWithLocalMemory(
+          kStabilityMetricsAllocSize, kStabilityMetricsAllocId,
+          kBrowserStabilityMetricsName);
+    } else {
+      base::FilePath metrics_dir =
+          base_dir.AppendASCII(kBrowserStabilityMetricsName);
+
+      base::CreateDirectory(metrics_dir);
+
+      base::FilePath active_file =
+          base::GlobalHistogramAllocator::ConstructFilePathForUploadDir(
+              metrics_dir, kBrowserStabilityMetricsName, base::Time::Now(),
+              base::GetCurrentProcId());
+
+      // Instantiate 512 KB memory-mapped PMA
+      if (base::GlobalHistogramAllocator::CreateWithFile(
+              active_file, kStabilityMetricsAllocSize, kStabilityMetricsAllocId,
+              kBrowserStabilityMetricsName, /*exclusive_write=*/true)) {
+        LOG(INFO) << "Cobalt Persistent Histogram Allocator ("
+                  << kBrowserStabilityMetricsName
+                  << ", 512 KB) initialized at: " << active_file.value();
+      } else {
+        LOG(WARNING) << "Failed to initialize file-backed PMA for "
+                     << kBrowserStabilityMetricsName
+                     << ", falling back to 512 KB local memory.";
+        base::GlobalHistogramAllocator::CreateWithLocalMemory(
+            kStabilityMetricsAllocSize, kStabilityMetricsAllocId,
+            kBrowserStabilityMetricsName);
+      }
+    }
+
+    auto* allocator = base::GlobalHistogramAllocator::Get();
+    if (allocator) {
+      metrics::GlobalPersistentSystemProfile::GetInstance()
+          ->RegisterPersistentAllocator(allocator->memory_allocator());
+      allocator->CreateTrackingHistograms(kBrowserStabilityMetricsName);
+    }
+  }
+
+  return ShellBrowserMainParts::PreEarlyInitialization();
+}
 
 void CobaltBrowserMainParts::InitializeMessageLoopContext() {
   // On Android, we completely defer WebContents creation until the Java layer
@@ -198,6 +294,8 @@ int CobaltBrowserMainParts::PreCreateThreads() {
 #if BUILDFLAG(IS_ANDROIDTV)
   starboard::StarboardBridge::GetInstance()->SetStartupMilestone(17);
 #endif
+  base::UmaHistogramSparse("Cobalt.Startup.MilestoneReached", 17);
+  LogStabilityMetricsCapacity("PreCreateThreads");
   SetupMetrics();
 
   InitializeBrowserMemoryInstrumentationClient();
@@ -220,6 +318,7 @@ int CobaltBrowserMainParts::PreCreateThreads() {
 
 int CobaltBrowserMainParts::PreMainMessageLoopRun() {
   StartMetricsRecording();
+  LogStabilityMetricsCapacity("PreMainMessageLoopRun");
 
 #if BUILDFLAG(COBALT_DETAILED_MEMORY_METRICS)
   static base::NoDestructor<CobaltDetailedMetricsDelegate> delegate;

--- a/cobalt/browser/cobalt_browser_main_parts.h
+++ b/cobalt/browser/cobalt_browser_main_parts.h
@@ -54,6 +54,7 @@ class CobaltBrowserMainParts : public content::ShellBrowserMainParts {
   ~CobaltBrowserMainParts() override = default;
 
   // ShellBrowserMainParts overrides.
+  int PreEarlyInitialization() override;
   int PreCreateThreads() override;
   int PreMainMessageLoopRun() override;
   void PostDestroyThreads() override;

--- a/cobalt/browser/cobalt_web_contents_observer.cc
+++ b/cobalt/browser/cobalt_web_contents_observer.cc
@@ -140,6 +140,11 @@ void CobaltWebContentsObserver::DidStartNavigation(
   }
 
   latest_navigation_id_ = handle->GetNavigationId();
+  if (handle->IsInPrimaryMainFrame() && !has_recorded_startup_navigation_ &&
+      navigation_start_ticks_.is_null()) {
+    navigation_start_ticks_ = base::TimeTicks::Now();
+    base::UmaHistogramSparse("Cobalt.Startup.MilestoneReached", 22);
+  }
 
   // Start a navigation timer with a timeout callback to raise a
   // network error dialog
@@ -166,6 +171,19 @@ void CobaltWebContentsObserver::DidFinishNavigation(
   }
 
   timeout_timer_->Stop();
+  if (navigation_handle->IsInPrimaryMainFrame() &&
+      !has_recorded_startup_navigation_ && !navigation_start_ticks_.is_null() &&
+      navigation_handle->HasCommitted() && !navigation_handle->IsErrorPage() &&
+      navigation_handle->GetNetErrorCode() == net::OK) {
+    base::UmaHistogramSparse("Cobalt.Startup.MilestoneReached", 26);
+    base::TimeDelta nav_duration =
+        base::TimeTicks::Now() - navigation_start_ticks_;
+    base::UmaHistogramCustomTimes(
+        "Cobalt.Startup.Time.NavigationDispatchToCommit", nav_duration,
+        base::Milliseconds(10), base::Seconds(60), 50);
+    has_recorded_startup_navigation_ = true;
+    navigation_start_ticks_ = base::TimeTicks();
+  }
   const auto net_error_code = navigation_handle->GetNetErrorCode();
   if (net_error_code != net::OK && net_error_code != net::ERR_ABORTED) {
     base::UmaHistogramBoolean("Cobalt.WebContentsObserver.FailedNavigation",

--- a/cobalt/browser/cobalt_web_contents_observer.h
+++ b/cobalt/browser/cobalt_web_contents_observer.h
@@ -18,6 +18,7 @@
 #include <map>
 
 #include "base/memory/weak_ptr.h"
+#include "base/time/time.h"
 #include "base/timer/timer.h"
 #include "cobalt/browser/lifecycle/public/mojom/cobalt_lifecycle.mojom.h"
 #include "content/public/browser/web_contents_observer.h"
@@ -65,6 +66,8 @@ class CobaltWebContentsObserver : public content::WebContentsObserver {
            mojo::Remote<cobalt::mojom::CobaltLifecycleController>>
       controllers_;
   int64_t latest_navigation_id_ = 0;
+  base::TimeTicks navigation_start_ticks_;
+  bool has_recorded_startup_navigation_ = false;
 #if BUILDFLAG(IS_ANDROIDTV) || BUILDFLAG(IS_STARBOARD)
   int platform_error_raised_count_ = 0;
 #endif  // BUILDFLAG(IS_ANDROIDTV)

--- a/cobalt/browser/global_features.cc
+++ b/cobalt/browser/global_features.cc
@@ -27,6 +27,7 @@
 #include "base/time/time.h"
 #include "cobalt/browser/constants/cobalt_experiment_names.h"
 #include "cobalt/browser/metrics/cobalt_metrics_services_manager_client.h"
+#include "components/metrics/file_metrics_provider.h"
 #include "components/metrics/metrics_pref_names.h"
 #include "components/metrics/metrics_service.h"
 #include "components/metrics_services_manager/metrics_services_manager.h"
@@ -170,6 +171,9 @@ void GlobalFeatures::CreateMetricsLocalState() {
   // reference to it.
   auto pref_registry = base::MakeRefCounted<PrefRegistrySimple>();
   metrics::MetricsService::RegisterPrefs(pref_registry.get());
+  metrics::FileMetricsProvider::RegisterPrefs(pref_registry.get());
+  metrics::FileMetricsProvider::RegisterSourcePrefs(pref_registry.get(),
+                                                    "BrowserStabilityMetrics");
   // This is the pref used to globally enable/disable metrics reporting. When
   // metrics reporting is toggled via any method (e.g., command line, JS API
   // call, etc., this is the setting that's overridden).

--- a/cobalt/browser/metrics/cobalt_metrics_browsertest.cc
+++ b/cobalt/browser/metrics/cobalt_metrics_browsertest.cc
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "base/metrics/persistent_histogram_allocator.h"
+#include "base/metrics/persistent_memory_allocator.h"
+#include "base/metrics/sparse_histogram.h"
 #include "base/metrics/statistics_recorder.h"
 #include "base/no_destructor.h"
 #include "base/run_loop.h"
@@ -25,6 +28,8 @@
 #include "cobalt/browser/metrics/cobalt_metrics_services_manager_client.h"
 #include "cobalt/testing/browser_tests/browser/test_shell.h"
 #include "cobalt/testing/browser_tests/content_browser_test.h"
+#include "components/metrics/file_metrics_provider.h"
+#include "components/metrics/metrics_pref_names.h"
 #include "components/metrics/metrics_service.h"
 #include "components/metrics_services_manager/metrics_services_manager.h"
 #include "content/public/test/browser_test.h"
@@ -354,6 +359,125 @@ IN_PROC_BROWSER_TEST_F(CobaltMetricsBrowserTest, MAYBE_RecordsCpuMetrics) {
   // on the first call
   EXPECT_GE(histogram_tester.GetBucketCount("CPU.Total.UsageInPercentage", 0),
             1);
+}
+
+IN_PROC_BROWSER_TEST_F(CobaltMetricsBrowserTest,
+                       StabilityMetricsPersistentAllocatorInitialized) {
+  base::GlobalHistogramAllocator* allocator =
+      base::GlobalHistogramAllocator::Get();
+  ASSERT_NE(allocator, nullptr);
+  EXPECT_EQ(allocator->Name(), "BrowserStabilityMetrics");
+
+  base::PersistentMemoryAllocator* mem_allocator =
+      allocator->memory_allocator();
+  ASSERT_NE(mem_allocator, nullptr);
+
+  // Verify the strict 512 KiB cap
+  EXPECT_EQ(mem_allocator->size(), 512u * 1024u);
+
+  // Verify allocator ID "STAB"
+  EXPECT_EQ(mem_allocator->Id(), 0x53544142u);
+
+  // Verify the allocator is valid and not corrupt
+  EXPECT_FALSE(mem_allocator->IsCorrupt());
+  EXPECT_GT(mem_allocator->used(), 0u);
+  EXPECT_LT(mem_allocator->used(), mem_allocator->size());
+}
+
+IN_PROC_BROWSER_TEST_F(CobaltMetricsBrowserTest,
+                       StartupMilestonesAndNavigationMetricsRecorded) {
+  base::HistogramTester histogram_tester;
+
+  base::ScopedAllowBlockingForTesting allow_blocking;
+  auto* features = GlobalFeatures::GetInstance();
+  features->metrics_services_manager()->UpdateUploadPermissions(true);
+
+  // Navigate to a test page to trigger navigation lifecycle events
+  GURL url("data:text/html;charset=utf-8,<h1>Startup Milestone Test</h1>");
+  ASSERT_TRUE(content::NavigateToURL(shell()->web_contents(), url));
+
+  // Sync histograms from persistent memory / providers
+  base::StatisticsRecorder::ImportProvidedHistogramsSync();
+
+  // Milestone 17 was recorded in PreCreateThreads (before test body)
+  base::HistogramBase* milestone_hist = base::StatisticsRecorder::FindHistogram(
+      "Cobalt.Startup.MilestoneReached");
+  ASSERT_TRUE(milestone_hist);
+  EXPECT_GE(milestone_hist->SnapshotSamples()->GetCount(17), 1);
+
+  // Milestone 22 (DidStartNavigation) and 26 (DidFinishNavigation)
+  EXPECT_EQ(
+      histogram_tester.GetBucketCount("Cobalt.Startup.MilestoneReached", 22),
+      1);
+  EXPECT_EQ(
+      histogram_tester.GetBucketCount("Cobalt.Startup.MilestoneReached", 26),
+      1);
+
+  // Verify navigation duration metric was recorded exactly once
+  histogram_tester.ExpectTotalCount(
+      "Cobalt.Startup.Time.NavigationDispatchToCommit", 1);
+
+  // Second navigation should not re-record startup milestones or duration
+  GURL second_url("data:text/html;charset=utf-8,<h1>Second Page</h1>");
+  ASSERT_TRUE(content::NavigateToURL(shell()->web_contents(), second_url));
+  EXPECT_EQ(
+      histogram_tester.GetBucketCount("Cobalt.Startup.MilestoneReached", 22),
+      1);
+  EXPECT_EQ(
+      histogram_tester.GetBucketCount("Cobalt.Startup.MilestoneReached", 26),
+      1);
+  histogram_tester.ExpectTotalCount(
+      "Cobalt.Startup.Time.NavigationDispatchToCommit", 1);
+}
+
+IN_PROC_BROWSER_TEST_F(CobaltMetricsBrowserTest,
+                       StabilityMetricsCapacityMonitoring) {
+  base::ScopedAllowBlockingForTesting allow_blocking;
+  auto* features = GlobalFeatures::GetInstance();
+  features->metrics_services_manager()->UpdateUploadPermissions(true);
+
+  base::StatisticsRecorder::ImportProvidedHistogramsSync();
+
+  // Verify PercentFull is sampled and within valid bounds (0 - 100%)
+  base::HistogramBase* percent_hist = base::StatisticsRecorder::FindHistogram(
+      "Cobalt.StabilityMetrics.PercentFull");
+  ASSERT_TRUE(percent_hist);
+  auto percent_samples = percent_hist->SnapshotSamples();
+  EXPECT_GT(percent_samples->TotalCount(), 0);
+  EXPECT_LE(percent_samples->sum() / percent_samples->TotalCount(), 100);
+
+  // Verify UsedKilobytes is sampled and within 0 - 512 KB
+  base::HistogramBase* used_kb_hist = base::StatisticsRecorder::FindHistogram(
+      "Cobalt.StabilityMetrics.UsedKilobytes");
+  ASSERT_TRUE(used_kb_hist);
+  auto used_samples = used_kb_hist->SnapshotSamples();
+  EXPECT_GT(used_samples->TotalCount(), 0);
+  EXPECT_LE(used_samples->sum() / used_samples->TotalCount(), 512);
+
+  // Verify we have not hit near-capacity condition under normal operation
+  // and that the false bucket (the denominator) is recorded.
+  base::HistogramBase* near_capacity_hist =
+      base::StatisticsRecorder::FindHistogram(
+          "Cobalt.StabilityMetrics.IsNearCapacity");
+  ASSERT_TRUE(near_capacity_hist);
+  EXPECT_EQ(near_capacity_hist->SnapshotSamples()->GetCount(1), 0);
+  EXPECT_GT(near_capacity_hist->SnapshotSamples()->GetCount(0), 0);
+}
+
+IN_PROC_BROWSER_TEST_F(CobaltMetricsBrowserTest,
+                       FileMetricsProviderRegistrationAndPrefs) {
+  auto* features = GlobalFeatures::GetInstance();
+  ASSERT_TRUE(features);
+  PrefService* local_state = features->metrics_local_state();
+  ASSERT_TRUE(local_state);
+
+  // Verify FileMetricsProvider prefs were properly registered for
+  // BrowserStabilityMetrics
+  EXPECT_TRUE(
+      local_state->FindPreference(metrics::prefs::kMetricsFileMetricsMetadata));
+  EXPECT_TRUE(
+      local_state->FindPreference(metrics::prefs::kMetricsLastSeenPrefix +
+                                  std::string("BrowserStabilityMetrics")));
 }
 
 }  // namespace cobalt

--- a/cobalt/browser/metrics/cobalt_metrics_service_client.cc
+++ b/cobalt/browser/metrics/cobalt_metrics_service_client.cc
@@ -17,18 +17,26 @@
 #include <memory>
 #include <string_view>
 
+#include "base/base_paths.h"
 #include "base/command_line.h"
+#include "base/functional/bind.h"
 #include "base/logging.h"
+#include "base/metrics/persistent_histogram_allocator.h"
+#include "base/path_service.h"
+#include "base/process/process_handle.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/task/sequenced_task_runner.h"
 #include "base/task/thread_pool.h"
 #include "base/threading/sequence_bound.h"
 #include "base/timer/timer.h"
 #include "base/version.h"
+#include "build/build_config.h"
+#include "build/buildflag.h"
 #include "cobalt/browser/features.h"
 #include "cobalt/browser/metrics/cobalt_cpu_metrics_emitter.h"
 #include "cobalt/browser/metrics/cobalt_memory_metrics_emitter.h"
 #include "cobalt/browser/metrics/cobalt_metrics_log_uploader.h"
+#include "components/metrics/file_metrics_provider.h"
 #include "components/metrics/metrics_service.h"
 #include "components/metrics/metrics_state_manager.h"
 #include "components/prefs/pref_service.h"
@@ -38,6 +46,22 @@
 #include "url/gurl.h"
 
 namespace cobalt {
+
+namespace {
+
+metrics::FileMetricsProvider::FilterAction FilterBrowserMetricsFiles(
+    const base::FilePath& path) {
+  base::ProcessId pid;
+  if (base::GlobalHistogramAllocator::ParseFilePath(path, nullptr, nullptr,
+                                                    &pid)) {
+    if (pid == base::GetCurrentProcId()) {
+      return metrics::FileMetricsProvider::FILTER_ACTIVE_THIS_PID;
+    }
+  }
+  return metrics::FileMetricsProvider::FILTER_PROCESS_FILE;
+}
+
+}  // namespace
 
 // TODO(b/495528560): Unify CPU and memory polling state into one class.
 class MetricsPollingState {
@@ -131,6 +155,35 @@ void CobaltMetricsServiceClient::Initialize() {
 
   metrics_service_ = CreateMetricsServiceInternal(metrics_state_manager_.get(),
                                                   this, local_state_.get());
+
+  // Register FileMetricsProvider for persistent stability metrics (.pma files)
+  base::FilePath base_dir;
+  bool path_ok = false;
+#if BUILDFLAG(IS_ANDROID)
+  path_ok = base::PathService::Get(base::DIR_ANDROID_APP_DATA, &base_dir);
+#else
+  path_ok = base::PathService::Get(base::DIR_TEMP, &base_dir);
+#endif
+  if (path_ok) {
+    base::FilePath metrics_dir =
+        base_dir.AppendASCII("BrowserStabilityMetrics");
+
+    auto file_metrics_provider =
+        std::make_unique<metrics::FileMetricsProvider>(local_state_.get());
+    metrics::FileMetricsProvider::Params params(
+        metrics_dir, metrics::FileMetricsProvider::SOURCE_HISTOGRAMS_ATOMIC_DIR,
+        metrics::FileMetricsProvider::ASSOCIATE_INTERNAL_PROFILE,
+        "BrowserStabilityMetrics");
+    params.filter = base::BindRepeating(&FilterBrowserMetricsFiles);
+    params.max_dir_kib = 10 * 1024;
+    file_metrics_provider->RegisterSource(params,
+                                          /*metrics_reporting_enabled=*/true);
+    metrics_service_->RegisterMetricsProvider(std::move(file_metrics_provider));
+  } else {
+    LOG(WARNING) << "Failed to get base directory for BrowserStabilityMetrics, "
+                 << "skipping FileMetricsProvider registration.";
+  }
+
   log_uploader_ = CreateLogUploaderInternal();
   log_uploader_weak_ptr_ = log_uploader_->GetWeakPtr();
   StartIdleRefreshTimer();

--- a/cobalt/browser/metrics/cobalt_metrics_service_client_test.cc
+++ b/cobalt/browser/metrics/cobalt_metrics_service_client_test.cc
@@ -36,6 +36,7 @@
 #include "cobalt/browser/metrics/cobalt_memory_metrics_emitter.h"
 #include "cobalt/browser/metrics/cobalt_metrics_log_uploader.h"
 #include "cobalt/shell/common/shell_paths.h"
+#include "components/metrics/file_metrics_provider.h"
 #include "components/metrics/metrics_pref_names.h"
 #include "components/metrics/metrics_service.h"
 #include "components/metrics/metrics_state_manager.h"
@@ -395,6 +396,9 @@ class CobaltMetricsServiceClientBaseTest : public ::testing::Test {
     // Register all metric-related prefs, otherwise tests crash when calling
     // upstream metrics code.
     metrics::MetricsService::RegisterPrefs(prefs_.registry());
+    metrics::FileMetricsProvider::RegisterPrefs(prefs_.registry());
+    metrics::FileMetricsProvider::RegisterSourcePrefs(
+        prefs_.registry(), "BrowserStabilityMetrics");
     prefs_.registry()->RegisterBooleanPref(
         metrics::prefs::kMetricsReportingEnabled, false);
 

--- a/cobalt/browser/metrics/cobalt_metrics_services_manager_client_test.cc
+++ b/cobalt/browser/metrics/cobalt_metrics_services_manager_client_test.cc
@@ -25,6 +25,7 @@
 #include "cobalt/browser/metrics/cobalt_enabled_state_provider.h"
 #include "cobalt/browser/metrics/cobalt_metrics_service_client.h"
 #include "cobalt/shell/common/shell_paths.h"
+#include "components/metrics/file_metrics_provider.h"
 #include "components/metrics/metrics_pref_names.h"
 #include "components/metrics/metrics_service.h"
 #include "components/metrics/metrics_state_manager.h"
@@ -56,6 +57,9 @@ class CobaltMetricsServicesManagerClientTest : public ::testing::Test {
         base::DIR_CACHE, temp_dir_.GetPath());
 
     metrics::MetricsService::RegisterPrefs(prefs_.registry());
+    metrics::FileMetricsProvider::RegisterPrefs(prefs_.registry());
+    metrics::FileMetricsProvider::RegisterSourcePrefs(
+        prefs_.registry(), "BrowserStabilityMetrics");
     // Add any other prefs that might be accessed.
     prefs_.registry()->RegisterBooleanPref(
         metrics::prefs::kMetricsReportingEnabled, false);

--- a/cobalt/testing/browser_tests/content_browser_test_content_browser_client.cc
+++ b/cobalt/testing/browser_tests/content_browser_test_content_browser_client.cc
@@ -19,6 +19,11 @@
 
 #include "base/test/task_environment.h"
 #include "cobalt/browser/cobalt_browser_interface_binders.h"
+#include "cobalt/browser/cobalt_browser_main_parts.h"
+#include "cobalt/browser/cobalt_web_contents_observer.h"
+#include "cobalt/shell/common/url_constants.h"
+#include "content/public/browser/render_frame_host.h"
+#include "content/public/browser/web_contents.h"
 #include "content/public/common/content_client.h"
 
 namespace content {
@@ -60,6 +65,49 @@ void ContentBrowserTestContentBrowserClient::
   cobalt::PopulateCobaltFrameBinders(std::nullopt, render_frame_host, map);
   ShellContentBrowserClient::RegisterBrowserInterfaceBindersForFrame(
       render_frame_host, map);
+}
+
+namespace {
+
+class ContentBrowserTestBrowserMainParts
+    : public cobalt::CobaltBrowserMainParts {
+ public:
+  ContentBrowserTestBrowserMainParts()
+      : cobalt::CobaltBrowserMainParts("", /*is_visible=*/true) {}
+
+  void PostOrRunIfStorageMigrationFinished(base::OnceClosure task) override {
+    // In browser tests, do not defer window creation tasks.
+    std::move(task).Run();
+  }
+
+ protected:
+  void InitializeMessageLoopContext() override {
+    // In browser tests, ensure the initial test shell window is created on all
+    // platforms including Android.
+    ShellBrowserMainParts::InitializeMessageLoopContext();
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<BrowserMainParts>
+ContentBrowserTestContentBrowserClient::CreateBrowserMainParts(
+    bool /*is_integration_test*/) {
+  auto browser_main_parts =
+      std::make_unique<ContentBrowserTestBrowserMainParts>();
+  set_browser_main_parts(browser_main_parts.get());
+  return browser_main_parts;
+}
+
+void ContentBrowserTestContentBrowserClient::OnWebContentsCreated(
+    content::WebContents* web_contents) {
+  if (web_contents->GetPrimaryMainFrame() &&
+      web_contents->GetPrimaryMainFrame()->GetFrameName() ==
+          content::kCobaltSplashMainFrameName) {
+    return;
+  }
+  web_contents_observer_ =
+      std::make_unique<cobalt::CobaltWebContentsObserver>(web_contents);
 }
 
 }  // namespace content

--- a/cobalt/testing/browser_tests/content_browser_test_content_browser_client.h
+++ b/cobalt/testing/browser_tests/content_browser_test_content_browser_client.h
@@ -19,6 +19,10 @@
 
 #include "cobalt/testing/browser_tests/browser/shell_content_browser_test_client.h"
 
+namespace cobalt {
+class CobaltWebContentsObserver;
+}
+
 namespace content {
 
 // ContentBrowserClient implementation used in content browser tests.
@@ -37,6 +41,14 @@ class ContentBrowserTestContentBrowserClient
   void RegisterBrowserInterfaceBindersForFrame(
       RenderFrameHost* render_frame_host,
       mojo::BinderMapWithContext<RenderFrameHost*>* map) override;
+
+  std::unique_ptr<BrowserMainParts> CreateBrowserMainParts(
+      bool is_integration_test) override;
+
+  void OnWebContentsCreated(content::WebContents* web_contents) override;
+
+ private:
+  std::unique_ptr<cobalt::CobaltWebContentsObserver> web_contents_observer_;
 };
 
 }  // namespace content

--- a/tools/metrics/histograms/metadata/cobalt/enums.xml
+++ b/tools/metrics/histograms/metadata/cobalt/enums.xml
@@ -44,6 +44,20 @@ https://chromium.googlesource.com/chromium/src.git/+/HEAD/tools/metrics/histogra
   <int value="1" label="Is hung"/>
 </enum>
 
+<enum name="CobaltStartupMilestone">
+  <int value="17" label="PreCreateThreads"/>
+  <int value="22" label="DidStartNavigation"/>
+  <int value="26" label="DidFinishNavigation"/>
+</enum>
+
+<enum name="FinchConfigOutcome">
+  <int value="0" label="Regular config loaded"/>
+  <int value="1" label="Safe config loaded"/>
+  <int value="2" label="Empty config loaded due to crash streak"/>
+  <int value="3" label="Empty config loaded due to expiration"/>
+  <int value="4" label="Empty config loaded due to rollback"/>
+</enum>
+
 <enum name="LocalStorageDatabaseResetReason">
   <int value="0" label="Failure to open the database"/>
   <int value="1" label="Schema version mismatch"/>
@@ -86,7 +100,8 @@ https://chromium.googlesource.com/chromium/src.git/+/HEAD/tools/metrics/histogra
   <int value="9" label="Roll back: Failed to check SABI"/>
   <int value="10" label="Roll back: Failed to look up symbols"/>
   <int value="11" label="Evergreen Lite"/>
-  <int value="12" label="Load system image: Failed to initialize installation manager"/>
+  <int value="12"
+      label="Load system image: Failed to initialize installation manager"/>
 </enum>
 
 <enum name="SplashScreenFetchedState">
@@ -121,14 +136,6 @@ https://chromium.googlesource.com/chromium/src.git/+/HEAD/tools/metrics/histogra
   <int value="0" label="Config is valid"/>
   <int value="1" label="Config is expired"/>
   <int value="2" label="Config is missing timestamp"/>
-</enum>
-
-<enum name="FinchConfigOutcome">
-  <int value="0" label="Regular config loaded"/>
-  <int value="1" label="Safe config loaded"/>
-  <int value="2" label="Empty config loaded due to crash streak"/>
-  <int value="3" label="Empty config loaded due to expiration"/>
-  <int value="4" label="Empty config loaded due to rollback"/>
 </enum>
 
 </enums>

--- a/tools/metrics/histograms/metadata/cobalt/histograms.xml
+++ b/tools/metrics/histograms/metadata/cobalt/histograms.xml
@@ -201,6 +201,7 @@ Always run the pretty print utility on this file after editing:
 <histogram name="Cobalt.LoaderApp.ElfDecompressionDuration" units="ms"
     expires_after="never">
 <!-- expires-never: Needed for long-term tracking of ELF load performance. -->
+
 <!-- TODO(b/537769651): Consider recording this metric for libcobalt.zst
      installations. -->
 
@@ -230,6 +231,7 @@ Always run the pretty print utility on this file after editing:
 <histogram name="Cobalt.LoaderApp.ElfLoadUnexplainedDuration" units="ms"
     expires_after="never">
 <!-- expires-never: Needed for long-term tracking of ELF load performance. -->
+
 <!-- TODO(b/537769651): Consider recording this metric for libcobalt.zst
      installations. -->
 
@@ -369,6 +371,53 @@ Always run the pretty print utility on this file after editing:
     Records whether a splash screen resource was successfully retrieved from
     cache and indicates the reason when on error. This is recorded for every
     splash screen request handled by h5vcc scheme loader.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.StabilityMetrics.IsNearCapacity" enum="Boolean"
+    expires_after="never">
+  <owner>avvall@google.com</owner>
+  <summary>
+    Records whether the Cobalt Persistent Memory Allocator (PMA) for stability
+    metrics is full or within 90% of capacity. Recorded at key startup stages.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.StabilityMetrics.PercentFull" units="%"
+    expires_after="never">
+  <owner>avvall@google.com</owner>
+  <summary>
+    The percentage of capacity currently used in the Cobalt Persistent Memory
+    Allocator (PMA) for stability metrics (BrowserStabilityMetrics). Recorded at
+    key startup stages.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.StabilityMetrics.UsedKilobytes" units="KB"
+    expires_after="never">
+  <owner>avvall@google.com</owner>
+  <summary>
+    The number of kilobytes currently used in the Cobalt Persistent Memory
+    Allocator (PMA) for stability metrics (BrowserStabilityMetrics). Recorded at
+    key startup stages.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.Startup.MilestoneReached" enum="CobaltStartupMilestone"
+    expires_after="never">
+  <owner>avvall@google.com</owner>
+  <summary>
+    Records startup milestone markers reached during browser initialization and
+    initial navigation.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.Startup.Time.NavigationDispatchToCommit" units="ms"
+    expires_after="never">
+  <owner>avvall@google.com</owner>
+  <summary>
+    Measures the duration from DidStartNavigation to DidFinishNavigation
+    (commit) for the initial startup navigation in the primary main frame.
   </summary>
 </histogram>
 
@@ -710,6 +759,16 @@ Always run the pretty print utility on this file after editing:
   </summary>
 </histogram>
 
+<histogram
+    name="Memory.Experimental.Renderer.PeakResidentSet.AtHighestPrivateMemoryFootprint"
+    units="MB" expires_after="2027-08-13">
+  <owner>avvall@google.com</owner>
+  <owner>cobalt-dev@google.com</owner>
+  <summary>
+    The peak resident set at the time of the highest private memory footprint.
+  </summary>
+</histogram>
+
 <histogram name="Memory.Media.AllocatedEncodedBuffer" units="MB"
     expires_after="never">
   <owner>tasunny@google.com</owner>
@@ -746,16 +805,6 @@ Always run the pretty print utility on this file after editing:
     are emitted.
   </summary>
 </histogram>
-
-<histogram name="Memory.Experimental.Renderer.PeakResidentSet.AtHighestPrivateMemoryFootprint"
-    units="MB" expires_after="2027-08-13">
-  <owner>avvall@google.com</owner>
-  <owner>cobalt-dev@google.com</owner>
-  <summary>
-    The peak resident set at the time of the highest private memory footprint.
-  </summary>
-</histogram>
-
 
 </histograms>
 


### PR DESCRIPTION
## Summary
Initializes a 512 KiB file-backed Persistent Memory Allocator (PMA) in `CobaltBrowserMainParts::PreEarlyInitialization()` under `BrowserStabilityMetrics/`.

## Key Changes
- **Persistent Allocator**: Instantiates a 512 KiB PMA with allocator ID `0x53544142` (`"STAB"`) and registers the allocator with `metrics::GlobalPersistentSystemProfile`.
- **Metrics Harvesting**: Integrates `metrics::FileMetricsProvider` in `CobaltMetricsServiceClient` configured with `SOURCE_HISTOGRAMS_ATOMIC_DIR` and `ASSOCIATE_INTERNAL_PROFILE` to automatically upload persistent stability histograms from prior sessions.
- **Preference Registration**: Registers `FileMetricsProvider` metadata and last-seen preferences in `GlobalFeatures`.
- **Capacity Monitoring**: Adds `LogStabilityMetricsCapacity()` to monitor PMA capacity (`Cobalt.StabilityMetrics.PercentFull`, `UsedKilobytes`, and `IsNearCapacity`), logging a warning if >= 90% full.
- **Startup Milestones**: Records milestones 17 (`PreCreateThreads`), 22 (`DidStartNavigation`), and 26 (`DidFinishNavigation`), along with `Cobalt.Startup.Time.NavigationDispatchToCommit`.
- **Browser Tests**: Adds comprehensive browser tests in `cobalt_browsertests` validating allocator initialization, capacity monitoring, milestone emission, and preference registration.

## Verification
Test: `out/linux-x64x11_devel/bin/run_cobalt_browsertests --gtest_filter="CobaltMetricsBrowserTest.StabilityMetrics*:CobaltMetricsBrowserTest.StartupMilestones*:CobaltMetricsBrowserTest.FileMetricsProvider*"`

Bug: 555232785
