### PR TITLE
media: Ignore MediaCodec callbacks during flush

### DIFF
--- a/starboard/shared/starboard/experimental_features.h
+++ b/starboard/shared/starboard/experimental_features.h
@@ -209,7 +209,8 @@ inline constexpr ExperimentalFeatureKey<bool> kMediaForceDualThreads(
 
 inline constexpr ExperimentalFeatureKey<bool>
     kMediaIgnoreMediaCodecCallbacksDuringFlushing(
-        "Media.IgnoreMediaCodecCallbacksDuringFlushing");
+        "Media.IgnoreMediaCodecCallbacksDuringFlushing",
+        true);
 
 inline constexpr ExperimentalFeatureKey<bool> kMediaNdkAudioTrack(
     "Media.NdkAudioTrack");


### PR DESCRIPTION
Enable the IgnoreMediaCodecCallbacksDuringFlushing experimental feature
by default. This improvement helps reduce qoe.restart errors by
ensuring that MediaCodec callbacks are ignored while a flush
operation is in progress.

Issue: 497004556
Issue: 524642946