### PR TITLE
build: Update base Docker image for Linux

### DIFF
--- a/docker/linux/base/Dockerfile
+++ b/docker/linux/base/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_OS
 ARG BASE_OS_TAG
-FROM ${BASE_OS:-gcr.io/cloud-marketplace-containers/google/debian10}:${BASE_OS_TAG:-latest}
+FROM ${BASE_OS:-debian}:${BASE_OS_TAG:-10-slim}
 
 ENV PYTHONUNBUFFERED 1
 


### PR DESCRIPTION
Replace deprecated/unauthorized GCR debian10 base image with official Docker Hub debian:10-slim.

Bug: 555298755