### PR TITLE
cobalt: Add measureSystemMemoryInfo bulk performance API

### DIFF
--- a/cobalt/browser/performance/performance_impl.cc
+++ b/cobalt/browser/performance/performance_impl.cc
@@ -69,8 +69,86 @@ void PerformanceImpl::Create(
                       std::move(receiver));
 }
 
-void PerformanceImpl::MeasureAvailableCpuMemory(
-    MeasureAvailableCpuMemoryCallback callback) {
+void PerformanceImpl::MeasureSystemMemoryInfo(
+    MeasureSystemMemoryInfoCallback callback) {
+  base::ThreadPool::PostTaskAndReplyWithResult(
+      FROM_HERE, {base::MayBlock(), base::TaskPriority::USER_VISIBLE},
+      base::BindOnce([]() -> mojom::SystemMemoryInfoPtr {
+        auto info = mojom::SystemMemoryInfo::New();
+
+        auto process_metrics = base::ProcessMetrics::CreateProcessMetrics(
+            base::GetCurrentProcessHandle());
+        if (process_metrics) {
+          auto mem_info = process_metrics->GetMemoryInfo();
+          if (mem_info.has_value()) {
+            info->used_rss_memory = mem_info->resident_set_bytes;
+            info->reserved_virtual_memory = mem_info->vm_size_bytes;
+#if !BUILDFLAG(IS_IOS_TVOS)
+            info->used_swap_memory = mem_info->vm_swap_bytes;
+#endif
+#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID)
+            info->rss_high_water_mark_memory = mem_info->vm_hwm_bytes;
+            info->used_rss_anon_memory = mem_info->rss_anon_bytes;
+#endif
+          }
+        }
+
+        info->free_rss_memory =
+            base::SysInfo::AmountOfAvailablePhysicalMemory();
+
+#if BUILDFLAG(IS_POSIX) && defined(_SC_PHYS_PAGES)
+        long pages = sysconf(_SC_PHYS_PAGES);
+#if defined(_SC_PAGESIZE)
+        long page_size = sysconf(_SC_PAGESIZE);
+#elif defined(_SC_PAGE_SIZE)
+        long page_size = sysconf(_SC_PAGE_SIZE);
+#else
+        long page_size = -1;
+#endif
+        if (pages > 0 && page_size > 0) {
+          info->total_cpu_memory =
+              static_cast<uint64_t>(pages) * static_cast<uint64_t>(page_size);
+        }
+#endif
+
+#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID)
+        auto smaps_rollup = base::debug::ReadAndParseSmapsRollup();
+        if (smaps_rollup.has_value()) {
+          info->used_pss_memory = smaps_rollup->pss;
+        }
+#endif
+
+#if BUILDFLAG(IS_STARBOARD)
+        int64_t limit = SbSystemGetTotalCPUMemory();
+        if (limit > 0) {
+          info->application_limit_memory = static_cast<uint64_t>(limit);
+        }
+#endif
+
+#if BUILDFLAG(IS_STARBOARD)
+        if (SbSystemHasCapability(kSbSystemCapabilityCanQueryGPUMemoryStats)) {
+          info->used_gpu_memory = SbSystemGetUsedGPUMemory();
+        }
+#elif BUILDFLAG(IS_ANDROID)
+        JNIEnv* env = base::android::AttachCurrentThread();
+        base::android::ScopedJavaLocalRef<jobject> memory_info =
+            Java_MemoryInfoBridge_getActivityManagerMemoryInfoForSelf(env);
+        if (!memory_info.is_null()) {
+          int graphics_kb =
+              Java_CobaltMemoryInfoBridge_getGraphicsMemoryKb(env, memory_info);
+          if (graphics_kb >= 0) {
+            info->used_gpu_memory = static_cast<uint64_t>(graphics_kb) * 1024;
+          }
+        }
+#endif
+
+        return info;
+      }),
+      std::move(callback));
+}
+
+void PerformanceImpl::MeasureFreeRssMemory(
+    MeasureFreeRssMemoryCallback callback) {
   // Use lambda to resolve overload resolution ambiguity on platforms like
   // Android.
   base::ThreadPool::PostTaskAndReplyWithResult(
@@ -80,8 +158,13 @@ void PerformanceImpl::MeasureAvailableCpuMemory(
       std::move(callback));
 }
 
-void PerformanceImpl::MeasureUsedCpuMemory(
-    MeasureUsedCpuMemoryCallback callback) {
+void PerformanceImpl::MeasureAvailableCpuMemory(
+    MeasureAvailableCpuMemoryCallback callback) {
+  MeasureFreeRssMemory(std::move(callback));
+}
+
+void PerformanceImpl::MeasureUsedRssMemory(
+    MeasureUsedRssMemoryCallback callback) {
   base::ThreadPool::PostTaskAndReplyWithResult(
       FROM_HERE, {base::MayBlock(), base::TaskPriority::USER_VISIBLE},
       base::BindOnce([]() -> uint64_t {
@@ -94,6 +177,11 @@ void PerformanceImpl::MeasureUsedCpuMemory(
         return info.has_value() ? info->resident_set_bytes : 0;
       }),
       std::move(callback));
+}
+
+void PerformanceImpl::MeasureUsedCpuMemory(
+    MeasureUsedCpuMemoryCallback callback) {
+  MeasureUsedRssMemory(std::move(callback));
 }
 
 void PerformanceImpl::MeasureUsedSwapMemory(

--- a/cobalt/browser/performance/performance_impl.h
+++ b/cobalt/browser/performance/performance_impl.h
@@ -42,7 +42,10 @@ class PerformanceImpl
   PerformanceImpl(const PerformanceImpl&) = delete;
   PerformanceImpl& operator=(const PerformanceImpl&) = delete;
 
+  void MeasureSystemMemoryInfo(MeasureSystemMemoryInfoCallback) override;
+  void MeasureFreeRssMemory(MeasureFreeRssMemoryCallback) override;
   void MeasureAvailableCpuMemory(MeasureAvailableCpuMemoryCallback) override;
+  void MeasureUsedRssMemory(MeasureUsedRssMemoryCallback) override;
   void MeasureUsedCpuMemory(MeasureUsedCpuMemoryCallback) override;
   void MeasureUsedSwapMemory(MeasureUsedSwapMemoryCallback) override;
   void MeasureReservedVirtualMemory(

--- a/cobalt/browser/performance/public/mojom/performance.mojom
+++ b/cobalt/browser/performance/public/mojom/performance.mojom
@@ -14,13 +14,38 @@
 
 module performance.mojom;
 
+struct SystemMemoryInfo {
+  uint64 free_rss_memory;
+  uint64 used_rss_memory;
+  uint64 used_swap_memory;
+  uint64 reserved_virtual_memory;
+  uint64 rss_high_water_mark_memory;
+  uint64 used_rss_anon_memory;
+  uint64 total_cpu_memory;
+  uint64 used_pss_memory;
+  uint64 application_limit_memory;
+  uint64? used_gpu_memory;
+};
+
 interface CobaltPerformance {
+  // Get a snapshot of all system memory metrics in a single call.
+  [Sync]
+  MeasureSystemMemoryInfo() => (SystemMemoryInfo info);
+
   // Get the amount of available memory on the device in bytes.
+  [Sync]
+  MeasureFreeRssMemory() => (uint64 bytes);
+
+  // Deprecated alias for MeasureFreeRssMemory.
   [Sync]
   MeasureAvailableCpuMemory() => (uint64 bytes);
 
   // Get the amount of memory used by the Cobalt process, in bytes. This is also
   // known as the resident set size.
+  [Sync]
+  MeasureUsedRssMemory() => (uint64 bytes);
+
+  // Deprecated alias for MeasureUsedRssMemory.
   [Sync]
   MeasureUsedCpuMemory() => (uint64 bytes);
 

--- a/third_party/blink/renderer/bindings/generated_in_core.gni
+++ b/third_party/blink/renderer/bindings/generated_in_core.gni
@@ -2019,6 +2019,10 @@ generated_union_sources_in_core = [
 ]
 
 if (is_cobalt) {
+  generated_dictionary_sources_in_core += [
+    "$root_gen_dir/third_party/blink/renderer/bindings/core/v8/v8_system_memory_info.cc",
+    "$root_gen_dir/third_party/blink/renderer/bindings/core/v8/v8_system_memory_info.h",
+  ]
   generated_union_sources_in_core += [
     "$root_gen_dir/third_party/blink/renderer/bindings/core/v8/v8_union_boolean_double_long_string.cc",
     "$root_gen_dir/third_party/blink/renderer/bindings/core/v8/v8_union_boolean_double_long_string.h",

--- a/third_party/blink/renderer/bindings/idl_in_core.gni
+++ b/third_party/blink/renderer/bindings/idl_in_core.gni
@@ -814,7 +814,10 @@ static_idl_files_in_core = [
 
 if (is_cobalt) {
   static_idl_files_in_core += get_path_info(
-          [ "//third_party/blink/renderer/core/cobalt/performance/performance_extensions.idl" ],
+          [
+            "//third_party/blink/renderer/core/cobalt/performance/performance_extensions.idl",
+            "//third_party/blink/renderer/core/cobalt/performance/system_memory_info.idl",
+          ],
           "abspath")
   if (use_starboard_media) {
     static_idl_files_in_core += get_path_info(

--- a/third_party/blink/renderer/core/cobalt/performance/performance_extensions.cc
+++ b/third_party/blink/renderer/core/cobalt/performance/performance_extensions.cc
@@ -14,13 +14,17 @@
 
 #include "third_party/blink/renderer/core/cobalt/performance/performance_extensions.h"
 
+#include "build/build_config.h"
 #include "cobalt/browser/performance/public/mojom/performance.mojom.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "third_party/blink/public/platform/browser_interface_broker_proxy.h"
+#include "third_party/blink/public/platform/platform.h"
 #include "third_party/blink/renderer/bindings/core/v8/script_promise_resolver.h"
+#include "third_party/blink/renderer/bindings/core/v8/v8_system_memory_info.h"
 #include "third_party/blink/renderer/core/dom/dom_exception.h"
 #include "third_party/blink/renderer/core/execution_context/execution_context.h"
 #include "third_party/blink/renderer/core/timing/performance.h"
+#include "v8/include/v8.h"
 
 namespace blink {
 
@@ -41,19 +45,75 @@ mojo::Remote<performance::mojom::CobaltPerformance> BindRemotePerformance(
 
 }  // namespace
 
-uint64_t PerformanceExtensions::measureAvailableCpuMemory(
+SystemMemoryInfo* PerformanceExtensions::measureSystemMemoryInfo(
     ScriptState* script_state,
     const Performance&) {
+  auto* result = SystemMemoryInfo::Create();
+
+  performance::mojom::SystemMemoryInfoPtr info;
+  BindRemotePerformance(script_state)->MeasureSystemMemoryInfo(&info);
+
+  if (info) {
+    result->setFreeRssMemory(info->free_rss_memory);
+    result->setUsedRssMemory(info->used_rss_memory);
+    result->setUsedSwapMemory(info->used_swap_memory);
+    result->setReservedVirtualMemory(info->reserved_virtual_memory);
+    result->setRssHighWaterMarkMemory(info->rss_high_water_mark_memory);
+    result->setUsedRssAnonMemory(info->used_rss_anon_memory);
+    result->setTotalCpuMemory(info->total_cpu_memory);
+    result->setUsedPssMemory(info->used_pss_memory);
+    result->setApplicationLimitMemory(info->application_limit_memory);
+    if (info->used_gpu_memory.has_value()) {
+      result->setUsedGpuMemory(info->used_gpu_memory.value());
+    }
+  }
+
+  if (script_state && script_state->GetIsolate()) {
+    v8::HeapStatistics heap_statistics;
+    script_state->GetIsolate()->GetHeapStatistics(&heap_statistics);
+    result->setUsedJSHeapSize(heap_statistics.used_heap_size());
+    result->setTotalJSHeapSize(heap_statistics.total_physical_size());
+    result->setJsHeapSizeLimit(heap_statistics.heap_size_limit());
+  }
+
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  if (Platform::Current()) {
+    result->setMediaSourceTotalAllocatedMemory(
+        Platform::Current()->GetMediaSourceTotalAllocatedMemory());
+    result->setMediaSourceCurrentMemoryCapacity(
+        Platform::Current()->GetMediaSourceCurrentMemoryCapacity());
+    result->setMediaSourceMaximumMemoryCapacity(
+        Platform::Current()->GetMediaSourceMaximumMemoryCapacity());
+  }
+#endif
+
+  return result;
+}
+
+uint64_t PerformanceExtensions::measureFreeRssMemory(ScriptState* script_state,
+                                                     const Performance&) {
   uint64_t free_memory = 0;
-  BindRemotePerformance(script_state)->MeasureAvailableCpuMemory(&free_memory);
+  BindRemotePerformance(script_state)->MeasureFreeRssMemory(&free_memory);
   return free_memory;
 }
 
-uint64_t PerformanceExtensions::measureUsedCpuMemory(ScriptState* script_state,
+uint64_t PerformanceExtensions::measureAvailableCpuMemory(
+    ScriptState* script_state,
+    const Performance& performance) {
+  return measureFreeRssMemory(script_state, performance);
+}
+
+uint64_t PerformanceExtensions::measureUsedRssMemory(ScriptState* script_state,
                                                      const Performance&) {
   uint64_t used_memory = 0;
-  BindRemotePerformance(script_state)->MeasureUsedCpuMemory(&used_memory);
+  BindRemotePerformance(script_state)->MeasureUsedRssMemory(&used_memory);
   return used_memory;
+}
+
+uint64_t PerformanceExtensions::measureUsedCpuMemory(
+    ScriptState* script_state,
+    const Performance& performance) {
+  return measureUsedRssMemory(script_state, performance);
 }
 
 uint64_t PerformanceExtensions::measureUsedSwapMemory(ScriptState* script_state,

--- a/third_party/blink/renderer/core/cobalt/performance/performance_extensions.h
+++ b/third_party/blink/renderer/core/cobalt/performance/performance_extensions.h
@@ -26,13 +26,18 @@ namespace blink {
 class ExceptionState;
 class Performance;
 class ScriptState;
+class SystemMemoryInfo;
 
 class CORE_EXPORT PerformanceExtensions final {
   STATIC_ONLY(PerformanceExtensions);
 
  public:
   // Web-exposed interface:
+  static SystemMemoryInfo* measureSystemMemoryInfo(ScriptState*,
+                                                   const Performance&);
+  static uint64_t measureFreeRssMemory(ScriptState*, const Performance&);
   static uint64_t measureAvailableCpuMemory(ScriptState*, const Performance&);
+  static uint64_t measureUsedRssMemory(ScriptState*, const Performance&);
   static uint64_t measureUsedCpuMemory(ScriptState*, const Performance&);
   static uint64_t measureUsedSwapMemory(ScriptState*, const Performance&);
   static uint64_t measureReservedVirtualMemory(ScriptState*,

--- a/third_party/blink/renderer/core/cobalt/performance/performance_extensions.idl
+++ b/third_party/blink/renderer/core/cobalt/performance/performance_extensions.idl
@@ -2,12 +2,21 @@
 [
     ImplementedAs=PerformanceExtensions
 ] partial interface Performance {
+    // Returns a snapshot of system memory metrics in a single call.
+    [CallWith=ScriptState] SystemMemoryInfo measureSystemMemoryInfo();
+
     // Returns the amount of available memory on the device in bytes, according
     // to base::SysInfo::AmountOfAvailablePhysicalMemory().
+    [CallWith=ScriptState] unsigned long long measureFreeRssMemory();
+
+    // Deprecated alias for measureFreeRssMemory.
     [CallWith=ScriptState] unsigned long long measureAvailableCpuMemory();
 
     // Returns the amount of memory used by the Cobalt process, in bytes. This
     // is also known as the resident set size.
+    [CallWith=ScriptState] unsigned long long measureUsedRssMemory();
+
+    // Deprecated alias for measureUsedRssMemory.
     [CallWith=ScriptState] unsigned long long measureUsedCpuMemory();
 
     // Returns the amount of virtual memory that has been swapped out to disk in bytes.

--- a/third_party/blink/renderer/core/cobalt/performance/system_memory_info.idl
+++ b/third_party/blink/renderer/core/cobalt/performance/system_memory_info.idl
@@ -1,0 +1,65 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Non standard interface used for Cobalt only.
+// Bulk response for system memory metrics. All values are in bytes.
+dictionary SystemMemoryInfo {
+    // Amount of available physical memory on the device.
+    unsigned long long freeRssMemory;
+
+    // Amount of resident memory used by the process (RSS).
+    unsigned long long usedRssMemory;
+
+    // Amount of virtual memory that has been swapped out to disk.
+    unsigned long long usedSwapMemory;
+
+    // Total virtual memory size reserved for the process.
+    unsigned long long reservedVirtualMemory;
+
+    // Peak resident set size (high-water mark).
+    unsigned long long rssHighWaterMarkMemory;
+
+    // Amount of memory allocated to the heap and not shared with other processes.
+    unsigned long long usedRssAnonMemory;
+
+    // Total physical RAM available on the device.
+    unsigned long long totalCpuMemory;
+
+    // Proportional set size (PSS) memory in use.
+    unsigned long long usedPssMemory;
+
+    // Maximum memory limit allocated to Cobalt by Starboard.
+    unsigned long long applicationLimitMemory;
+
+    // GPU memory used by the process, or null if unsupported on the platform.
+    unsigned long long? usedGpuMemory = null;
+
+    // The portion of the heap currently used by JavaScript objects.
+    unsigned long long? usedJSHeapSize = null;
+
+    // Total allocated heap size for JavaScript execution.
+    unsigned long long? totalJSHeapSize = null;
+
+    // Maximum JavaScript heap size allowed before terminating the execution context.
+    unsigned long long? jsHeapSizeLimit = null;
+
+    // Total memory allocated for MediaSource buffers.
+    unsigned long long? mediaSourceTotalAllocatedMemory = null;
+
+    // Current memory capacity allocated for MediaSource buffers.
+    unsigned long long? mediaSourceCurrentMemoryCapacity = null;
+
+    // Maximum allowable memory capacity for MediaSource buffers.
+    unsigned long long? mediaSourceMaximumMemoryCapacity = null;
+};


### PR DESCRIPTION
Add a unified performance.measureSystemMemoryInfo() API to retrieve all system, V8 JavaScript heap, and Starboard media memory metrics:
- Process OS memory: used RSS, free RSS, swap, reserved VM, peak RSS, anonymous RSS, PSS, total CPU memory, app limits, and GPU memory
- V8 JS heap: used JS heap, total JS heap, and JS heap limit
- Starboard Media: total allocated media memory, current capacity, and maximum capacity

Additionally, rename measureUsedCpuMemory to measureUsedRssMemory and measureAvailableCpuMemory to measureFreeRssMemory to avoid terminology confusion, retaining the previous methods as deprecated aliases for backwards compatibility.

Bug: 549199426