### PR TITLE
media: Add SbPlayer performance benchmarks

### DIFF
--- a/build/android/pylib/gtest/gtest_test_instance.py
+++ b/build/android/pylib/gtest/gtest_test_instance.py
@@ -44,7 +44,8 @@ RUN_IN_SUB_THREAD_TEST_SUITES = [
     'ipc_tests',
     'mojo_perftests',
     'mojo_unittests',
-    'net_unittests'
+    'net_unittests',
+    'player_benchmarks_gtest'
 ]
 
 

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/BaseCobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/BaseCobaltActivity.java
@@ -30,7 +30,9 @@ import dev.cobalt.util.Log;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
+import org.chromium.base.CommandLine;
 
 /**
  * Base Activity shared by all Cobalt embedders. It owns the StarboardBridge lifecycle
@@ -146,6 +148,19 @@ public abstract class BaseCobaltActivity extends Activity {
     ArrayList<String> args = new ArrayList<>();
     if (commandLineArgs != null) {
       args.addAll(Arrays.asList(commandLineArgs));
+    }
+
+    if (CommandLine.isInitialized()) {
+      CommandLine commandLine = CommandLine.getInstance();
+      for (Map.Entry<String, String> entry : commandLine.getSwitches().entrySet()) {
+        String key = entry.getKey();
+        String value = entry.getValue();
+        if (value != null && !value.isEmpty()) {
+          args.add("--" + key + "=" + value);
+        } else {
+          args.add("--" + key);
+        }
+      }
     }
 
     // If the URL arg isn't specified, get it from AndroidManifest.xml.

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/BaseCobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/BaseCobaltActivity.java
@@ -30,9 +30,7 @@ import dev.cobalt.util.Log;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.regex.Pattern;
-import org.chromium.base.CommandLine;
 
 /**
  * Base Activity shared by all Cobalt embedders. It owns the StarboardBridge lifecycle
@@ -148,19 +146,6 @@ public abstract class BaseCobaltActivity extends Activity {
     ArrayList<String> args = new ArrayList<>();
     if (commandLineArgs != null) {
       args.addAll(Arrays.asList(commandLineArgs));
-    }
-
-    if (CommandLine.isInitialized()) {
-      CommandLine commandLine = CommandLine.getInstance();
-      for (Map.Entry<String, String> entry : commandLine.getSwitches().entrySet()) {
-        String key = entry.getKey();
-        String value = entry.getValue();
-        if (value != null && !value.isEmpty()) {
-          args.add("--" + key + "=" + value);
-        } else {
-          args.add("--" + key);
-        }
-      }
     }
 
     // If the URL arg isn't specified, get it from AndroidManifest.xml.

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/BaseStarboardBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/BaseStarboardBridge.java
@@ -121,6 +121,7 @@ public class BaseStarboardBridge {
     mServiceHolder = serviceHolder;
     mArgs = new String[0];
     mAudioOutputManager = new AudioOutputManager(appContext);
+    mResourceOverlay = new ResourceOverlay(appContext);
     mIsAmatiDevice = false;
     mNativeApp = 0;
   }

--- a/starboard/BUILD.gn
+++ b/starboard/BUILD.gn
@@ -188,6 +188,7 @@ source_set("starboard_test_main") {
   testonly = true
   sources = [ "//starboard/common/test_main.cc" ]
   public_deps = [
+    "//starboard/common",
     "//starboard/testing:test_runner",
     "//testing/gtest",
   ]

--- a/starboard/android/shared/media_codec_decoder.cc
+++ b/starboard/android/shared/media_codec_decoder.cc
@@ -987,6 +987,8 @@ void MediaCodecDecoder::OnMediaCodecError(bool is_recoverable,
 
 void MediaCodecDecoder::OnMediaCodecInputBufferAvailable(int32_t buffer_index) {
   SB_CHECK_GE(buffer_index, 0);
+  SB_LOG(INFO) << (media_type_ == kSbMediaTypeAudio ? "audio" : "video")
+               << " input buffer available: " << buffer_index;
   if (media_type_ == kSbMediaTypeVideo && first_call_on_handler_thread_) {
     // Set the thread priority of the Handler thread to dispatch the async
     // decoder callbacks to high.
@@ -1012,6 +1014,10 @@ void MediaCodecDecoder::OnMediaCodecOutputBufferAvailable(
     int64_t presentation_time_us,
     int32_t size) {
   SB_CHECK_GE(buffer_index, 0);
+  SB_LOG(INFO) << (media_type_ == kSbMediaTypeAudio ? "audio" : "video")
+               << " output buffer available: " << buffer_index
+               << ", size=" << size
+               << ", presentation_time_us=" << presentation_time_us;
 
   // TODO(b/291959069): After the output thread is destroyed, it may still
   // receive output buffer, discard this invalid output buffer.

--- a/starboard/android/shared/media_codec_decoder.cc
+++ b/starboard/android/shared/media_codec_decoder.cc
@@ -987,8 +987,6 @@ void MediaCodecDecoder::OnMediaCodecError(bool is_recoverable,
 
 void MediaCodecDecoder::OnMediaCodecInputBufferAvailable(int32_t buffer_index) {
   SB_CHECK_GE(buffer_index, 0);
-  SB_LOG(INFO) << (media_type_ == kSbMediaTypeAudio ? "audio" : "video")
-               << " input buffer available: " << buffer_index;
   if (media_type_ == kSbMediaTypeVideo && first_call_on_handler_thread_) {
     // Set the thread priority of the Handler thread to dispatch the async
     // decoder callbacks to high.
@@ -1014,10 +1012,6 @@ void MediaCodecDecoder::OnMediaCodecOutputBufferAvailable(
     int64_t presentation_time_us,
     int32_t size) {
   SB_CHECK_GE(buffer_index, 0);
-  SB_LOG(INFO) << (media_type_ == kSbMediaTypeAudio ? "audio" : "video")
-               << " output buffer available: " << buffer_index
-               << ", size=" << size
-               << ", presentation_time_us=" << presentation_time_us;
 
   // TODO(b/291959069): After the output thread is destroyed, it may still
   // receive output buffer, discard this invalid output buffer.

--- a/starboard/android/shared/starboard_test_environment.cc
+++ b/starboard/android/shared/starboard_test_environment.cc
@@ -14,6 +14,7 @@
 
 #include "starboard/android/shared/starboard_test_environment.h"
 
+#include "starboard/shared/starboard/audio_sink/audio_sink_internal.h"
 #include "starboard/shared/starboard/features_test_util.h"
 
 namespace starboard {
@@ -24,5 +25,6 @@ StarboardTestEnvironment::~StarboardTestEnvironment() = default;
 
 void StarboardTestEnvironment::SetUp() {
   features::InitializeStarboardFeatureListWithDefaults();
+  SbAudioSinkImpl::Initialize();
 }
 }  // namespace starboard

--- a/starboard/benchmark/BUILD.gn
+++ b/starboard/benchmark/BUILD.gn
@@ -33,6 +33,7 @@ target(_benchmark_type, "benchmark") {
     "player/player_benchmark_helper.h",
     "player/player_create_benchmark.cc",
     "player/player_destroy_benchmark.cc",
+    "player/player_seek_benchmark.cc",
     "thread_benchmark.cc",
     "thread_id_benchmark.cc",
   ]
@@ -40,6 +41,7 @@ target(_benchmark_type, "benchmark") {
   public_deps = [
     "//starboard:starboard_group",
     "//starboard/common",
+    "//starboard/shared/starboard/player:video_dmp",
     "//starboard/testing:fake_graphics_context_provider",
     "//third_party/google_benchmark",
   ]
@@ -57,6 +59,7 @@ test("player_benchmarks_gtest") {
     "player/player_benchmark_helper.h",
     "player/player_create_benchmark.cc",
     "player/player_destroy_benchmark.cc",
+    "player/player_seek_benchmark.cc",
   ]
 
   configs += [ "//starboard/build/config:starboard_implementation" ]
@@ -65,12 +68,14 @@ test("player_benchmarks_gtest") {
     "//starboard:starboard_group",
     "//starboard:starboard_test_main",
     "//starboard/common",
+    "//starboard/shared/starboard/player:video_dmp",
     "//starboard/testing:fake_graphics_context_provider",
     "//testing/gmock",
     "//testing/gtest",
     "//third_party/google_benchmark",
   ]
   deps = cobalt_platform_dependencies
+  deps += [ "//starboard/shared/starboard/player:player_test_data" ]
   if (is_android) {
     deps += [
       "//cobalt/android:cobalt_testing_java",

--- a/starboard/benchmark/BUILD.gn
+++ b/starboard/benchmark/BUILD.gn
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import("//cobalt/build/modular_executable.gni")
+import("//testing/test.gni")
 
 if (is_cobalt_hermetic_build) {
   _benchmark_type = "modular_executable"
@@ -25,6 +26,8 @@ target(_benchmark_type, "benchmark") {
 
   sources = [
     "//starboard/common/benchmark_main.cc",
+    "//starboard/shared/starboard/features_test_util.cc",
+    "//starboard/shared/starboard/features_test_util.h",
     "memory_benchmark.cc",
     "player/player_benchmark_helper.cc",
     "player/player_benchmark_helper.h",
@@ -43,4 +46,37 @@ target(_benchmark_type, "benchmark") {
   deps = cobalt_platform_dependencies
 
   configs += [ "//starboard/build/config:starboard_implementation" ]
+}
+
+test("player_benchmarks_gtest") {
+  testonly = true
+
+  sources = [
+    "player/player_benchmark_gtest_wrapper.cc",
+    "player/player_benchmark_helper.cc",
+    "player/player_benchmark_helper.h",
+    "player/player_create_benchmark.cc",
+    "player/player_destroy_benchmark.cc",
+  ]
+
+  configs += [ "//starboard/build/config:starboard_implementation" ]
+
+  public_deps = [
+    "//starboard:starboard_group",
+    "//starboard:starboard_test_main",
+    "//starboard/common",
+    "//starboard/testing:fake_graphics_context_provider",
+    "//testing/gmock",
+    "//testing/gtest",
+    "//third_party/google_benchmark",
+  ]
+  deps = cobalt_platform_dependencies
+  if (is_android) {
+    deps += [
+      "//cobalt/android:cobalt_testing_java",
+      "//cobalt/android:jni_headers",
+    ]
+    android_manifest_template =
+        "//starboard/android/shared/testing/AndroidManifest.xml.jinja2"
+  }
 }

--- a/starboard/benchmark/BUILD.gn
+++ b/starboard/benchmark/BUILD.gn
@@ -50,10 +50,7 @@ target(_benchmark_type, "benchmark") {
       "//starboard/shared/starboard/features_test_util.cc",
       "//starboard/shared/starboard/features_test_util.h",
     ]
-    deps += [
-      "//starboard/extension:feature_config_header",
-      "//starboard/shared/starboard:feature_list",
-    ]
+    deps += [ "//starboard/shared/starboard:feature_list" ]
   }
 
   configs += [ "//starboard/build/config:starboard_implementation" ]

--- a/starboard/benchmark/BUILD.gn
+++ b/starboard/benchmark/BUILD.gn
@@ -26,8 +26,6 @@ target(_benchmark_type, "benchmark") {
 
   sources = [
     "//starboard/common/benchmark_main.cc",
-    "//starboard/shared/starboard/features_test_util.cc",
-    "//starboard/shared/starboard/features_test_util.h",
     "memory_benchmark.cc",
     "player/player_benchmark_helper.cc",
     "player/player_benchmark_helper.h",
@@ -46,6 +44,17 @@ target(_benchmark_type, "benchmark") {
     "//third_party/google_benchmark",
   ]
   deps = cobalt_platform_dependencies
+
+  if (is_android) {
+    sources += [
+      "//starboard/shared/starboard/features_test_util.cc",
+      "//starboard/shared/starboard/features_test_util.h",
+    ]
+    deps += [
+      "//starboard/extension:feature_config_header",
+      "//starboard/shared/starboard:feature_list",
+    ]
+  }
 
   configs += [ "//starboard/build/config:starboard_implementation" ]
 }

--- a/starboard/benchmark/BUILD.gn
+++ b/starboard/benchmark/BUILD.gn
@@ -26,6 +26,10 @@ target(_benchmark_type, "benchmark") {
   sources = [
     "//starboard/common/benchmark_main.cc",
     "memory_benchmark.cc",
+    "player/player_benchmark_helper.cc",
+    "player/player_benchmark_helper.h",
+    "player/player_create_benchmark.cc",
+    "player/player_destroy_benchmark.cc",
     "thread_benchmark.cc",
     "thread_id_benchmark.cc",
   ]
@@ -33,6 +37,7 @@ target(_benchmark_type, "benchmark") {
   public_deps = [
     "//starboard:starboard_group",
     "//starboard/common",
+    "//starboard/testing:fake_graphics_context_provider",
     "//third_party/google_benchmark",
   ]
   deps = cobalt_platform_dependencies

--- a/starboard/benchmark/player/player_benchmark_gtest_wrapper.cc
+++ b/starboard/benchmark/player/player_benchmark_gtest_wrapper.cc
@@ -17,20 +17,10 @@
 #include "testing/gtest/include/gtest/gtest.h"
 #include "third_party/google_benchmark/src/include/benchmark/benchmark.h"
 
-#if BUILDFLAG(IS_ANDROID)
-#include "perfetto/tracing.h"
-#endif
-
 namespace starboard {
 namespace benchmark {
 
 TEST(SbPlayerBenchmarkTest, RunPlayerBenchmarks) {
-#if BUILDFLAG(IS_ANDROID)
-  perfetto::TracingInitArgs perfetto_args;
-  perfetto_args.backends = perfetto::kSystemBackend;
-  perfetto::Tracing::Initialize(perfetto_args);
-#endif
-
   // Run only the player benchmarks.
   // Google Benchmark modifies argc/argv.
   int argc = 2;

--- a/starboard/benchmark/player/player_benchmark_gtest_wrapper.cc
+++ b/starboard/benchmark/player/player_benchmark_gtest_wrapper.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "starboard/common/command_line.h"
+#include "starboard/testing/test_runner.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "third_party/google_benchmark/src/include/benchmark/benchmark.h"
 
@@ -25,6 +27,7 @@ namespace benchmark {
 // Dummy functions to force linking of benchmark objects
 void LinkPlayerCreateBenchmark();
 void LinkPlayerDestroyBenchmark();
+void LinkPlayerSeekBenchmark();
 
 TEST(SbPlayerBenchmarkTest, RunPlayerBenchmarks) {
 #if BUILDFLAG(IS_ANDROID)
@@ -36,12 +39,20 @@ TEST(SbPlayerBenchmarkTest, RunPlayerBenchmarks) {
   // Force linking of benchmarks
   LinkPlayerCreateBenchmark();
   LinkPlayerDestroyBenchmark();
+  LinkPlayerSeekBenchmark();
 
   // Run only the player benchmarks.
   // Google Benchmark modifies argc/argv.
   int argc = 2;
+  std::string filter = "BM_Player";
+  const starboard::CommandLine* command_line =
+      starboard::testing::GetTestCommandLine();
+  if (command_line && command_line->HasSwitch("benchmark_filter")) {
+    filter = command_line->GetSwitchValue("benchmark_filter");
+  }
+  std::string filter_arg = "--benchmark_filter=" + filter;
   char* argv[] = {(char*)"player_benchmarks",
-                  (char*)"--benchmark_filter=BM_Player"};
+                  const_cast<char*>(filter_arg.c_str())};
 
   ::benchmark::Initialize(&argc, argv);
   ::benchmark::RunSpecifiedBenchmarks();

--- a/starboard/benchmark/player/player_benchmark_gtest_wrapper.cc
+++ b/starboard/benchmark/player/player_benchmark_gtest_wrapper.cc
@@ -1,0 +1,51 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "testing/gtest/include/gtest/gtest.h"
+#include "third_party/google_benchmark/src/include/benchmark/benchmark.h"
+
+#if BUILDFLAG(IS_ANDROID)
+#include "perfetto/tracing.h"
+#endif
+
+namespace starboard {
+namespace benchmark {
+
+// Dummy functions to force linking of benchmark objects
+void LinkPlayerCreateBenchmark();
+void LinkPlayerDestroyBenchmark();
+
+TEST(SbPlayerBenchmarkTest, RunPlayerBenchmarks) {
+#if BUILDFLAG(IS_ANDROID)
+  perfetto::TracingInitArgs perfetto_args;
+  perfetto_args.backends = perfetto::kSystemBackend;
+  perfetto::Tracing::Initialize(perfetto_args);
+#endif
+
+  // Force linking of benchmarks
+  LinkPlayerCreateBenchmark();
+  LinkPlayerDestroyBenchmark();
+
+  // Run only the player benchmarks.
+  // Google Benchmark modifies argc/argv.
+  int argc = 2;
+  char* argv[] = {(char*)"player_benchmarks",
+                  (char*)"--benchmark_filter=BM_Player"};
+
+  ::benchmark::Initialize(&argc, argv);
+  ::benchmark::RunSpecifiedBenchmarks();
+}
+
+}  // namespace benchmark
+}  // namespace starboard

--- a/starboard/benchmark/player/player_benchmark_gtest_wrapper.cc
+++ b/starboard/benchmark/player/player_benchmark_gtest_wrapper.cc
@@ -24,22 +24,12 @@
 namespace starboard {
 namespace benchmark {
 
-// Dummy functions to force linking of benchmark objects
-void LinkPlayerCreateBenchmark();
-void LinkPlayerDestroyBenchmark();
-void LinkPlayerSeekBenchmark();
-
 TEST(SbPlayerBenchmarkTest, RunPlayerBenchmarks) {
 #if BUILDFLAG(IS_ANDROID)
   perfetto::TracingInitArgs perfetto_args;
   perfetto_args.backends = perfetto::kSystemBackend;
   perfetto::Tracing::Initialize(perfetto_args);
 #endif
-
-  // Force linking of benchmarks
-  LinkPlayerCreateBenchmark();
-  LinkPlayerDestroyBenchmark();
-  LinkPlayerSeekBenchmark();
 
   // Run only the player benchmarks.
   // Google Benchmark modifies argc/argv.

--- a/starboard/benchmark/player/player_benchmark_helper.cc
+++ b/starboard/benchmark/player/player_benchmark_helper.cc
@@ -1,0 +1,109 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/benchmark/player/player_benchmark_helper.h"
+
+#include "starboard/common/log.h"
+#include "starboard/shared/starboard/queue_application.h"
+
+namespace starboard {
+namespace benchmark {
+
+namespace {
+// A minimal Application implementation to satisfy SbPlayer dependencies
+class MockApplication : public QueueApplication {
+ public:
+  MockApplication() : QueueApplication(DummyEventHandleCallback) {
+    SetCommandLine(0, nullptr);
+  }
+
+  static void DummyEventHandleCallback(const SbEvent* event) {}
+
+ protected:
+  bool MayHaveSystemEvents() override { return false; }
+  Event* WaitForSystemEventWithTimeout(int64_t time) override {
+    return nullptr;
+  }
+  void WakeSystemEventWait() override {}
+};
+}  // namespace
+
+SbPlayerBenchmarkHelper::SbPlayerBenchmarkHelper() {
+  mock_application_.reset(new MockApplication());
+}
+
+SbPlayerBenchmarkHelper::~SbPlayerBenchmarkHelper() {}
+
+void SbPlayerBenchmarkHelper::GetCreationParam(
+    SbPlayerCreationParam* out_creation_param,
+    SbPlayerOutputMode output_mode) {
+  SB_DCHECK(out_creation_param);
+
+  *out_creation_param = {};
+  out_creation_param->drm_system = kSbDrmSystemInvalid;
+  out_creation_param->output_mode = output_mode;
+
+  // Initialize a default stereo AAC audio config
+  static const uint8_t kAacAudioSpecificConfig[16] = {18, 16};
+  out_creation_param->audio_stream_info.codec = kSbMediaAudioCodecAac;
+  out_creation_param->audio_stream_info.mime = "audio/mp4";
+  out_creation_param->audio_stream_info.number_of_channels = 2;
+  out_creation_param->audio_stream_info.samples_per_second = 44100;
+  out_creation_param->audio_stream_info.bits_per_sample = 16;
+  out_creation_param->audio_stream_info.audio_specific_config =
+      kAacAudioSpecificConfig;
+  out_creation_param->audio_stream_info.audio_specific_config_size =
+      sizeof(kAacAudioSpecificConfig);
+
+  // Initialize a default 1080p H.264 video config
+  out_creation_param->video_stream_info.codec = kSbMediaVideoCodecH264;
+  out_creation_param->video_stream_info.mime = "video/mp4";
+  out_creation_param->video_stream_info.max_video_capabilities = "";
+  out_creation_param->video_stream_info.color_metadata.bits_per_channel = 8;
+  out_creation_param->video_stream_info.color_metadata.primaries =
+      kSbMediaPrimaryIdBt709;
+  out_creation_param->video_stream_info.color_metadata.transfer =
+      kSbMediaTransferIdBt709;
+  out_creation_param->video_stream_info.color_metadata.matrix =
+      kSbMediaMatrixIdBt709;
+  out_creation_param->video_stream_info.color_metadata.range =
+      kSbMediaRangeIdLimited;
+  out_creation_param->video_stream_info.frame_width = 1920;
+  out_creation_param->video_stream_info.frame_height = 1080;
+}
+
+// Dummy callbacks
+void SbPlayerBenchmarkHelper::DummyDeallocateSampleFunc(
+    SbPlayer player,
+    void* context,
+    const void* sample_buffer) {}
+
+void SbPlayerBenchmarkHelper::DummyDecoderStatusFunc(SbPlayer player,
+                                                     void* context,
+                                                     SbMediaType type,
+                                                     SbPlayerDecoderState state,
+                                                     int ticket) {}
+
+void SbPlayerBenchmarkHelper::DummyPlayerStatusFunc(SbPlayer player,
+                                                    void* context,
+                                                    SbPlayerState state,
+                                                    int ticket) {}
+
+void SbPlayerBenchmarkHelper::DummyPlayerErrorFunc(SbPlayer player,
+                                                   void* context,
+                                                   SbPlayerError error,
+                                                   const char* message) {}
+
+}  // namespace benchmark
+}  // namespace starboard

--- a/starboard/benchmark/player/player_benchmark_helper.cc
+++ b/starboard/benchmark/player/player_benchmark_helper.cc
@@ -18,39 +18,12 @@
 #include <limits>
 
 #include "starboard/common/log.h"
-#include "starboard/shared/starboard/application.h"
 #include "starboard/shared/starboard/experimental_features.h"
 
 namespace starboard {
 namespace benchmark {
 
-namespace {
-// A minimal Application implementation to satisfy SbPlayer dependencies
-class MockApplication : public Application {
- public:
-  MockApplication() : Application(DummyEventHandleCallback) {
-    SetCommandLine(0, nullptr);
-  }
-
-  static void DummyEventHandleCallback(const SbEvent* event) {}
-
- protected:
-  // --- Application overrides ---
-  Event* GetNextEvent() override { return nullptr; }
-  void Inject(Event* event) override { delete event; }
-  void InjectTimedEvent(TimedEvent* timed_event) override {
-    delete timed_event;
-  }
-  void CancelTimedEvent(SbEventId event_id) override {}
-  TimedEvent* GetNextDueTimedEvent() override { return nullptr; }
-  int64_t GetNextTimedEventTargetTime() override {
-    return std::numeric_limits<int64_t>::max();
-  }
-};
-}  // namespace
-
 SbPlayerBenchmarkHelper::SbPlayerBenchmarkHelper() {
-  mock_application_.reset(new MockApplication());
   StarboardExtensionExperimentalFeatures experimental_features = {};
   experimental_features.entries = nullptr;
   experimental_features.entry_count = 0;

--- a/starboard/benchmark/player/player_benchmark_helper.cc
+++ b/starboard/benchmark/player/player_benchmark_helper.cc
@@ -14,33 +14,46 @@
 
 #include "starboard/benchmark/player/player_benchmark_helper.h"
 
+#include <limits>
+
 #include "starboard/common/log.h"
-#include "starboard/shared/starboard/queue_application.h"
+#include "starboard/shared/starboard/application.h"
+#include "starboard/shared/starboard/experimental_features.h"
 
 namespace starboard {
 namespace benchmark {
 
 namespace {
 // A minimal Application implementation to satisfy SbPlayer dependencies
-class MockApplication : public QueueApplication {
+class MockApplication : public Application {
  public:
-  MockApplication() : QueueApplication(DummyEventHandleCallback) {
+  MockApplication() : Application(DummyEventHandleCallback) {
     SetCommandLine(0, nullptr);
   }
 
   static void DummyEventHandleCallback(const SbEvent* event) {}
 
  protected:
-  bool MayHaveSystemEvents() override { return false; }
-  Event* WaitForSystemEventWithTimeout(int64_t time) override {
-    return nullptr;
+  // --- Application overrides ---
+  Event* GetNextEvent() override { return nullptr; }
+  void Inject(Event* event) override { delete event; }
+  void InjectTimedEvent(TimedEvent* timed_event) override {
+    delete timed_event;
   }
-  void WakeSystemEventWait() override {}
+  void CancelTimedEvent(SbEventId event_id) override {}
+  TimedEvent* GetNextDueTimedEvent() override { return nullptr; }
+  int64_t GetNextTimedEventTargetTime() override {
+    return std::numeric_limits<int64_t>::max();
+  }
 };
 }  // namespace
 
 SbPlayerBenchmarkHelper::SbPlayerBenchmarkHelper() {
   mock_application_.reset(new MockApplication());
+  StarboardExtensionExperimentalFeatures experimental_features = {};
+  experimental_features.entries = nullptr;
+  experimental_features.entry_count = 0;
+  starboard::SetExperimentalFeaturesForCurrentThread(&experimental_features);
 }
 
 SbPlayerBenchmarkHelper::~SbPlayerBenchmarkHelper() {}

--- a/starboard/benchmark/player/player_benchmark_helper.cc
+++ b/starboard/benchmark/player/player_benchmark_helper.cc
@@ -14,6 +14,7 @@
 
 #include "starboard/benchmark/player/player_benchmark_helper.h"
 
+#include <iostream>
 #include <limits>
 
 #include "starboard/common/log.h"
@@ -56,7 +57,332 @@ SbPlayerBenchmarkHelper::SbPlayerBenchmarkHelper() {
   starboard::SetExperimentalFeaturesForCurrentThread(&experimental_features);
 }
 
-SbPlayerBenchmarkHelper::~SbPlayerBenchmarkHelper() {}
+SbPlayerBenchmarkHelper::~SbPlayerBenchmarkHelper() {
+  DestroyPlayer();
+}
+
+bool SbPlayerBenchmarkHelper::InitializePlayer(const char* audio_file,
+                                               const char* video_file,
+                                               SbPlayerOutputMode output_mode) {
+  std::cout << "[HELPER] InitializePlayer start: audio="
+            << (audio_file ? audio_file : "none")
+            << ", video=" << (video_file ? video_file : "none")
+            << ", mode=" << output_mode << std::endl;
+  SbPlayerCreationParam creation_param = {};
+  creation_param.drm_system = kSbDrmSystemInvalid;
+  creation_param.output_mode = output_mode;
+
+  {
+    std::unique_lock<std::mutex> lock(mutex_);
+    SB_DCHECK(player_ == kSbPlayerInvalid);
+
+    error_occurred_ = false;
+    // Set to kSbPlayerStateDestroyed as a placeholder to ensure we wait for the
+    // Initialized callback
+    player_state_ = kSbPlayerStateDestroyed;
+    player_state_ticket_ = SB_PLAYER_INITIAL_TICKET;
+    ticket_ = SB_PLAYER_INITIAL_TICKET;
+
+    if (audio_file) {
+      std::cout << "[HELPER] Loading audio DMP..." << std::endl;
+      audio_reader_.reset(
+          new VideoDmpReader(audio_file, VideoDmpReader::kEnableReadOnDemand));
+      if (audio_reader_->number_of_audio_buffers() == 0) {
+        std::cout << "[HELPER] Failed to load audio DMP (0 buffers)"
+                  << std::endl;
+        SB_LOG(ERROR) << "Failed to load audio DMP: " << audio_file;
+        return false;
+      }
+      audio_reader_->audio_stream_info().ConvertTo(
+          &creation_param.audio_stream_info);
+      audio_mime_ = audio_reader_->audio_mime_type();
+      creation_param.audio_stream_info.mime = audio_mime_.c_str();
+      next_audio_sample_index_ = 0;
+      audio_eos_written_ = false;
+    } else {
+      creation_param.audio_stream_info.codec = kSbMediaAudioCodecNone;
+    }
+
+    if (video_file) {
+      std::cout << "[HELPER] Loading video DMP..." << std::endl;
+      video_reader_.reset(
+          new VideoDmpReader(video_file, VideoDmpReader::kEnableReadOnDemand));
+      if (video_reader_->number_of_video_buffers() == 0) {
+        std::cout << "[HELPER] Failed to load video DMP (0 buffers)"
+                  << std::endl;
+        SB_LOG(ERROR) << "Failed to load video DMP: " << video_file;
+        return false;
+      }
+      video_reader_->video_stream_info().ConvertTo(
+          &creation_param.video_stream_info);
+      video_mime_ = video_reader_->video_mime_type();
+      creation_param.video_stream_info.mime = video_mime_.c_str();
+      next_video_sample_index_ = 0;
+      video_eos_written_ = false;
+    } else {
+      creation_param.video_stream_info.codec = kSbMediaVideoCodecNone;
+    }
+  }
+
+  std::cout << "[HELPER] Calling SbPlayerCreate..." << std::endl;
+  SbPlayer player =
+      SbPlayerCreate(GetWindow(), &creation_param, DummyDeallocateSampleFunc,
+                     DecoderStatusCallback, PlayerStatusCallback,
+                     DummyPlayerErrorFunc, this, GetDecoderTargetProvider());
+
+  if (!SbPlayerIsValid(player)) {
+    std::cout << "[HELPER] SbPlayerCreate failed (returned invalid player)"
+              << std::endl;
+    SB_LOG(ERROR) << "SbPlayerCreate failed";
+    return false;
+  }
+
+  {
+    std::unique_lock<std::mutex> lock(mutex_);
+    player_ = player;
+  }
+
+  std::cout << "[HELPER] Waiting for player to be Initialized..." << std::endl;
+  // Wait for the kSbPlayerStateInitialized callback
+  if (!WaitForPlayerState(kSbPlayerStateInitialized,
+                          SB_PLAYER_INITIAL_TICKET)) {
+    std::cout << "[HELPER] Timeout waiting for Initialized state" << std::endl;
+    SB_LOG(ERROR) << "Timeout waiting for kSbPlayerStateInitialized";
+    return false;
+  }
+
+  std::cout << "[HELPER] Calling initial Seek(0)..." << std::endl;
+  // Call Seek(0) to start the playback pipelines and decoders!
+  Seek(0);
+  SbPlayerSetPlaybackRate(player_, 1.0);
+  SbPlayerSetVolume(player_, 1.0);
+
+  std::cout << "[HELPER] InitializePlayer success!" << std::endl;
+  return true;
+}
+
+void SbPlayerBenchmarkHelper::DestroyPlayer() {
+  SbPlayer player_to_destroy = kSbPlayerInvalid;
+  {
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (player_ == kSbPlayerInvalid) {
+      return;
+    }
+    player_to_destroy = player_;
+    player_ = kSbPlayerInvalid;
+  }
+  SbPlayerDestroy(player_to_destroy);
+  audio_reader_.reset();
+  video_reader_.reset();
+}
+
+void SbPlayerBenchmarkHelper::FeedData(int64_t duration_us) {
+  SB_LOG(INFO) << "FeedData: start, target duration=" << duration_us;
+  while (true) {
+    bool write_audio = false;
+    bool write_video = false;
+    bool audio_done = false;
+    bool video_done = false;
+
+    {
+      std::unique_lock<std::mutex> lock(mutex_);
+      if (error_occurred_) {
+        SB_LOG(ERROR) << "Error occurred during FeedData";
+        break;
+      }
+
+      if (audio_reader_) {
+        int64_t last_audio_ts = 0;
+        if (next_audio_sample_index_ > 0) {
+          last_audio_ts =
+              audio_reader_
+                  ->GetPlayerSampleInfo(kSbMediaTypeAudio,
+                                        next_audio_sample_index_ - 1)
+                  .timestamp;
+        }
+        if (audio_eos_written_ || last_audio_ts >= duration_us) {
+          audio_done = true;
+        } else if (audio_needs_data_) {
+          write_audio = true;
+        }
+      } else {
+        audio_done = true;
+      }
+
+      if (video_reader_) {
+        int64_t last_video_ts = 0;
+        if (next_video_sample_index_ > 0) {
+          last_video_ts =
+              video_reader_
+                  ->GetPlayerSampleInfo(kSbMediaTypeVideo,
+                                        next_video_sample_index_ - 1)
+                  .timestamp;
+        }
+        if (video_eos_written_ || last_video_ts >= duration_us) {
+          video_done = true;
+        } else if (video_needs_data_) {
+          write_video = true;
+        }
+      } else {
+        video_done = true;
+      }
+
+      if (audio_done && video_done) {
+        SB_LOG(INFO) << "FeedData: done! (audio_done=" << audio_done
+                     << ", video_done=" << video_done << ")";
+        break;
+      }
+
+      if (!write_audio && !write_video) {
+        SB_LOG(INFO) << "FeedData: waiting... (audio_needs_data="
+                     << audio_needs_data_
+                     << ", video_needs_data=" << video_needs_data_ << ")";
+        cv_.wait(lock);
+        SB_LOG(INFO) << "FeedData: woke up!";
+        continue;
+      }
+    }
+
+    if (write_audio) {
+      WriteSamples(kSbMediaTypeAudio);
+    }
+    if (write_video) {
+      WriteSamples(kSbMediaTypeVideo);
+    }
+  }
+}
+
+void SbPlayerBenchmarkHelper::Seek(int64_t seek_time_us) {
+  int ticket = PrepareSeek(seek_time_us);
+  SbPlayerSeek(player_, seek_time_us, ticket);
+}
+
+int SbPlayerBenchmarkHelper::PrepareSeek(int64_t seek_time_us) {
+  std::unique_lock<std::mutex> lock(mutex_);
+  audio_eos_written_ = false;
+  video_eos_written_ = false;
+  audio_needs_data_ = false;
+  video_needs_data_ = false;
+
+  next_audio_sample_index_ = FindAudioStartIndex(seek_time_us);
+  next_video_sample_index_ = FindVideoStartIndex(seek_time_us);
+
+  ticket_ = GetNextTicket();
+  return ticket_;
+}
+
+bool SbPlayerBenchmarkHelper::WaitForPlayerState(SbPlayerState state,
+                                                 int ticket,
+                                                 int64_t timeout_us) {
+  std::unique_lock<std::mutex> lock(mutex_);
+  auto timeout = std::chrono::microseconds(timeout_us);
+  return cv_.wait_for(lock, timeout, [this, state, ticket] {
+    return player_state_ == state && player_state_ticket_ == ticket;
+  });
+}
+
+void SbPlayerBenchmarkHelper::WriteSamples(SbMediaType type) {
+  std::unique_lock<std::mutex> lock(mutex_);
+  if (player_ == kSbPlayerInvalid) {
+    return;
+  }
+
+  int max_samples = SbPlayerGetMaximumNumberOfSamplesPerWrite(player_, type);
+  if (max_samples <= 0) {
+    max_samples = 1;
+  }
+
+  if (type == kSbMediaTypeAudio) {
+    if (!audio_reader_) {
+      return;
+    }
+    size_t total_samples = audio_reader_->number_of_audio_buffers();
+    if (next_audio_sample_index_ >= total_samples) {
+      if (!audio_eos_written_) {
+        SB_LOG(INFO) << "WriteSamples: writing audio EOS";
+        SbPlayerWriteEndOfStream(player_, kSbMediaTypeAudio);
+        audio_eos_written_ = true;
+        audio_needs_data_ = false;
+      }
+      return;
+    }
+
+    int samples_to_write = std::min(static_cast<size_t>(max_samples),
+                                    total_samples - next_audio_sample_index_);
+    SB_LOG(INFO) << "WriteSamples: writing " << samples_to_write
+                 << " audio samples, next index=" << next_audio_sample_index_;
+    std::vector<SbPlayerSampleInfo> sample_infos;
+    sample_infos.reserve(samples_to_write);
+    for (int i = 0; i < samples_to_write; ++i) {
+      sample_infos.push_back(audio_reader_->GetPlayerSampleInfo(
+          kSbMediaTypeAudio, next_audio_sample_index_++));
+    }
+    SbPlayerWriteSamples(player_, kSbMediaTypeAudio, sample_infos.data(),
+                         samples_to_write);
+    audio_needs_data_ = false;
+  } else {
+    if (!video_reader_) {
+      return;
+    }
+    size_t total_samples = video_reader_->number_of_video_buffers();
+    if (next_video_sample_index_ >= total_samples) {
+      if (!video_eos_written_) {
+        SB_LOG(INFO) << "WriteSamples: writing video EOS";
+        SbPlayerWriteEndOfStream(player_, kSbMediaTypeVideo);
+        video_eos_written_ = true;
+        video_needs_data_ = false;
+      }
+      return;
+    }
+
+    int samples_to_write = std::min(static_cast<size_t>(max_samples),
+                                    total_samples - next_video_sample_index_);
+    SB_LOG(INFO) << "WriteSamples: writing " << samples_to_write
+                 << " video samples, next index=" << next_video_sample_index_;
+    std::vector<SbPlayerSampleInfo> sample_infos;
+    sample_infos.reserve(samples_to_write);
+    for (int i = 0; i < samples_to_write; ++i) {
+      sample_infos.push_back(video_reader_->GetPlayerSampleInfo(
+          kSbMediaTypeVideo, next_video_sample_index_++));
+    }
+    SbPlayerWriteSamples(player_, kSbMediaTypeVideo, sample_infos.data(),
+                         samples_to_write);
+    video_needs_data_ = false;
+  }
+}
+
+size_t SbPlayerBenchmarkHelper::FindAudioStartIndex(int64_t target_time_us) {
+  if (!audio_reader_) {
+    return 0;
+  }
+  size_t num_samples = audio_reader_->number_of_audio_buffers();
+  for (size_t i = 0; i < num_samples; ++i) {
+    if (audio_reader_->GetPlayerSampleInfo(kSbMediaTypeAudio, i).timestamp >=
+        target_time_us) {
+      return i;
+    }
+  }
+  return num_samples;
+}
+
+size_t SbPlayerBenchmarkHelper::FindVideoStartIndex(int64_t target_time_us) {
+  if (!video_reader_) {
+    return 0;
+  }
+  size_t num_samples = video_reader_->number_of_video_buffers();
+  size_t best_index = 0;
+  for (size_t i = 0; i < num_samples; ++i) {
+    auto sample_info = video_reader_->GetPlayerSampleInfo(kSbMediaTypeVideo, i);
+    if (sample_info.timestamp <= target_time_us) {
+      if (sample_info.video_sample_info.is_key_frame) {
+        best_index = i;
+      }
+    } else {
+      break;
+    }
+  }
+  return best_index;
+}
 
 void SbPlayerBenchmarkHelper::GetCreationParam(
     SbPlayerCreationParam* out_creation_param,
@@ -67,7 +393,6 @@ void SbPlayerBenchmarkHelper::GetCreationParam(
   out_creation_param->drm_system = kSbDrmSystemInvalid;
   out_creation_param->output_mode = output_mode;
 
-  // Initialize a default stereo AAC audio config
   static const uint8_t kAacAudioSpecificConfig[16] = {18, 16};
   out_creation_param->audio_stream_info.codec = kSbMediaAudioCodecAac;
   out_creation_param->audio_stream_info.mime = "audio/mp4";
@@ -79,7 +404,6 @@ void SbPlayerBenchmarkHelper::GetCreationParam(
   out_creation_param->audio_stream_info.audio_specific_config_size =
       sizeof(kAacAudioSpecificConfig);
 
-  // Initialize a default 1080p H.264 video config
   out_creation_param->video_stream_info.codec = kSbMediaVideoCodecH264;
   out_creation_param->video_stream_info.mime = "video/mp4";
   out_creation_param->video_stream_info.max_video_capabilities = "";
@@ -96,27 +420,64 @@ void SbPlayerBenchmarkHelper::GetCreationParam(
   out_creation_param->video_stream_info.frame_height = 1080;
 }
 
-// Dummy callbacks
 void SbPlayerBenchmarkHelper::DummyDeallocateSampleFunc(
     SbPlayer player,
     void* context,
     const void* sample_buffer) {}
 
-void SbPlayerBenchmarkHelper::DummyDecoderStatusFunc(SbPlayer player,
-                                                     void* context,
-                                                     SbMediaType type,
-                                                     SbPlayerDecoderState state,
-                                                     int ticket) {}
-
-void SbPlayerBenchmarkHelper::DummyPlayerStatusFunc(SbPlayer player,
+void SbPlayerBenchmarkHelper::DecoderStatusCallback(SbPlayer player,
                                                     void* context,
-                                                    SbPlayerState state,
-                                                    int ticket) {}
+                                                    SbMediaType type,
+                                                    SbPlayerDecoderState state,
+                                                    int ticket) {
+  SbPlayerBenchmarkHelper* helper =
+      static_cast<SbPlayerBenchmarkHelper*>(context);
+  std::unique_lock<std::mutex> lock(helper->mutex_);
+  SB_LOG(INFO) << "DecoderStatusCallback: type=" << type << ", state=" << state
+               << ", ticket=" << ticket
+               << " (current helper ticket=" << helper->ticket_ << ")";
+  if (ticket != helper->ticket_) {
+    return;
+  }
+  if (type == kSbMediaTypeAudio) {
+    helper->audio_needs_data_ = (state == kSbPlayerDecoderStateNeedsData);
+    helper->audio_ticket_ = ticket;
+  } else if (type == kSbMediaTypeVideo) {
+    helper->video_needs_data_ = (state == kSbPlayerDecoderStateNeedsData);
+    helper->video_ticket_ = ticket;
+  }
+  helper->cv_.notify_all();
+}
+
+void SbPlayerBenchmarkHelper::PlayerStatusCallback(SbPlayer player,
+                                                   void* context,
+                                                   SbPlayerState state,
+                                                   int ticket) {
+  SbPlayerBenchmarkHelper* helper =
+      static_cast<SbPlayerBenchmarkHelper*>(context);
+  std::unique_lock<std::mutex> lock(helper->mutex_);
+  SB_LOG(INFO) << "PlayerStatusCallback: state=" << state
+               << ", ticket=" << ticket
+               << " (current helper ticket=" << helper->ticket_ << ")";
+  if (ticket != helper->ticket_) {
+    return;
+  }
+  helper->player_state_ = state;
+  helper->player_state_ticket_ = ticket;
+  helper->cv_.notify_all();
+}
 
 void SbPlayerBenchmarkHelper::DummyPlayerErrorFunc(SbPlayer player,
                                                    void* context,
                                                    SbPlayerError error,
-                                                   const char* message) {}
+                                                   const char* message) {
+  SB_LOG(ERROR) << "DummyPlayerErrorFunc: error=" << error
+                << ", message=" << message;
+  SbPlayerBenchmarkHelper* helper =
+      static_cast<SbPlayerBenchmarkHelper*>(context);
+  helper->error_occurred_ = true;
+  helper->cv_.notify_all();
+}
 
 }  // namespace benchmark
 }  // namespace starboard

--- a/starboard/benchmark/player/player_benchmark_helper.h
+++ b/starboard/benchmark/player/player_benchmark_helper.h
@@ -22,7 +22,7 @@
 #include "starboard/testing/fake_graphics_context_provider.h"
 
 namespace starboard {
-class QueueApplication;
+class Application;
 
 namespace benchmark {
 
@@ -59,7 +59,7 @@ class SbPlayerBenchmarkHelper {
                                    const char* message);
 
  private:
-  std::unique_ptr<starboard::QueueApplication> mock_application_;
+  std::unique_ptr<starboard::Application> mock_application_;
   starboard::FakeGraphicsContextProvider fake_graphics_context_provider_;
 };
 

--- a/starboard/benchmark/player/player_benchmark_helper.h
+++ b/starboard/benchmark/player/player_benchmark_helper.h
@@ -15,10 +15,15 @@
 #ifndef STARBOARD_BENCHMARK_PLAYER_PLAYER_BENCHMARK_HELPER_H_
 #define STARBOARD_BENCHMARK_PLAYER_PLAYER_BENCHMARK_HELPER_H_
 
+#include <atomic>
+#include <condition_variable>
 #include <memory>
+#include <mutex>
+#include <string>
 
 #include "starboard/media.h"
 #include "starboard/player.h"
+#include "starboard/shared/starboard/player/video_dmp_reader.h"
 #include "starboard/testing/fake_graphics_context_provider.h"
 
 namespace starboard {
@@ -31,16 +36,46 @@ class SbPlayerBenchmarkHelper {
   SbPlayerBenchmarkHelper();
   ~SbPlayerBenchmarkHelper();
 
+  // Initialize the player with specific audio and video DMP files.
+  // Returns true on success.
+  bool InitializePlayer(const char* audio_file,
+                        const char* video_file,
+                        SbPlayerOutputMode output_mode);
+
+  // Safely destroy the player and wait for it to be fully released.
+  void DestroyPlayer();
+
   // Generate creation parameters for standard AVC and AAC playback
   void GetCreationParam(SbPlayerCreationParam* out_creation_param,
                         SbPlayerOutputMode output_mode);
+
+  // Feed audio/video samples up to the specified media time (in microseconds).
+  // Blocks the calling thread until target duration is written or EOS is
+  // reached.
+  void FeedData(int64_t duration_us);
+
+  // Trigger seek on the player to the specified target time.
+  void Seek(int64_t seek_time_us);
+
+  // Prepare seek by resetting DMP reader index and return the next ticket.
+  int PrepareSeek(int64_t seek_time_us);
+
+  // Wait for the player to reach a specific state for a given ticket.
+  // Returns false if timeout expires.
+  bool WaitForPlayerState(SbPlayerState state,
+                          int ticket,
+                          int64_t timeout_us = 5000000);
+
+  SbPlayer GetPlayer() const { return player_; }
+  int GetCurrentTicket() const { return ticket_; }
+  int GetNextTicket() { return ++ticket_; }
 
   SbWindow GetWindow() { return fake_graphics_context_provider_.window(); }
   SbDecodeTargetGraphicsContextProvider* GetDecoderTargetProvider() {
     return fake_graphics_context_provider_.decoder_target_provider();
   }
 
-  // Dummy callbacks required by SbPlayerCreate
+  // JNI and player callbacks
   static void DummyDeallocateSampleFunc(SbPlayer player,
                                         void* context,
                                         const void* sample_buffer);
@@ -48,19 +83,61 @@ class SbPlayerBenchmarkHelper {
                                      void* context,
                                      SbMediaType type,
                                      SbPlayerDecoderState state,
-                                     int ticket);
+                                     int ticket) {}
   static void DummyPlayerStatusFunc(SbPlayer player,
                                     void* context,
                                     SbPlayerState state,
+                                    int ticket) {}
+  static void DecoderStatusCallback(SbPlayer player,
+                                    void* context,
+                                    SbMediaType type,
+                                    SbPlayerDecoderState state,
                                     int ticket);
+  static void PlayerStatusCallback(SbPlayer player,
+                                   void* context,
+                                   SbPlayerState state,
+                                   int ticket);
   static void DummyPlayerErrorFunc(SbPlayer player,
                                    void* context,
                                    SbPlayerError error,
                                    const char* message);
 
  private:
+  void WriteSamples(SbMediaType type);
+  size_t FindAudioStartIndex(int64_t target_time_us);
+  size_t FindVideoStartIndex(int64_t target_time_us);
+
   std::unique_ptr<starboard::Application> mock_application_;
   starboard::FakeGraphicsContextProvider fake_graphics_context_provider_;
+
+  SbPlayer player_ = kSbPlayerInvalid;
+  int ticket_ = SB_PLAYER_INITIAL_TICKET;
+
+  std::string audio_mime_;
+  std::string video_mime_;
+
+  std::unique_ptr<VideoDmpReader> audio_reader_;
+  std::unique_ptr<VideoDmpReader> video_reader_;
+
+  size_t next_audio_sample_index_ = 0;
+  size_t next_video_sample_index_ = 0;
+
+  bool audio_eos_written_ = false;
+  bool video_eos_written_ = false;
+
+  // Thread synchronization and state tracking
+  std::mutex mutex_;
+  std::condition_variable cv_;
+
+  SbPlayerState player_state_ = kSbPlayerStateInitialized;
+  int player_state_ticket_ = 0;
+
+  bool audio_needs_data_ = false;
+  int audio_ticket_ = 0;
+  bool video_needs_data_ = false;
+  int video_ticket_ = 0;
+
+  std::atomic_bool error_occurred_{false};
 };
 
 }  // namespace benchmark

--- a/starboard/benchmark/player/player_benchmark_helper.h
+++ b/starboard/benchmark/player/player_benchmark_helper.h
@@ -27,8 +27,6 @@
 #include "starboard/testing/fake_graphics_context_provider.h"
 
 namespace starboard {
-class Application;
-
 namespace benchmark {
 
 class SbPlayerBenchmarkHelper {
@@ -106,8 +104,6 @@ class SbPlayerBenchmarkHelper {
   void WriteSamples(SbMediaType type);
   size_t FindAudioStartIndex(int64_t target_time_us);
   size_t FindVideoStartIndex(int64_t target_time_us);
-
-  std::unique_ptr<starboard::Application> mock_application_;
   starboard::FakeGraphicsContextProvider fake_graphics_context_provider_;
 
   SbPlayer player_ = kSbPlayerInvalid;

--- a/starboard/benchmark/player/player_benchmark_helper.h
+++ b/starboard/benchmark/player/player_benchmark_helper.h
@@ -1,0 +1,69 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_BENCHMARK_PLAYER_PLAYER_BENCHMARK_HELPER_H_
+#define STARBOARD_BENCHMARK_PLAYER_PLAYER_BENCHMARK_HELPER_H_
+
+#include <memory>
+
+#include "starboard/media.h"
+#include "starboard/player.h"
+#include "starboard/testing/fake_graphics_context_provider.h"
+
+namespace starboard {
+class QueueApplication;
+
+namespace benchmark {
+
+class SbPlayerBenchmarkHelper {
+ public:
+  SbPlayerBenchmarkHelper();
+  ~SbPlayerBenchmarkHelper();
+
+  // Generate creation parameters for standard AVC and AAC playback
+  void GetCreationParam(SbPlayerCreationParam* out_creation_param,
+                        SbPlayerOutputMode output_mode);
+
+  SbWindow GetWindow() { return fake_graphics_context_provider_.window(); }
+  SbDecodeTargetGraphicsContextProvider* GetDecoderTargetProvider() {
+    return fake_graphics_context_provider_.decoder_target_provider();
+  }
+
+  // Dummy callbacks required by SbPlayerCreate
+  static void DummyDeallocateSampleFunc(SbPlayer player,
+                                        void* context,
+                                        const void* sample_buffer);
+  static void DummyDecoderStatusFunc(SbPlayer player,
+                                     void* context,
+                                     SbMediaType type,
+                                     SbPlayerDecoderState state,
+                                     int ticket);
+  static void DummyPlayerStatusFunc(SbPlayer player,
+                                    void* context,
+                                    SbPlayerState state,
+                                    int ticket);
+  static void DummyPlayerErrorFunc(SbPlayer player,
+                                   void* context,
+                                   SbPlayerError error,
+                                   const char* message);
+
+ private:
+  std::unique_ptr<starboard::QueueApplication> mock_application_;
+  starboard::FakeGraphicsContextProvider fake_graphics_context_provider_;
+};
+
+}  // namespace benchmark
+}  // namespace starboard
+
+#endif  // STARBOARD_BENCHMARK_PLAYER_PLAYER_BENCHMARK_HELPER_H_

--- a/starboard/benchmark/player/player_create_benchmark.cc
+++ b/starboard/benchmark/player/player_create_benchmark.cc
@@ -23,9 +23,6 @@
 namespace starboard {
 namespace benchmark {
 
-// Dummy function to force linking of this translation unit
-void LinkPlayerCreateBenchmark() {}
-
 namespace {
 
 struct AsyncCreateContext {

--- a/starboard/benchmark/player/player_create_benchmark.cc
+++ b/starboard/benchmark/player/player_create_benchmark.cc
@@ -61,7 +61,7 @@ void AsyncPlayerErrorFunc(SbPlayer player,
 void BM_PlayerCreateSync(::benchmark::State& state) {
   SbPlayerBenchmarkHelper helper;
   SbPlayerCreationParam creation_param;
-  helper.GetCreationParam(&creation_param, kSbPlayerOutputModePunchOut);
+  helper.GetCreationParam(&creation_param, kSbPlayerOutputModeDecodeToTexture);
 
   for (auto _ : state) {
     auto start_time = std::chrono::high_resolution_clock::now();
@@ -74,22 +74,25 @@ void BM_PlayerCreateSync(::benchmark::State& state) {
                        SbPlayerBenchmarkHelper::DummyPlayerErrorFunc, nullptr,
                        helper.GetDecoderTargetProvider());
 
+    if (!SbPlayerIsValid(player)) {
+      state.SkipWithError("SbPlayerCreate failed");
+      break;
+    }
+
     auto end_time = std::chrono::high_resolution_clock::now();
 
     auto elapsed = std::chrono::duration_cast<std::chrono::duration<double>>(
         end_time - start_time);
     state.SetIterationTime(elapsed.count());
 
-    if (SbPlayerIsValid(player)) {
-      SbPlayerDestroy(player);
-    }
+    SbPlayerDestroy(player);
   }
 }
 
 void BM_PlayerCreateAsync(::benchmark::State& state) {
   SbPlayerBenchmarkHelper helper;
   SbPlayerCreationParam creation_param;
-  helper.GetCreationParam(&creation_param, kSbPlayerOutputModePunchOut);
+  helper.GetCreationParam(&creation_param, kSbPlayerOutputModeDecodeToTexture);
 
   for (auto _ : state) {
     AsyncCreateContext ctx;

--- a/starboard/benchmark/player/player_create_benchmark.cc
+++ b/starboard/benchmark/player/player_create_benchmark.cc
@@ -1,0 +1,135 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+#include <condition_variable>  // NOLINT(build/c++11)
+#include <mutex>               // NOLINT(build/c++11)
+
+#include "starboard/benchmark/player/player_benchmark_helper.h"
+#include "starboard/player.h"
+#include "third_party/google_benchmark/src/include/benchmark/benchmark.h"
+
+namespace starboard {
+namespace benchmark {
+
+// Dummy function to force linking of this translation unit
+void LinkPlayerCreateBenchmark() {}
+
+namespace {
+
+struct AsyncCreateContext {
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool initialized = false;
+  bool failed = false;
+};
+
+void AsyncPlayerStatusFunc(SbPlayer player,
+                           void* context,
+                           SbPlayerState state,
+                           int ticket) {
+  AsyncCreateContext* ctx = static_cast<AsyncCreateContext*>(context);
+  if (state == kSbPlayerStateInitialized) {
+    std::unique_lock<std::mutex> lock(ctx->mutex);
+    ctx->initialized = true;
+    ctx->cv.notify_one();
+  }
+}
+
+void AsyncPlayerErrorFunc(SbPlayer player,
+                          void* context,
+                          SbPlayerError error,
+                          const char* message) {
+  AsyncCreateContext* ctx = static_cast<AsyncCreateContext*>(context);
+  std::unique_lock<std::mutex> lock(ctx->mutex);
+  ctx->initialized = true;
+  ctx->failed = true;
+  ctx->cv.notify_one();
+}
+
+void BM_PlayerCreateSync(::benchmark::State& state) {
+  SbPlayerBenchmarkHelper helper;
+  SbPlayerCreationParam creation_param;
+  helper.GetCreationParam(&creation_param, kSbPlayerOutputModePunchOut);
+
+  for (auto _ : state) {
+    auto start_time = std::chrono::high_resolution_clock::now();
+
+    SbPlayer player =
+        SbPlayerCreate(helper.GetWindow(), &creation_param,
+                       SbPlayerBenchmarkHelper::DummyDeallocateSampleFunc,
+                       SbPlayerBenchmarkHelper::DummyDecoderStatusFunc,
+                       SbPlayerBenchmarkHelper::DummyPlayerStatusFunc,
+                       SbPlayerBenchmarkHelper::DummyPlayerErrorFunc, nullptr,
+                       helper.GetDecoderTargetProvider());
+
+    auto end_time = std::chrono::high_resolution_clock::now();
+
+    auto elapsed = std::chrono::duration_cast<std::chrono::duration<double>>(
+        end_time - start_time);
+    state.SetIterationTime(elapsed.count());
+
+    if (SbPlayerIsValid(player)) {
+      SbPlayerDestroy(player);
+    }
+  }
+}
+
+void BM_PlayerCreateAsync(::benchmark::State& state) {
+  SbPlayerBenchmarkHelper helper;
+  SbPlayerCreationParam creation_param;
+  helper.GetCreationParam(&creation_param, kSbPlayerOutputModePunchOut);
+
+  for (auto _ : state) {
+    AsyncCreateContext ctx;
+    auto start_time = std::chrono::high_resolution_clock::now();
+
+    SbPlayer player = SbPlayerCreate(
+        helper.GetWindow(), &creation_param,
+        SbPlayerBenchmarkHelper::DummyDeallocateSampleFunc,
+        SbPlayerBenchmarkHelper::DummyDecoderStatusFunc, AsyncPlayerStatusFunc,
+        AsyncPlayerErrorFunc, &ctx, helper.GetDecoderTargetProvider());
+
+    if (!SbPlayerIsValid(player)) {
+      state.SkipWithError("SbPlayerCreate failed");
+      break;
+    }
+
+    {
+      std::unique_lock<std::mutex> lock(ctx.mutex);
+      ctx.cv.wait(lock, [&ctx] { return ctx.initialized; });
+    }
+
+    auto end_time = std::chrono::high_resolution_clock::now();
+
+    if (ctx.failed) {
+      state.SkipWithError("SbPlayer initialization failed");
+      SbPlayerDestroy(player);
+      break;
+    }
+
+    auto elapsed = std::chrono::duration_cast<std::chrono::duration<double>>(
+        end_time - start_time);
+    state.SetIterationTime(elapsed.count());
+
+    SbPlayerDestroy(player);
+  }
+}
+
+BENCHMARK(BM_PlayerCreateSync)->UseManualTime();
+BENCHMARK(BM_PlayerCreateAsync)->UseManualTime();
+
+}  // namespace
+}  // namespace benchmark
+}  // namespace starboard

--- a/starboard/benchmark/player/player_destroy_benchmark.cc
+++ b/starboard/benchmark/player/player_destroy_benchmark.cc
@@ -1,0 +1,64 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+
+#include "starboard/benchmark/player/player_benchmark_helper.h"
+#include "starboard/player.h"
+#include "third_party/google_benchmark/src/include/benchmark/benchmark.h"
+
+namespace starboard {
+namespace benchmark {
+
+// Dummy function to force linking of this translation unit
+void LinkPlayerDestroyBenchmark() {}
+
+namespace {
+
+void BM_PlayerDestroySync(::benchmark::State& state) {
+  SbPlayerBenchmarkHelper helper;
+  SbPlayerCreationParam creation_param;
+  helper.GetCreationParam(&creation_param, kSbPlayerOutputModePunchOut);
+
+  for (auto _ : state) {
+    // 1. Create player (not timed)
+    SbPlayer player =
+        SbPlayerCreate(helper.GetWindow(), &creation_param,
+                       SbPlayerBenchmarkHelper::DummyDeallocateSampleFunc,
+                       SbPlayerBenchmarkHelper::DummyDecoderStatusFunc,
+                       SbPlayerBenchmarkHelper::DummyPlayerStatusFunc,
+                       SbPlayerBenchmarkHelper::DummyPlayerErrorFunc, nullptr,
+                       helper.GetDecoderTargetProvider());
+
+    if (!SbPlayerIsValid(player)) {
+      state.SkipWithError("SbPlayerCreate failed");
+      break;
+    }
+
+    // 2. Measure only the destruction time
+    auto start_time = std::chrono::high_resolution_clock::now();
+    SbPlayerDestroy(player);
+    auto end_time = std::chrono::high_resolution_clock::now();
+
+    auto elapsed = std::chrono::duration_cast<std::chrono::duration<double>>(
+        end_time - start_time);
+    state.SetIterationTime(elapsed.count());
+  }
+}
+
+BENCHMARK(BM_PlayerDestroySync)->UseManualTime();
+
+}  // namespace
+}  // namespace benchmark
+}  // namespace starboard

--- a/starboard/benchmark/player/player_destroy_benchmark.cc
+++ b/starboard/benchmark/player/player_destroy_benchmark.cc
@@ -29,7 +29,7 @@ namespace {
 void BM_PlayerDestroySync(::benchmark::State& state) {
   SbPlayerBenchmarkHelper helper;
   SbPlayerCreationParam creation_param;
-  helper.GetCreationParam(&creation_param, kSbPlayerOutputModePunchOut);
+  helper.GetCreationParam(&creation_param, kSbPlayerOutputModeDecodeToTexture);
 
   for (auto _ : state) {
     // 1. Create player (not timed)

--- a/starboard/benchmark/player/player_destroy_benchmark.cc
+++ b/starboard/benchmark/player/player_destroy_benchmark.cc
@@ -21,9 +21,6 @@
 namespace starboard {
 namespace benchmark {
 
-// Dummy function to force linking of this translation unit
-void LinkPlayerDestroyBenchmark() {}
-
 namespace {
 
 void BM_PlayerDestroySync(::benchmark::State& state) {

--- a/starboard/benchmark/player/player_seek_benchmark.cc
+++ b/starboard/benchmark/player/player_seek_benchmark.cc
@@ -20,8 +20,6 @@
 namespace starboard {
 namespace benchmark {
 
-void LinkPlayerSeekBenchmark() {}
-
 namespace {
 
 const char* kAudioFile = "beneath_the_canopy_aac_stereo.dmp";

--- a/starboard/benchmark/player/player_seek_benchmark.cc
+++ b/starboard/benchmark/player/player_seek_benchmark.cc
@@ -1,0 +1,98 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+
+#include "starboard/benchmark/player/player_benchmark_helper.h"
+#include "third_party/google_benchmark/src/include/benchmark/benchmark.h"
+
+namespace starboard {
+namespace benchmark {
+
+void LinkPlayerSeekBenchmark() {}
+
+namespace {
+
+const char* kAudioFile = "beneath_the_canopy_aac_stereo.dmp";
+const char* kVideoFile = "vertical_1080p_30_fps_137_avc.dmp";
+const int64_t kFeedDurationUs = 2000000;  // 2 seconds
+const int64_t kSeekTargetUs = 1000000;    // 1 second
+
+void BM_PlayerSeekSync(::benchmark::State& state) {
+  SbPlayerBenchmarkHelper helper;
+  if (!helper.InitializePlayer(kAudioFile, kVideoFile,
+                               kSbPlayerOutputModeDecodeToTexture)) {
+    state.SkipWithError("Player initialization failed");
+    return;
+  }
+
+  // Initial preroll
+  helper.FeedData(kFeedDurationUs);
+
+  // Wait for initial presenting to ensure player is stable
+  int ticket = helper.GetCurrentTicket();
+  helper.WaitForPlayerState(kSbPlayerStatePresenting, ticket);
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    int next_ticket = helper.PrepareSeek(kSeekTargetUs);
+    state.ResumeTiming();
+
+    // Measure ONLY the SbPlayerSeek call
+    SbPlayerSeek(helper.GetPlayer(), kSeekTargetUs, next_ticket);
+
+    state.PauseTiming();
+    // Feed data from seek target (1s) to target + 2s (3s)
+    helper.FeedData(kSeekTargetUs + kFeedDurationUs);
+    helper.WaitForPlayerState(kSbPlayerStatePresenting, next_ticket);
+    state.ResumeTiming();
+  }
+}
+BENCHMARK(BM_PlayerSeekSync)->Iterations(20);
+
+void BM_PlayerSeekAsync(::benchmark::State& state) {
+  SbPlayerBenchmarkHelper helper;
+  if (!helper.InitializePlayer(kAudioFile, kVideoFile,
+                               kSbPlayerOutputModeDecodeToTexture)) {
+    state.SkipWithError("Player initialization failed");
+    return;
+  }
+
+  // Initial preroll
+  helper.FeedData(kFeedDurationUs);
+  int ticket = helper.GetCurrentTicket();
+  helper.WaitForPlayerState(kSbPlayerStatePresenting, ticket);
+
+  for (auto _ : state) {
+    int next_ticket = helper.PrepareSeek(kSeekTargetUs);
+
+    // Measure from SbPlayerSeek to kSbPlayerStatePresenting
+    auto start = std::chrono::high_resolution_clock::now();
+
+    SbPlayerSeek(helper.GetPlayer(), kSeekTargetUs, next_ticket);
+    helper.FeedData(kSeekTargetUs + kFeedDurationUs);
+    helper.WaitForPlayerState(kSbPlayerStatePresenting, next_ticket);
+
+    auto end = std::chrono::high_resolution_clock::now();
+
+    auto elapsed =
+        std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
+    state.SetIterationTime(elapsed.count());
+  }
+}
+BENCHMARK(BM_PlayerSeekAsync)->UseManualTime()->Iterations(20);
+
+}  // namespace
+}  // namespace benchmark
+}  // namespace starboard

--- a/starboard/common/benchmark_main.cc
+++ b/starboard/common/benchmark_main.cc
@@ -24,14 +24,6 @@
 #include "perfetto/tracing.h"
 #endif
 
-namespace starboard {
-namespace benchmark {
-void LinkPlayerCreateBenchmark();
-void LinkPlayerDestroyBenchmark();
-void LinkPlayerSeekBenchmark();
-}  // namespace benchmark
-}  // namespace starboard
-
 namespace {
 int RunAllBenchmarks(int argc, char** argv) {
 #if BUILDFLAG(IS_ANDROID)
@@ -42,9 +34,6 @@ int RunAllBenchmarks(int argc, char** argv) {
 #if BUILDFLAG(IS_ANDROID)
   starboard::features::InitializeStarboardFeatureListWithDefaults();
 #endif
-  starboard::benchmark::LinkPlayerCreateBenchmark();
-  starboard::benchmark::LinkPlayerDestroyBenchmark();
-  starboard::benchmark::LinkPlayerSeekBenchmark();
   ::benchmark::Initialize(&argc, argv);
   ::benchmark::RunSpecifiedBenchmarks();
   return 0;

--- a/starboard/common/benchmark_main.cc
+++ b/starboard/common/benchmark_main.cc
@@ -14,8 +14,13 @@
 
 #include "starboard/client_porting/wrap_main/wrap_main.h"
 #include "starboard/event.h"
+#include "starboard/shared/starboard/features_test_util.h"
 #include "starboard/system.h"
 #include "third_party/google_benchmark/src/include/benchmark/benchmark.h"
+
+#if BUILDFLAG(IS_ANDROID)
+#include "perfetto/tracing.h"
+#endif
 
 namespace starboard {
 namespace benchmark {
@@ -26,6 +31,12 @@ void LinkPlayerDestroyBenchmark();
 
 namespace {
 int RunAllBenchmarks(int argc, char** argv) {
+#if BUILDFLAG(IS_ANDROID)
+  perfetto::TracingInitArgs perfetto_args;
+  perfetto_args.backends = perfetto::kSystemBackend;
+  perfetto::Tracing::Initialize(perfetto_args);
+#endif
+  starboard::features::InitializeStarboardFeatureListWithDefaults();
   starboard::benchmark::LinkPlayerCreateBenchmark();
   starboard::benchmark::LinkPlayerDestroyBenchmark();
   ::benchmark::Initialize(&argc, argv);

--- a/starboard/common/benchmark_main.cc
+++ b/starboard/common/benchmark_main.cc
@@ -20,17 +20,8 @@
 #include "starboard/system.h"
 #include "third_party/google_benchmark/src/include/benchmark/benchmark.h"
 
-#if BUILDFLAG(IS_ANDROID)
-#include "perfetto/tracing.h"
-#endif
-
 namespace {
 int RunAllBenchmarks(int argc, char** argv) {
-#if BUILDFLAG(IS_ANDROID)
-  perfetto::TracingInitArgs perfetto_args;
-  perfetto_args.backends = perfetto::kSystemBackend;
-  perfetto::Tracing::Initialize(perfetto_args);
-#endif
 #if BUILDFLAG(IS_ANDROID)
   starboard::features::InitializeStarboardFeatureListWithDefaults();
 #endif

--- a/starboard/common/benchmark_main.cc
+++ b/starboard/common/benchmark_main.cc
@@ -17,8 +17,17 @@
 #include "starboard/system.h"
 #include "third_party/google_benchmark/src/include/benchmark/benchmark.h"
 
+namespace starboard {
+namespace benchmark {
+void LinkPlayerCreateBenchmark();
+void LinkPlayerDestroyBenchmark();
+}  // namespace benchmark
+}  // namespace starboard
+
 namespace {
 int RunAllBenchmarks(int argc, char** argv) {
+  starboard::benchmark::LinkPlayerCreateBenchmark();
+  starboard::benchmark::LinkPlayerDestroyBenchmark();
   ::benchmark::Initialize(&argc, argv);
   ::benchmark::RunSpecifiedBenchmarks();
   return 0;

--- a/starboard/common/benchmark_main.cc
+++ b/starboard/common/benchmark_main.cc
@@ -14,7 +14,9 @@
 
 #include "starboard/client_porting/wrap_main/wrap_main.h"
 #include "starboard/event.h"
+#if BUILDFLAG(IS_ANDROID)
 #include "starboard/shared/starboard/features_test_util.h"
+#endif
 #include "starboard/system.h"
 #include "third_party/google_benchmark/src/include/benchmark/benchmark.h"
 
@@ -37,7 +39,9 @@ int RunAllBenchmarks(int argc, char** argv) {
   perfetto_args.backends = perfetto::kSystemBackend;
   perfetto::Tracing::Initialize(perfetto_args);
 #endif
+#if BUILDFLAG(IS_ANDROID)
   starboard::features::InitializeStarboardFeatureListWithDefaults();
+#endif
   starboard::benchmark::LinkPlayerCreateBenchmark();
   starboard::benchmark::LinkPlayerDestroyBenchmark();
   starboard::benchmark::LinkPlayerSeekBenchmark();

--- a/starboard/common/benchmark_main.cc
+++ b/starboard/common/benchmark_main.cc
@@ -26,6 +26,7 @@ namespace starboard {
 namespace benchmark {
 void LinkPlayerCreateBenchmark();
 void LinkPlayerDestroyBenchmark();
+void LinkPlayerSeekBenchmark();
 }  // namespace benchmark
 }  // namespace starboard
 
@@ -39,6 +40,7 @@ int RunAllBenchmarks(int argc, char** argv) {
   starboard::features::InitializeStarboardFeatureListWithDefaults();
   starboard::benchmark::LinkPlayerCreateBenchmark();
   starboard::benchmark::LinkPlayerDestroyBenchmark();
+  starboard::benchmark::LinkPlayerSeekBenchmark();
   ::benchmark::Initialize(&argc, argv);
   ::benchmark::RunSpecifiedBenchmarks();
   return 0;

--- a/starboard/common/test_main.cc
+++ b/starboard/common/test_main.cc
@@ -43,9 +43,7 @@ int RunTests(int argc, char** argv) {
 int InitAndRunAllTests(int argc, char** argv) {
   starboard::testing::g_test_command_line =
       std::make_unique<starboard::CommandLine>(argc, argv);
-  for (int i = 0; i < argc; ++i) {
-    SB_LOG(INFO) << "test_main argv[" << i << "]: " << argv[i];
-  }
+
   ::testing::InitGoogleTest(&argc, argv);
   return starboard::RunPlatformTestSuite(argc, argv, &RunTests);
 }

--- a/starboard/common/test_main.cc
+++ b/starboard/common/test_main.cc
@@ -12,9 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <memory>
+
 #include "build/build_config.h"
 #include "starboard/client_porting/wrap_main/wrap_main.h"
+#include "starboard/common/command_line.h"
+#include "starboard/common/log.h"
 #include "starboard/configuration.h"
+
+namespace starboard {
+namespace testing {
+std::unique_ptr<CommandLine> g_test_command_line;
+const CommandLine* GetTestCommandLine() {
+  return g_test_command_line.get();
+}
+}  // namespace testing
+}  // namespace starboard
 #include "starboard/event.h"
 #include "starboard/system.h"
 #include "starboard/testing/test_runner.h"
@@ -28,6 +41,11 @@ int RunTests(int argc, char** argv) {
 }
 
 int InitAndRunAllTests(int argc, char** argv) {
+  starboard::testing::g_test_command_line =
+      std::make_unique<starboard::CommandLine>(argc, argv);
+  for (int i = 0; i < argc; ++i) {
+    SB_LOG(INFO) << "test_main argv[" << i << "]: " << argv[i];
+  }
   ::testing::InitGoogleTest(&argc, argv);
   return starboard::RunPlatformTestSuite(argc, argv, &RunTests);
 }

--- a/starboard/shared/starboard/application.h
+++ b/starboard/shared/starboard/application.h
@@ -40,7 +40,7 @@ namespace starboard {
 
 // A small application framework for managing the application life-cycle, and
 // dispatching events to the Starboard event handler, SbEventHandle.
-class SB_EXPORT_ANDROID Application {
+class SB_EXPORT Application {
  public:
   // Executes a SbEventHandle method callback.
   SbEventHandleCallback sb_event_handle_callback_ = NULL;

--- a/starboard/shared/starboard/application.h
+++ b/starboard/shared/starboard/application.h
@@ -40,7 +40,7 @@ namespace starboard {
 
 // A small application framework for managing the application life-cycle, and
 // dispatching events to the Starboard event handler, SbEventHandle.
-class SB_EXPORT Application {
+class SB_EXPORT_ANDROID Application {
  public:
   // Executes a SbEventHandle method callback.
   SbEventHandleCallback sb_event_handle_callback_ = NULL;

--- a/starboard/shared/starboard/feature_list.h
+++ b/starboard/shared/starboard/feature_list.h
@@ -133,6 +133,21 @@ class FeatureList {
   bool is_initialized_ = false;
 };
 
+template <typename T>
+constexpr SbFeatureParamType GetSbFeatureParamType() {
+  if constexpr (std::is_same_v<bool, T>) {
+    return SbFeatureParamTypeBool;
+  } else if constexpr (std::is_same_v<int, T>) {
+    return SbFeatureParamTypeInt;
+  } else if constexpr (std::is_same_v<double, T>) {
+    return SbFeatureParamTypeDouble;
+  } else if constexpr (std::is_same_v<std::string, T>) {
+    return SbFeatureParamTypeString;
+  } else if constexpr (std::is_same_v<int64_t, T>) {
+    return SbFeatureParamTypeTime;
+  }
+}
+
 // SbFeatureParamExt is a bridge structure used in starboard to support params
 // of different data types, like base::FeatureParam.
 template <typename T>
@@ -145,7 +160,7 @@ struct SbFeatureParamExt : public SbFeatureParam {
                 "Unsupported Starboard FeatureParam<> type");
 
   constexpr SbFeatureParamExt(const SbFeature& feature, const char* name)
-      : SbFeatureParam{feature.name, name} {}
+      : SbFeatureParam{feature.name, name, GetSbFeatureParamType<T>()} {}
 
   // Function used to retrieve the parameter value for a given param. Outside
   // code will call this function, which will then call the corresponding

--- a/starboard/shared/starboard/player/video_dmp_reader.cc
+++ b/starboard/shared/starboard/player/video_dmp_reader.cc
@@ -279,10 +279,15 @@ bool VideoDmpReader::ParseOneRecord() {
              &dmp_info_.audio_sample_info);
         SB_DCHECK_EQ(dmp_info_.audio_codec,
                      dmp_info_.audio_sample_info.stream_info.codec);
+        audio_mime_ = audio_mime_type();
+        dmp_info_.audio_sample_info.stream_info.mime = audio_mime_;
       }
       break;
     case kRecordTypeVideoConfig:
       Read(read_cb_, reverse_byte_order_.value(), &dmp_info_.video_codec);
+      if (dmp_info_.video_codec != kSbMediaVideoCodecNone) {
+        video_mime_ = video_mime_type();
+      }
       break;
     case kRecordTypeAudioAccessUnit:
       audio_access_units_.push_back(ReadAudioAccessUnit());
@@ -402,6 +407,7 @@ VideoDmpReader::AudioAccessUnit VideoDmpReader::ReadAudioAccessUnit() {
 
   AudioSampleInfo audio_sample_info;
   Read(read_cb_, reverse_byte_order_.value(), &audio_sample_info);
+  audio_sample_info.stream_info.mime = audio_mime_;
 
   return AudioAccessUnit(timestamp,
                          drm_sample_info_present ? &drm_sample_info : NULL,
@@ -427,6 +433,7 @@ VideoDmpReader::VideoAccessUnit VideoDmpReader::ReadVideoAccessUnit() {
 
   VideoSampleInfo video_sample_info;
   Read(read_cb_, reverse_byte_order_.value(), &video_sample_info);
+  video_sample_info.stream_info.mime = video_mime_;
 
   return VideoAccessUnit(timestamp,
                          drm_sample_info_present ? &drm_sample_info : NULL,

--- a/starboard/shared/starboard/player/video_dmp_reader.h
+++ b/starboard/shared/starboard/player/video_dmp_reader.h
@@ -170,6 +170,9 @@ class VideoDmpReader {
   VideoAccessUnit ReadVideoAccessUnit();
   static Registry* GetRegistry();
 
+  std::string audio_mime_;
+  std::string video_mime_;
+
   const bool allow_read_on_demand_;
 
   FileCacheReader file_reader_;

--- a/starboard/shared/starboard/queue_application.h
+++ b/starboard/shared/starboard/queue_application.h
@@ -30,7 +30,7 @@ namespace starboard {
 
 // An application implementation that uses a signaling thread-safe queue to
 // manage event dispatching.
-class QueueApplication : public Application {
+class SB_EXPORT QueueApplication : public Application {
  public:
   explicit QueueApplication(SbEventHandleCallback sb_event_handle_callback)
       : Application(sb_event_handle_callback) {}

--- a/starboard/shared/starboard/queue_application.h
+++ b/starboard/shared/starboard/queue_application.h
@@ -30,7 +30,7 @@ namespace starboard {
 
 // An application implementation that uses a signaling thread-safe queue to
 // manage event dispatching.
-class SB_EXPORT QueueApplication : public Application {
+class QueueApplication : public Application {
  public:
   explicit QueueApplication(SbEventHandleCallback sb_event_handle_callback)
       : Application(sb_event_handle_callback) {}

--- a/starboard/testing/test_runner.h
+++ b/starboard/testing/test_runner.h
@@ -19,6 +19,12 @@
 
 namespace starboard {
 
+class CommandLine;
+
+namespace testing {
+const CommandLine* GetTestCommandLine();
+}
+
 using RunTestsCallback = std::function<int(int, char**)>;
 
 // Executes `action`. On platforms requiring main loop pumping (e.g. tvOS),

--- a/testing/gtest/BUILD.gn
+++ b/testing/gtest/BUILD.gn
@@ -80,6 +80,7 @@ source_set("gtest_main") {
     deps = [
       ":gtest",
       "//starboard:starboard_group",
+      "//starboard/common",
       "//starboard/testing:test_runner",
     ]
   } else {


### PR DESCRIPTION
Introduce a benchmarking suite for the SbPlayer interface to measure
the performance of player creation, destruction, and seek operations.
These metrics are essential for tracking media pipeline performance
and identifying regressions in platform implementations.

The change includes a GTest wrapper to enable these benchmarks on
Android via the standard test runner. Supporting changes include move
semantics for DecodedAudio and infrastructure to pass command-line
arguments from Android activities to the Starboard layer.

Bug: 541298090