### PR TITLE
media: Remove storage_type parameters from AudioResampler

### DIFF
--- a/starboard/shared/starboard/player/filter/adaptive_audio_decoder_internal.cc
+++ b/starboard/shared/starboard/player/filter/adaptive_audio_decoder_internal.cc
@@ -280,12 +280,10 @@ void AdaptiveAudioDecoder::OnDecoderOutput() {
     SB_DCHECK(!channel_mixer_);
     output_format_checked_ = true;
     if (output_sample_type_ != decoded_audio->sample_type() ||
-        output_storage_type_ != decoded_audio->storage_type() ||
         output_samples_per_second_ != decoded_sample_rate) {
       resampler_ = AudioResampler::Create(
-          decoded_audio->sample_type(), decoded_audio->storage_type(),
-          decoded_sample_rate, output_sample_type_, output_storage_type_,
-          output_samples_per_second_,
+          decoded_audio->sample_type(), decoded_sample_rate,
+          output_sample_type_, output_samples_per_second_,
           input_audio_stream_info_.number_of_channels);
     }
     if (input_audio_stream_info_.number_of_channels !=

--- a/starboard/shared/starboard/player/filter/audio_renderer_pcm_internal.cc
+++ b/starboard/shared/starboard/player/filter/audio_renderer_pcm_internal.cc
@@ -586,13 +586,10 @@ void AudioRendererPcm::OnFirstOutput(
   // kSbMediaAudioFrameStorageTypeInterleaved, so we resample the audio to that
   // format to avoid unnecessary extra conversion.
   if (decoded_sample_rate != destination_sample_rate ||
-      decoded_sample_type != kSbMediaAudioSampleTypeFloat32 ||
-      decoded_storage_type != kSbMediaAudioFrameStorageTypeInterleaved) {
+      decoded_sample_type != kSbMediaAudioSampleTypeFloat32) {
     resampler_ = AudioResampler::Create(
-        decoded_sample_type, decoded_storage_type, decoded_sample_rate,
-        kSbMediaAudioSampleTypeFloat32,
-        kSbMediaAudioFrameStorageTypeInterleaved, destination_sample_rate,
-        channels_);
+        decoded_sample_type, decoded_sample_rate,
+        kSbMediaAudioSampleTypeFloat32, destination_sample_rate, channels_);
     SB_DCHECK(resampler_);
   } else {
     resampler_.reset(new IdentityAudioResampler);

--- a/starboard/shared/starboard/player/filter/audio_resampler.h
+++ b/starboard/shared/starboard/player/filter/audio_resampler.h
@@ -25,8 +25,7 @@
 namespace starboard {
 
 // Classes inherited from this interface can convert input audio samples in one
-// sample and storage type into another sample and storage type.  For example,
-// it can convert planar int16 samples into interleaved float32 samples.
+// sample type and sample rate into another sample type and sample rate.
 // All functions (including Create() and the dtor) of the class should be called
 // on the same thread as the JobQueue passed in the Create() function.
 // It doesn't have a function to reset its internal state so during a seek the
@@ -53,10 +52,8 @@ class AudioResampler {
   // AudioResampler can call Read() to read the next chunk of resampled data.
   static std::unique_ptr<AudioResampler> Create(
       SbMediaAudioSampleType source_sample_type,
-      SbMediaAudioFrameStorageType source_storage_type,
       int source_sample_rate,
       SbMediaAudioSampleType destination_sample_type,
-      SbMediaAudioFrameStorageType destination_storage_type,
       int destination_sample_rate,
       int channels);
 };

--- a/starboard/shared/starboard/player/filter/audio_resampler_impl.cc
+++ b/starboard/shared/starboard/player/filter/audio_resampler_impl.cc
@@ -27,20 +27,15 @@ namespace starboard {
 
 namespace {
 
-// CPU based simple AudioResampler implementation.  Note that it currently only
-// supports resample audio between same storage type and same channels but with
-// different sample types.
+// CPU based simple AudioResampler implementation.
 class AudioResamplerImpl : public AudioResampler {
  public:
   AudioResamplerImpl(SbMediaAudioSampleType source_sample_type,
-                     SbMediaAudioFrameStorageType source_storage_type,
                      int source_sample_rate,
                      SbMediaAudioSampleType destination_sample_type,
-                     SbMediaAudioFrameStorageType destination_storage_type,
                      int destination_sample_rate,
                      int channels)
       : destination_sample_type_(destination_sample_type),
-        destination_storage_type_(destination_storage_type),
         interleaved_resampler_(static_cast<double>(source_sample_rate) /
                                    static_cast<double>(destination_sample_rate),
                                channels) {}
@@ -51,7 +46,6 @@ class AudioResamplerImpl : public AudioResampler {
 
  private:
   const SbMediaAudioSampleType destination_sample_type_;
-  const SbMediaAudioFrameStorageType destination_storage_type_;
 
   InterleavedSincResampler interleaved_resampler_;
 
@@ -67,15 +61,12 @@ class AudioResamplerImpl : public AudioResampler {
 // static
 std::unique_ptr<AudioResampler> AudioResampler::Create(
     SbMediaAudioSampleType source_sample_type,
-    SbMediaAudioFrameStorageType source_storage_type,
     int source_sample_rate,
     SbMediaAudioSampleType destination_sample_type,
-    SbMediaAudioFrameStorageType destination_storage_type,
     int destination_sample_rate,
     int channels) {
   return std::unique_ptr<AudioResampler>(new AudioResamplerImpl(
-      source_sample_type, source_storage_type, source_sample_rate,
-      destination_sample_type, destination_storage_type,
+      source_sample_type, source_sample_rate, destination_sample_type,
       destination_sample_rate, channels));
 }
 
@@ -99,9 +90,9 @@ std::optional<DecodedAudio> AudioResamplerImpl::WriteEndOfStream() {
       interleaved_resampler_.Resample(dst, out_num_of_frames);
 
       if (!resampled_audio.IsFormat(destination_sample_type_,
-                                    destination_storage_type_)) {
+                                    kSbMediaAudioFrameStorageTypeInterleaved)) {
         resampled_audio = resampled_audio.SwitchFormatTo(
-            destination_sample_type_, destination_storage_type_);
+            destination_sample_type_, kSbMediaAudioFrameStorageTypeInterleaved);
       }
       return resampled_audio;
     }
@@ -149,9 +140,10 @@ std::optional<DecodedAudio> AudioResamplerImpl::Resample(
     frames_resampled_ += next_audio_to_output.frames();
     frames_outputted_ += num_of_output_frames;
 
-    if (!output.IsFormat(destination_sample_type_, destination_storage_type_)) {
+    if (!output.IsFormat(destination_sample_type_,
+                         kSbMediaAudioFrameStorageTypeInterleaved)) {
       output = output.SwitchFormatTo(destination_sample_type_,
-                                     destination_storage_type_);
+                                     kSbMediaAudioFrameStorageTypeInterleaved);
     }
     resampled_audio = std::move(output);
 

--- a/starboard/shared/starboard/player/filter/testing/audio_resampler_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_resampler_test.cc
@@ -27,22 +27,12 @@ namespace {
 using ::testing::Combine;
 using ::testing::ValuesIn;
 
-typedef ::testing::tuple<SbMediaAudioSampleType,
-                         SbMediaAudioFrameStorageType,
-                         int,
-                         SbMediaAudioSampleType,
-                         SbMediaAudioFrameStorageType,
-                         int,
-                         int>
-    AudioResamplerTestParam;
+using AudioResamplerTestParam = ::testing::
+    tuple<SbMediaAudioSampleType, int, SbMediaAudioSampleType, int, int>;
 
 SbMediaAudioSampleType kSampleTypesToTest[] = {
     kSbMediaAudioSampleTypeInt16Deprecated,
     kSbMediaAudioSampleTypeFloat32,
-};
-SbMediaAudioFrameStorageType kStorageTypesToTest[] = {
-    kSbMediaAudioFrameStorageTypeInterleaved,
-    kSbMediaAudioFrameStorageTypePlanar,
 };
 int kSampleRatesToTest[] = {22050, 44100, 48000};
 int kChannelsToTest[] = {1, 2, 6};
@@ -57,29 +47,16 @@ const char* ConvertSampleTypeToString(SbMediaAudioSampleType sample_type) {
   return "";
 }
 
-const char* ConvertStorageTypeToString(
-    SbMediaAudioFrameStorageType storage_type) {
-  if (storage_type == kSbMediaAudioFrameStorageTypeInterleaved) {
-    return "interleaved";
-  } else if (storage_type == kSbMediaAudioFrameStorageTypePlanar) {
-    return "planar";
-  }
-  SB_NOTREACHED();
-  return "";
-}
-
 class AudioResamplerTest
     : public ::testing::TestWithParam<AudioResamplerTestParam> {
  protected:
   AudioResamplerTest() {
     const AudioResamplerTestParam& param = GetParam();
     source_sample_type_ = std::get<0>(param);
-    source_storage_type_ = std::get<1>(param);
-    source_sample_rate_ = std::get<2>(param);
-    destination_sample_type_ = std::get<3>(param);
-    destination_storage_type_ = std::get<4>(param);
-    destination_sample_rate_ = std::get<5>(param);
-    channels_ = std::get<6>(param);
+    source_sample_rate_ = std::get<1>(param);
+    destination_sample_type_ = std::get<2>(param);
+    destination_sample_rate_ = std::get<3>(param);
+    channels_ = std::get<4>(param);
 
     GenerateAudioInputs();
   }
@@ -104,10 +81,8 @@ class AudioResamplerTest
   }
 
   SbMediaAudioSampleType source_sample_type_;
-  SbMediaAudioFrameStorageType source_storage_type_;
   int source_sample_rate_;
   SbMediaAudioSampleType destination_sample_type_;
-  SbMediaAudioFrameStorageType destination_storage_type_;
   int destination_sample_rate_;
   int channels_;
 
@@ -116,8 +91,7 @@ class AudioResamplerTest
 
 TEST_P(AudioResamplerTest, SunnyDay) {
   std::unique_ptr<AudioResampler> resampler = AudioResampler::Create(
-      source_sample_type_, source_storage_type_, source_sample_rate_,
-      destination_sample_type_, destination_storage_type_,
+      source_sample_type_, source_sample_rate_, destination_sample_type_,
       destination_sample_rate_, channels_);
 
   int total_input_frames = 0;
@@ -157,18 +131,14 @@ std::string GetTestConfigName(
     ::testing::TestParamInfo<AudioResamplerTestParam> info) {
   const AudioResamplerTestParam& param = info.param;
   SbMediaAudioSampleType source_sample_type = std::get<0>(param);
-  SbMediaAudioFrameStorageType source_storage_type = std::get<1>(param);
-  int source_sample_rate = std::get<2>(param);
-  SbMediaAudioSampleType destination_sample_type = std::get<3>(param);
-  SbMediaAudioFrameStorageType destination_storage_type = std::get<4>(param);
-  int destination_sample_rate = std::get<5>(param);
-  int channels = std::get<6>(param);
+  int source_sample_rate = std::get<1>(param);
+  SbMediaAudioSampleType destination_sample_type = std::get<2>(param);
+  int destination_sample_rate = std::get<3>(param);
+  int channels = std::get<4>(param);
   std::string name = FormatString(
-      "%s_%s_%d_to_%s_%s_%d_channels_%d",
-      ConvertSampleTypeToString(source_sample_type),
-      ConvertStorageTypeToString(source_storage_type), source_sample_rate,
+      "%s_%d_to_%s_%d_channels_%d",
+      ConvertSampleTypeToString(source_sample_type), source_sample_rate,
       ConvertSampleTypeToString(destination_sample_type),
-      ConvertStorageTypeToString(destination_storage_type),
       destination_sample_rate, channels);
   return name;
 }
@@ -176,10 +146,8 @@ std::string GetTestConfigName(
 INSTANTIATE_TEST_SUITE_P(AudioResamplerTests,
                          AudioResamplerTest,
                          Combine(ValuesIn(kSampleTypesToTest),
-                                 ValuesIn(kStorageTypesToTest),
                                  ValuesIn(kSampleRatesToTest),
                                  ValuesIn(kSampleTypesToTest),
-                                 ValuesIn(kStorageTypesToTest),
                                  ValuesIn(kSampleRatesToTest),
                                  ValuesIn(kChannelsToTest)),
                          GetTestConfigName);


### PR DESCRIPTION
This is part of the effort to remove kSbMediaAudioFrameStorageTypePlanar from 1P implementation.

Remove the source and destination storage type parameters from the
AudioResampler interface. As AudioResampler only supports interleaved
audio, specifying storage types is unnecessary.

This change simplifies AudioResamplerImpl and updates its call sites
in AdaptiveAudioDecoder and AudioRendererPcmImpl

Bug: 272837615