### PR TITLE
tvos: Skip test targets on nightly builds

### DIFF
--- a/cobalt/devinfra/kokoro/bin/common.sh
+++ b/cobalt/devinfra/kokoro/bin/common.sh
@@ -124,6 +124,11 @@ is_release_build () {
 }
 
 
+is_nightly_build () {
+  is_release_build || [[ "${KOKORO_JOB_NAME:-}" == *nightly* ]] || [[ "${KOKORO_ROOT_JOB_NAME:-}" == *nightly* ]]
+}
+
+
 is_release_config () {
   [[ "${RELEASE_CONFIGS}" =~ "${CONFIG}" ]]
 }

--- a/cobalt/devinfra/kokoro/bin/presubmit_build_mac.sh
+++ b/cobalt/devinfra/kokoro/bin/presubmit_build_mac.sh
@@ -85,9 +85,6 @@ EOF
   local json_targets=""
   if ! is_nightly_build; then
     local test_targets_json="${WORKSPACE_COBALT}/cobalt/build/testing/targets/${TARGET_PLATFORM}/test_targets.json"
-    if [[ ! -f "${test_targets_json}" ]]; then
-      test_targets_json="${WORKSPACE_COBALT}/cobalt/build/testing/targets/tvos-arm64-simulator/test_targets.json"
-    fi
     if [[ -f "${test_targets_json}" ]]; then
       # Extract test targets from the JSON file (list of dicts schema)
       # and format them as a space-separated list of target names (after the colon).

--- a/cobalt/devinfra/kokoro/bin/presubmit_build_mac.sh
+++ b/cobalt/devinfra/kokoro/bin/presubmit_build_mac.sh
@@ -81,14 +81,19 @@ EOF
   # Build Cobalt.
   local out_dir="${WORKSPACE_COBALT}/out/${TARGET_PLATFORM}_${CONFIG}"
 
-  # Extract test targets from JSON.
+  # Extract test targets from JSON for non-nightly (e.g. presubmit) builds.
   local json_targets=""
-  local test_targets_json="${WORKSPACE_COBALT}/cobalt/build/testing/targets/tvos-arm64-simulator/test_targets.json"
-  if [[ -f "${test_targets_json}" ]]; then
-    # Extract test targets from the JSON file (list of dicts schema)
-    # and format them as a space-separated list of target names (after the colon).
-    json_targets=$(python3 -c "import json, re; data=json.loads(re.sub(r'//.*', '', open('${test_targets_json}').read())); targets=[e['target'] for e in data if isinstance(e, dict) and 'target' in e]; print(' '.join(t.split(':')[-1] for t in targets))")
-    GN_TARGET="${GN_TARGET:-} ${json_targets}"
+  if ! is_nightly_build; then
+    local test_targets_json="${WORKSPACE_COBALT}/cobalt/build/testing/targets/${TARGET_PLATFORM}/test_targets.json"
+    if [[ ! -f "${test_targets_json}" ]]; then
+      test_targets_json="${WORKSPACE_COBALT}/cobalt/build/testing/targets/tvos-arm64-simulator/test_targets.json"
+    fi
+    if [[ -f "${test_targets_json}" ]]; then
+      # Extract test targets from the JSON file (list of dicts schema)
+      # and format them as a space-separated list of target names (after the colon).
+      json_targets=$(python3 -c "import json, re; data=json.loads(re.sub(r'//.*', '', open('${test_targets_json}').read())); targets=[e['target'] for e in data if isinstance(e, dict) and 'target' in e]; print(' '.join(t.split(':')[-1] for t in targets))")
+      GN_TARGET="${GN_TARGET:-} ${json_targets}"
+    fi
   fi
 
   autoninja -C "${out_dir}" ${GN_TARGET}


### PR DESCRIPTION
Ensure Kokoro nightly builds do not parse or append test targets to
GN_TARGET regardless of build configuration, restricting test target
compilation to presubmit builds.

Tag: agy
Conv: 0b9b2541-b462-4f3a-90ac-a3533440ee35
Bug: 555298615

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>