### PR TITLE
Enforce default max cache size

### DIFF
--- a/cobalt/browser/cobalt_content_browser_client.cc
+++ b/cobalt/browser/cobalt_content_browser_client.cc
@@ -28,6 +28,7 @@
 #include "base/metrics/field_trial_params.h"
 #include "base/metrics/histogram_functions.h"
 #include "base/metrics/histogram_macros.h"
+#include "base/numerics/safe_conversions.h"
 #include "base/path_service.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_split.h"
@@ -83,6 +84,7 @@
 
 #if BUILDFLAG(IS_STARBOARD)
 #include "cobalt/browser/h5vcc_system/h5vcc_system_impl_base.h"
+#include "starboard/configuration_constants.h"
 #endif
 
 #if BUILDFLAG(USE_EVERGREEN)
@@ -413,6 +415,11 @@ void CobaltContentBrowserClient::ConfigureNetworkContextParams(
     CHECK(base::PathService::Get(base::DIR_CACHE, &cache_path));
     network_context_params->file_paths->http_cache_directory =
         cache_path.Append(kCacheDirname);
+
+#if BUILDFLAG(IS_STARBOARD)
+    network_context_params->http_cache_max_size =
+        base::saturated_cast<int32_t>(kSbMaxSystemPathCacheDirectorySize);
+#endif
 
     base::FilePath user_data_dir =
         context->GetPath().Append(relative_partition_path);

--- a/cobalt/browser/cobalt_content_browser_client_unittest.cc
+++ b/cobalt/browser/cobalt_content_browser_client_unittest.cc
@@ -17,10 +17,19 @@
 #include <string>
 #include <variant>
 
+#include "base/command_line.h"
+#include "base/numerics/safe_conversions.h"
+#include "base/test/scoped_command_line.h"
 #include "base/test/task_environment.h"
 #include "build/build_config.h"
 #include "cobalt/browser/global_features.h"
 #include "content/public/browser/overlay_window.h"
+#include "content/public/test/browser_task_environment.h"
+#include "content/public/test/test_browser_context.h"
+#include "services/network/public/mojom/network_context.mojom.h"
+#if BUILDFLAG(IS_STARBOARD)
+#include "starboard/configuration_constants.h"
+#endif
 #include "testing/gtest/include/gtest/gtest.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 
@@ -29,9 +38,7 @@ namespace {
 
 class CobaltContentBrowserClientTest : public testing::Test {
  protected:
-  base::test::TaskEnvironment task_environment_{
-      base::test::TaskEnvironment::MainThreadType::DEFAULT,
-      base::test::TaskEnvironment::ThreadPoolExecutionMode::QUEUED};
+  content::BrowserTaskEnvironment task_environment_;
 };
 
 TEST_F(CobaltContentBrowserClientTest, ParseAndApplyH5vccSettingsForTesting) {
@@ -63,6 +70,53 @@ TEST_F(CobaltContentBrowserClientTest,
 #else
   EXPECT_EQ(window, nullptr);
 #endif
+}
+
+TEST_F(CobaltContentBrowserClientTest,
+       ConfigureNetworkContextParams_DefaultHttpCacheMaxSize) {
+#if BUILDFLAG(IS_STARBOARD)
+  CobaltContentBrowserClient client(/*startup_timestamp=*/absl::nullopt,
+                                    /*deep_link=*/"",
+                                    /*is_visible=*/true);
+  content::TestBrowserContext context;
+  auto params = network::mojom::NetworkContextParams::New();
+  client.ConfigureNetworkContextParams(
+      &context, /*in_memory=*/false, base::FilePath(), params.get(),
+      /*cert_verifier_creation_params=*/nullptr);
+  EXPECT_EQ(params->http_cache_max_size,
+            base::saturated_cast<int32_t>(kSbMaxSystemPathCacheDirectorySize));
+#else
+  GTEST_SKIP() << "kSbMaxSystemPathCacheDirectorySize is not defined for "
+                  "non-Starboard builds.";
+#endif
+}
+
+TEST_F(CobaltContentBrowserClientTest,
+       ConfigureNetworkContextParams_HttpCacheMaxSizeFromCommandLineOverride) {
+  base::test::ScopedCommandLine scoped_command_line;
+  scoped_command_line.GetProcessCommandLine()->AppendSwitchASCII(
+      "max-http-cache-size", "12345");
+  CobaltContentBrowserClient client(/*startup_timestamp=*/absl::nullopt,
+                                    /*deep_link=*/"",
+                                    /*is_visible=*/true);
+  content::TestBrowserContext context;
+  auto params = network::mojom::NetworkContextParams::New();
+  client.ConfigureNetworkContextParams(
+      &context, /*in_memory=*/false, base::FilePath(), params.get(),
+      /*cert_verifier_creation_params=*/nullptr);
+  EXPECT_EQ(params->http_cache_max_size, 12345);
+}
+
+TEST_F(CobaltContentBrowserClientTest,
+       ConfigureNetworkContextParams_HttpCacheMaxSizeZeroWhenInMemory) {
+  CobaltContentBrowserClient client(/*startup_timestamp=*/absl::nullopt,
+                                    /*deep_link=*/"",
+                                    /*is_visible=*/true);
+  auto params = network::mojom::NetworkContextParams::New();
+  client.ConfigureNetworkContextParams(
+      /*context=*/nullptr, /*in_memory=*/true, base::FilePath(), params.get(),
+      /*cert_verifier_creation_params=*/nullptr);
+  EXPECT_EQ(params->http_cache_max_size, 0);
 }
 
 }  // namespace


### PR DESCRIPTION
Sets `network_context_params->http_cache_max_size` to kSbMaxSystemPathCacheDirectorySize by default, which was the behavior on C25. Otherwise, the default size of 0 allows Cobalt to use all available disk space for cache.

Bug: 527972396