### PR TITLE
Fix Omaha version spoofing vulnerability by parsing manifest.json

### DIFF
--- a/components/update_client/component.cc
+++ b/components/update_client/component.cc
@@ -182,7 +182,6 @@ void Component::SetUpdateCheckResult(std::optional<ProtocolParser::App> result,
 #endif
 #if BUILDFLAG(IS_STARBOARD)
         update_context_->update_checker->GetPersistedData(),
-        next_version_.GetString(),
 #endif
         base::BindRepeating(
             [](base::raw_ref<Component> component, ComponentState state) {

--- a/components/update_client/op_install.cc
+++ b/components/update_client/op_install.cc
@@ -44,7 +44,6 @@
 
 namespace update_client {
 
-
 namespace {
 
 // The sequence of calls is:

--- a/components/update_client/op_install.cc
+++ b/components/update_client/op_install.cc
@@ -38,10 +38,12 @@
 
 #if BUILDFLAG(IS_STARBOARD)
 #include "components/update_client/cobalt_slot_management.h"
+#include "components/update_client/utils.h"
 #include "starboard/extension/installation_manager.h"
 #endif
 
 namespace update_client {
+
 
 namespace {
 
@@ -143,7 +145,6 @@ void Install(base::OnceCallback<void(const CrxInstaller::Result&)> callback,
              CrxInstaller::ProgressCallback progress_callback,
 #if BUILDFLAG(IS_STARBOARD)
              PersistedData* metadata,
-             const std::string& next_version,
              const std::string& id,
              const OperationResult& crx_operation_result,
 #endif
@@ -190,9 +191,14 @@ void Install(base::OnceCallback<void(const CrxInstaller::Result&)> callback,
     install_error = InstallError::GENERIC_ERROR;
   } else {
     char app_key[IM_EXT_MAX_APP_KEY_LENGTH];
+    base::Version manifest_version = ReadEvergreenVersion(result.unpack_path);
+
     if (installation_api->GetAppKey(app_key, IM_EXT_MAX_APP_KEY_LENGTH) ==
         IM_EXT_ERROR) {
       LOG(ERROR) << "Failed to get app key.";
+      install_error = InstallError::GENERIC_ERROR;
+    } else if (!manifest_version.IsValid()) {
+      LOG(ERROR) << "Invalid Evergreen manifest. Installation aborted.";
       install_error = InstallError::GENERIC_ERROR;
     } else if (CobaltFinishInstallation(
                    installation_api, crx_operation_result.installation_index,
@@ -200,7 +206,7 @@ void Install(base::OnceCallback<void(const CrxInstaller::Result&)> callback,
       // Write the version of the unpacked update package to the persisted data.
       if (metadata != nullptr) {
         metadata->SetLastInstalledEgAndSbVersion(
-            id, next_version, std::to_string(SB_API_VERSION));
+            id, manifest_version.GetString(), std::to_string(SB_API_VERSION));
       }
     } else {
       LOG(ERROR) << "CobaltFinishInstallation failed.";
@@ -309,7 +315,6 @@ base::OnceClosure InstallOperation(
     std::unique_ptr<CrxInstaller::InstallParams> install_params,
 #if BUILDFLAG(IS_STARBOARD)
     PersistedData* metadata,
-    const std::string& next_version,
 #endif
     base::RepeatingCallback<void(base::Value::Dict)> event_adder,
     base::RepeatingCallback<void(ComponentState)> state_tracker,
@@ -333,7 +338,7 @@ base::OnceClosure InstallOperation(
                          std::move(callback), event_adder,
                          crx_operation_result),
           std::move(install_params), installer, progress_callback,
-          metadata, next_version, id,
+          metadata, id,
           crx_operation_result),
       crx_operation_result, std::move(unzipper), pk_hash, crx_format,
       base::unexpected(UnpackerError::kCrxCacheNotProvided));

--- a/components/update_client/op_install.h
+++ b/components/update_client/op_install.h
@@ -45,7 +45,6 @@ base::OnceClosure InstallOperation(
     std::unique_ptr<CrxInstaller::InstallParams> install_params,
 #if BUILDFLAG(IS_STARBOARD)
     PersistedData* metadata,
-    const std::string& next_version,
 #endif
     base::RepeatingCallback<void(base::Value::Dict)> event_adder,
     base::RepeatingCallback<void(ComponentState)> state_tracker,

--- a/components/update_client/pipeline.cc
+++ b/components/update_client/pipeline.cc
@@ -315,7 +315,6 @@ std::queue<Operation> MakeOperations(
 #endif
 #if BUILDFLAG(IS_STARBOARD)
     PersistedData* metadata,
-    const std::string& next_version,
 #endif
     base::RepeatingCallback<void(ComponentState)> state_tracker,
     base::RepeatingCallback<void(base::Value::Dict)> event_adder,
@@ -395,7 +394,7 @@ std::queue<Operation> MakeOperations(
               : std::make_unique<CrxInstaller::InstallParams>(
                     operation.path, operation.arguments, install_data),
 #if BUILDFLAG(IS_STARBOARD)
-          metadata, next_version,
+          metadata,
 #endif
           event_adder, state_tracker, install_progress_callback,
           install_complete_callback));
@@ -458,7 +457,6 @@ void MakePipeline(
 #endif
 #if BUILDFLAG(IS_STARBOARD)
     PersistedData* metadata,
-    const std::string& next_version,
 #endif
     base::RepeatingCallback<void(ComponentState)> state_tracker,
     base::RepeatingCallback<void(base::Value::Dict)> event_adder,
@@ -534,7 +532,6 @@ void MakePipeline(
 #endif
 #if BUILDFLAG(IS_STARBOARD)
             metadata,
-            next_version,
 #endif
             state_tracker,
             base::BindRepeating(

--- a/components/update_client/pipeline.h
+++ b/components/update_client/pipeline.h
@@ -86,7 +86,6 @@ void MakePipeline(
 #endif
 #if BUILDFLAG(IS_STARBOARD)
     PersistedData* metadata,
-    const std::string& next_version,
 #endif
     base::RepeatingCallback<void(ComponentState)> state_tracker,
     base::RepeatingCallback<void(base::Value::Dict)> event_adder,


### PR DESCRIPTION
Instead of relying on the unverified version string received in the Omaha updatecheck response, actively parse the `manifest.json` from the unpacked payload using `ReadEvergreenVersion` to dictate the reliable version written into the local persistent data. This prevents an attacker from inflating the version string to permanently inhibit future updates.

Bug: 555428363
TAG=agy