### PR TITLE
cobalt: Revert UserAgent platform property to OSPlatformName

### DIFF
--- a/base/system/sys_info_starboard.cc
+++ b/base/system/sys_info_starboard.cc
@@ -14,6 +14,7 @@
 
 #include "base/system/sys_info_starboard.h"
 
+#include "base/notimplemented.h"
 #include "build/build_config.h"
 
 #if BUILDFLAG(IS_ANDROID)
@@ -28,7 +29,7 @@ using starboard::GetSystemPropertyString;
 #include <sys/utsname.h>
 
 #include "base/containers/contains.h"
-#include "base/notimplemented.h"
+
 #endif  // BUILDFLAG(IS_ANDROID)
 
 #if BUILDFLAG(IS_STARBOARD)
@@ -80,8 +81,9 @@ std::string SbSysInfo::Brand() {
   return std::string(brand_str);
 }
 
-std::string SbSysInfo::OSFriendlyName() {
-  return "AOSP";
+std::string SbSysInfo::OSPlatformName() {
+  NOTIMPLEMENTED();
+  return "";
 }
 
 #elif BUILDFLAG(IS_STARBOARD)
@@ -101,8 +103,8 @@ std::string SbSysInfo::Brand() {
   return GetSystemPropertyString(kSbSystemPropertyBrandName);
 }
 
-std::string SbSysInfo::OSFriendlyName() {
-  return GetSystemPropertyString(kSbSystemPropertyFriendlyName);
+std::string SbSysInfo::OSPlatformName() {
+  return GetSystemPropertyString(kSbSystemPropertyPlatformName);
 }
 
 #elif BUILDFLAG(IS_IOS_TVOS)
@@ -162,7 +164,7 @@ std::string SbSysInfo::Brand() {
   return "Apple";
 }
 
-std::string SbSysInfo::OSFriendlyName() {
+std::string SbSysInfo::OSPlatformName() {
   NOTIMPLEMENTED();
   return "";
 }

--- a/base/system/sys_info_starboard.h
+++ b/base/system/sys_info_starboard.h
@@ -32,7 +32,7 @@ class BASE_EXPORT SbSysInfo {
 
   static std::string Brand();
 
-  static std::string OSFriendlyName();
+  static std::string OSPlatformName();
 };
 
 }  // namespace starboard

--- a/base/system/sys_info_starboard_unittest.cc
+++ b/base/system/sys_info_starboard_unittest.cc
@@ -47,9 +47,9 @@ TEST_F(SbSysInfoTest, Brand) {
 }
 #endif
 
-#if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_STARBOARD)
-TEST_F(SbSysInfoTest, OSFriendlyName) {
-  std::string os_name_str = SbSysInfo::OSFriendlyName();
+#if BUILDFLAG(IS_STARBOARD) && !BUILDFLAG(IS_ANDROID)
+TEST_F(SbSysInfoTest, OSPlatformName) {
+  std::string os_name_str = SbSysInfo::OSPlatformName();
   EXPECT_NE(os_name_str, "");
 }
 #endif

--- a/cobalt/browser/user_agent/user_agent_platform_info.cc
+++ b/cobalt/browser/user_agent/user_agent_platform_info.cc
@@ -193,10 +193,10 @@ void UserAgentPlatformInfo::InitializePlatformDependentFieldsAndroid() {
 #elif BUILDFLAG(IS_STARBOARD)
 void UserAgentPlatformInfo::InitializePlatformDependentFieldsStarboard() {
   std::string os_name = base::SysInfo::OperatingSystemName();
-  const std::string os_friendly_name =
-      base::starboard::SbSysInfo::OSFriendlyName();
-  if (!os_friendly_name.empty()) {
-    os_name = os_friendly_name + "; " + os_name;
+  const std::string os_platform_name =
+      base::starboard::SbSysInfo::OSPlatformName();
+  if (!os_platform_name.empty()) {
+    os_name = os_platform_name + "; " + os_name;
   }
   const std::string os_version = base::SysInfo::OperatingSystemVersion();
   set_os_name_and_version(

--- a/cobalt/browser/user_agent/user_agent_platform_info_test.cc
+++ b/cobalt/browser/user_agent/user_agent_platform_info_test.cc
@@ -16,6 +16,7 @@
 
 #include <map>
 
+#include "base/system/sys_info_starboard.h"
 #include "base/test/scoped_feature_list.h"
 #include "build/build_config.h"
 #include "cobalt/browser/features.h"
@@ -422,6 +423,17 @@ TEST_F(UserAgentStringTest, OmitsFinchTokenWhenFeatureDisabled) {
   std::string user_agent_string = platform_info.ToString();
   EXPECT_EQ(std::string::npos, user_agent_string.find("Finch/"));
 }
+
+#if BUILDFLAG(IS_STARBOARD)
+#if !BUILDFLAG(IS_ANDROID)
+TEST_F(UserAgentStringTest, StarboardPlatformNameIsInjectedInOsNameAndVersion) {
+  UserAgentPlatformInfo platform_info(/*for_testing=*/true);
+  std::string user_agent_string = platform_info.ToString();
+  std::string os_platform_name = base::starboard::SbSysInfo::OSPlatformName();
+  EXPECT_NE(std::string::npos, user_agent_string.find(os_platform_name));
+}
+#endif
+#endif
 
 class GetUserAgentInputMapTest : public testing::Test {};
 


### PR DESCRIPTION
PR 8706 incorrectly switched the target Starboard property when constructing the User Agent OS platform name. In `InitializePlatformDependentFieldsStarboard()`, the implementation was invoking `SbSysInfo::OSFriendlyName()`, which queried `kSbSystemPropertyFriendlyName`.

This resulted in the UA string returning the device's friendly name (e.g. `Roku_TV_H102X`) instead of the standardized platform ID expected by YTS, which caused certification and integration testing regressions across partner devices.

This change fixes the regression by removing the use of `kSbSystemPropertyFriendlyName` for the UserAgent platform and introduces a new `SbSysInfo::OSPlatformName()` accessor, which properly proxies the `kSbSystemPropertyPlatformName` property.

Tests are updated to reflect the `OSPlatformName` usage in `StarboardPlatformNameIsInjectedInOsNameAndVersion`.

Bug: 527960653
TAG=agy
CONV=b48c1cf8-919f-40eb-9cd3-8383c0115796
