### PR TITLE
aosp: disable base tracing in the AOSP toolchains

### DIFF
--- a/starboard/aosp/arm/toolchain/BUILD.gn
+++ b/starboard/aosp/arm/toolchain/BUILD.gn
@@ -54,6 +54,7 @@ android_clang_toolchain("starboard") {
     is_starboard = true
     use_cxx17 = true
     build_base_with_cpp17 = true
+    enable_base_tracing = false
 
     # 'aligned_alloc' is only available on Android 28 or newer.
     android_ndk_api_level = 28
@@ -66,5 +67,6 @@ android_clang_toolchain("native_target") {
     is_starboard = false
     use_cxx17 = true
     build_base_with_cpp17 = true
+    enable_base_tracing = false
   }
 }


### PR DESCRIPTION
starboard/shared/starboard/media/BUILD.gn defines ENABLE_MEDIA_TRACING and links libperfetto into media_util when a non-release build has enable_base_tracing on, which enables the EnsureMediaTracingIsInitialized() check.

SbPlayerCreate() calls it, and it reaches starboard_tracing::TrackEvent::Register().

In Evergreen, the loader has its own statically linked copy of the perfetto muxer and nothing initializes it. Only the libcobalt.so runs PerfettoTracedProcess::SetupClientLibrary().

Calling Register() with an  uninitialized copy traps in TracingMuxerFake::FailUninitialized(), so starting a video kills the process.

libloader_app/libelf_loader_sandbox and the starboard_platform they are built by the starboard toolchain, so disabling base tracing is needed both in the native_target and starboard toolchains.

libcobalt.so keeps the media tracing, it is built with the default toolchain.

Bug: 532068409