### PR TITLE
[starboard][android] Do not restart playback on audio device change i…

### DIFF
--- a/starboard/android/shared/audio_track_audio_sink_type.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type.cc
@@ -287,10 +287,8 @@ void AudioTrackAudioSink::AudioThreadFunc() {
     int64_t playback_head_position = 0;
     int64_t frames_consumed_at = 0;
     if (audio_track_->GetAndResetHasAudioDeviceChanged()) {
-      SB_LOG(INFO) << "Audio device changed, raising a capability changed "
-                      "error to restart playback.";
-      ReportError(true, "Audio device capability changed");
-      break;
+      SB_LOG(INFO) << "Audio device changed; continuing playback without "
+                      "restarting.";
     }
 
     // The audio data at the returned position by


### PR DESCRIPTION
…n AudioTrackAudioSink

When an audio device connects or disconnects (such as a Bluetooth speaker or HDMI ARC), AudioTrackAudioSink previously raised a capability-changed error that triggered a full player teardown and recreation, resulting in a black screen and loading spinner for several seconds.

For standard PCM playback, Android's AudioTrack handles audio rerouting transparently in AudioFlinger. Genuine stream failures (e.g. dead objects) are already caught and handled on write errors.

This change ignores audio device change events in AudioTrackAudioSink and logs the transition, allowing PCM playback to continue seamlessly across routing changes.

BUG=523148108
TAG=agy
CONV=a409072b-a360-4a55-bd3e-0790594cdb86