### PR TITLE
cobalt: fix build after HangWatcher shutdown fixes

### DIFF
--- a/cobalt/renderer/cobalt_content_renderer_client.cc
+++ b/cobalt/renderer/cobalt_content_renderer_client.cc
@@ -170,19 +170,6 @@ CobaltContentRendererClient::CobaltContentRendererClient()
 
 CobaltContentRendererClient::~CobaltContentRendererClient() {
   CHECK_CALLED_ON_VALID_THREAD(main_thread_checker_);
-  // In single-process mode, CobaltContentRendererClient is owned by
-  // CobaltMainDelegate and destroyed on the browser main thread during process
-  // termination. HangWatcher::UnregisterThread relies on TLS and can only be
-  // invoked on the registered thread itself, so we must not execute the closure
-  // on the browser main thread.
-  //
-  // Like the browser main thread and IO thread, the in-process renderer thread
-  // is a permanent thread that lives for the entire application lifetime.
-  // Releasing the closure without unregistering does not leak memory because
-  // this destructor only runs once immediately before process exit (where the
-  // OS reclaims all resources), and HangWatcher itself lives for the process
-  // duration as a base::NoDestructor singleton.
-  std::ignore = unregister_thread_closure.Release();
 }
 
 void CobaltContentRendererClient::RenderFrameCreated(


### PR DESCRIPTION
PR #12303 moved the release into PostSandboxInitialized() and removed the unregister_thread_closure member from the header, but did not touch the destructor, leaving a reference to the deleted member:

  cobalt/renderer/cobalt_content_renderer_client.cc: error:
    use of undeclared identifier 'unregister_thread_closure'

Drop the dead release call and the comment.

Bug: 532068409