### PR TITLE
android: Prevent surface destruction deadlocks

### DIFF
--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -238,6 +238,8 @@ static_library("starboard_platform") {
     "base_starboard_bridge.cc",
     "starboard_bridge.h",
     "starboard_feature_list.cc",
+    "surface_destroy_notifier.cc",
+    "surface_destroy_notifier.h",
     "system_get_extensions.cc",
     "system_get_locale_id.cc",
     "system_get_path.cc",

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -1218,7 +1218,6 @@ void MediaCodecVideoDecoder::OnSurfaceDestroyed() {
     // When using SurfaceDestroyNotifier, OnSurfaceDestroyed() is always invoked
     // on the decoder thread via NotifyDestroyed().
     SB_CHECK(BelongsToCurrentThread());
-    owns_video_surface_ = false;
     TeardownCodec();
     return;
   }

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -29,6 +29,7 @@
 #include "starboard/android/shared/media_capabilities_cache.h"
 #include "starboard/android/shared/media_codec_video_decoder_helpers.h"
 #include "starboard/android/shared/media_common.h"
+#include "starboard/android/shared/surface_destroy_notifier.h"
 #include "starboard/android/shared/video_render_algorithm_android.h"
 #include "starboard/android/shared/video_surface_texture_bridge.h"
 #include "starboard/common/check_op.h"
@@ -833,7 +834,9 @@ Result<void> MediaCodecVideoDecoder::InitializeCodec(
       if (surface_view_) {
         j_output_surface = surface_view_.AsLocalRef(env);
       } else {
-        j_output_surface = AcquireVideoSurface();
+        AcquiredSurface acquired_surface = AcquireVideoSurface(job_queue());
+        surface_destroy_notifier_ = acquired_surface.destroy_notifier;
+        j_output_surface = acquired_surface.surface.AsLocalRef(env);
       }
       if (j_output_surface) {
         owns_video_surface_ = true;
@@ -936,6 +939,10 @@ void MediaCodecVideoDecoder::TeardownCodec() {
   if (owns_video_surface_) {
     ReleaseVideoSurface();
     owns_video_surface_ = false;
+  }
+  if (surface_destroy_notifier_) {
+    surface_destroy_notifier_->Disconnect();
+    surface_destroy_notifier_ = nullptr;
   }
   media_decoder_.reset();
   color_metadata_ = std::nullopt;
@@ -1207,6 +1214,15 @@ void MediaCodecVideoDecoder::OnVideoFrameRelease() {
 }
 
 void MediaCodecVideoDecoder::OnSurfaceDestroyed() {
+  if (surface_destroy_notifier_) {
+    // When using SurfaceDestroyNotifier, OnSurfaceDestroyed() is always invoked
+    // on the decoder thread via NotifyDestroyed().
+    SB_CHECK(BelongsToCurrentThread());
+    owns_video_surface_ = false;
+    TeardownCodec();
+    return;
+  }
+
   if (!BelongsToCurrentThread()) {
     // Wait until codec is stopped.
     std::unique_lock lock(surface_destroy_mutex_);

--- a/starboard/android/shared/media_codec_video_decoder.h
+++ b/starboard/android/shared/media_codec_video_decoder.h
@@ -297,6 +297,8 @@ class MediaCodecVideoDecoder : public VideoDecoder,
       const PlatformOptions& platform_options);
 
   const std::unique_ptr<VideoSurfaceTextureBridge> surface_texture_bridge_;
+
+  scoped_refptr<SurfaceDestroyNotifier> surface_destroy_notifier_;
 };
 
 }  // namespace starboard

--- a/starboard/android/shared/surface_destroy_notifier.cc
+++ b/starboard/android/shared/surface_destroy_notifier.cc
@@ -1,0 +1,25 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/android/shared/surface_destroy_notifier.h"
+
+namespace starboard {
+
+void SurfaceDestroyNotifier::Disconnect() {}
+
+void SurfaceDestroyNotifier::Notify() {}
+
+void SurfaceDestroyNotifier::NotifyDestroyed() {}
+
+}  // namespace starboard

--- a/starboard/android/shared/surface_destroy_notifier.cc
+++ b/starboard/android/shared/surface_destroy_notifier.cc
@@ -40,6 +40,8 @@ void SurfaceDestroyNotifier::Notify() {
   if (state_ == State::kDone || !holder_ || !job_queue_) {
     return;
   }
+  state_ = State::kWaiting;
+
   scoped_refptr<SurfaceDestroyNotifier> self(this);
   auto task = [self]() { self->NotifyDestroyed(); };
   if (!job_queue_->Schedule(std::move(task))) {

--- a/starboard/android/shared/surface_destroy_notifier.cc
+++ b/starboard/android/shared/surface_destroy_notifier.cc
@@ -37,7 +37,7 @@ void SurfaceDestroyNotifier::Disconnect() {
 
 void SurfaceDestroyNotifier::Notify() {
   std::unique_lock lock(mutex_);
-  if (state_ == State::kDone || !holder_ || !job_queue_) {
+  if (state_ != State::kIdle || !holder_ || !job_queue_) {
     return;
   }
   state_ = State::kWaiting;
@@ -62,7 +62,7 @@ void SurfaceDestroyNotifier::NotifyDestroyed() {
   VideoSurfaceHolder* holder_to_notify = nullptr;
   {
     std::lock_guard lock(mutex_);
-    if (state_ == State::kDone) {
+    if (state_ != State::kWaiting) {
       return;
     }
     state_ = State::kExecuting;

--- a/starboard/android/shared/surface_destroy_notifier.cc
+++ b/starboard/android/shared/surface_destroy_notifier.cc
@@ -14,12 +14,69 @@
 
 #include "starboard/android/shared/surface_destroy_notifier.h"
 
+#include <chrono>
+#include <utility>
+
+#include "starboard/android/shared/video_window.h"
+#include "starboard/common/log.h"
+#include "starboard/shared/starboard/player/job_queue.h"
+
 namespace starboard {
 
-void SurfaceDestroyNotifier::Disconnect() {}
+void SurfaceDestroyNotifier::Disconnect() {
+  {
+    std::lock_guard lock(mutex_);
+    holder_ = nullptr;
+    job_queue_ = nullptr;
+    if (state_ != State::kExecuting) {
+      state_ = State::kDone;
+    }
+  }
+  cv_.notify_one();
+}
 
-void SurfaceDestroyNotifier::Notify() {}
+void SurfaceDestroyNotifier::Notify() {
+  std::unique_lock lock(mutex_);
+  if (state_ == State::kDone || !holder_ || !job_queue_) {
+    return;
+  }
+  scoped_refptr<SurfaceDestroyNotifier> self(this);
+  auto task = [self]() { self->NotifyDestroyed(); };
+  if (!job_queue_->Schedule(std::move(task))) {
+    SB_LOG(ERROR) << "Failed to schedule NotifyDestroyed on JobQueue.";
+    state_ = State::kDone;
+    return;
+  }
 
-void SurfaceDestroyNotifier::NotifyDestroyed() {}
+  constexpr std::chrono::seconds kTeardownTimeout(1);
+  if (!cv_.wait_for(lock, kTeardownTimeout,
+                    [this] { return state_ == State::kDone; })) {
+    SB_LOG(WARNING)
+        << "SurfaceDestroyNotifier::Notify timed out waiting for teardown!";
+  }
+}
+
+void SurfaceDestroyNotifier::NotifyDestroyed() {
+  VideoSurfaceHolder* holder_to_notify = nullptr;
+  {
+    std::lock_guard lock(mutex_);
+    if (state_ == State::kDone) {
+      return;
+    }
+    state_ = State::kExecuting;
+    holder_to_notify = holder_;
+  }
+  if (holder_to_notify) {
+    holder_to_notify->OnSurfaceDestroyed();
+  }
+
+  {
+    std::lock_guard lock(mutex_);
+    state_ = State::kDone;
+    holder_ = nullptr;
+    job_queue_ = nullptr;
+  }
+  cv_.notify_one();
+}
 
 }  // namespace starboard

--- a/starboard/android/shared/surface_destroy_notifier.h
+++ b/starboard/android/shared/surface_destroy_notifier.h
@@ -25,6 +25,20 @@ namespace starboard {
 class VideoSurfaceHolder;
 class JobQueue;
 
+// This class coordinates the destruction of the global video surface between
+// the Android JNI thread and the player decoder thread. It allows the JNI
+// thread to trigger surface destruction and wait for the teardown to complete
+// without holding the global view surface mutex.
+//
+// Thread safety & Lifetime:
+// - RefCountedThreadSafe with internal mutex guarding state transitions.
+// - Created in VideoSurfaceHolder::AcquireVideoSurface(), where references are
+//   stored globally in GetGlobalSurfaceDestroyNotifier() and locally in
+//   the decoder (VideoSurfaceHolder::active_notifier_ /
+//   MediaCodecVideoDecoder).
+// - When Notify() is invoked from the JNI thread, an in-flight task on the
+//   JobQueue also holds a reference to ensure the object stays alive until
+//   NotifyDestroyed() completes on the decoder thread.
 class SurfaceDestroyNotifier
     : public RefCountedThreadSafe<SurfaceDestroyNotifier> {
  public:

--- a/starboard/android/shared/surface_destroy_notifier.h
+++ b/starboard/android/shared/surface_destroy_notifier.h
@@ -15,11 +15,18 @@
 #ifndef STARBOARD_ANDROID_SHARED_SURFACE_DESTROY_NOTIFIER_H_
 #define STARBOARD_ANDROID_SHARED_SURFACE_DESTROY_NOTIFIER_H_
 
+#include <condition_variable>
+#include <mutex>
+
 #include "starboard/common/ref_counted.h"
 
 namespace starboard {
 
-class SurfaceDestroyNotifier : public RefCountedSafe<SurfaceDestroyNotifier> {
+class VideoSurfaceHolder;
+class JobQueue;
+
+class SurfaceDestroyNotifier
+    : public RefCountedThreadSafe<SurfaceDestroyNotifier> {
  public:
   SurfaceDestroyNotifier(VideoSurfaceHolder* holder, JobQueue* job_queue)
       : holder_(holder), job_queue_(job_queue) {}
@@ -34,6 +41,7 @@ class SurfaceDestroyNotifier : public RefCountedSafe<SurfaceDestroyNotifier> {
 
  private:
   ~SurfaceDestroyNotifier() = default;
+  friend class RefCountedThreadSafe<SurfaceDestroyNotifier>;
 
   void NotifyDestroyed();
 
@@ -49,7 +57,7 @@ class SurfaceDestroyNotifier : public RefCountedSafe<SurfaceDestroyNotifier> {
   State state_ = State::kIdle;
   VideoSurfaceHolder* holder_ = nullptr;
   JobQueue* job_queue_ = nullptr;
-}
+};
 
 }  // namespace starboard
 

--- a/starboard/android/shared/surface_destroy_notifier.h
+++ b/starboard/android/shared/surface_destroy_notifier.h
@@ -1,0 +1,56 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_ANDROID_SHARED_SURFACE_DESTROY_NOTIFIER_H_
+#define STARBOARD_ANDROID_SHARED_SURFACE_DESTROY_NOTIFIER_H_
+
+#include "starboard/common/ref_counted.h"
+
+namespace starboard {
+
+class SurfaceDestroyNotifier : public RefCountedSafe<SurfaceDestroyNotifier> {
+ public:
+  SurfaceDestroyNotifier(VideoSurfaceHolder* holder, JobQueue* job_queue)
+      : holder_(holder), job_queue_(job_queue) {}
+
+  void Disconnect();
+  void Notify();
+
+  bool IsCurrentHolder(VideoSurfaceHolder* holder) {
+    std::lock_guard lock(mutex_);
+    return holder_ == holder;
+  }
+
+ private:
+  ~SurfaceDestroyNotifier() = default;
+
+  void NotifyDestroyed();
+
+  enum class State {
+    kIdle,       // initial state
+    kWaiting,    // JNI thread waiting  on cv_
+    kExecuting,  // NotifyDestroyed running on player
+    kDone,       // completed or disconnected
+  };
+
+  mutable std::mutex mutex_;
+  std::condition_variable cv_;
+  State state_ = State::kIdle;
+  VideoSurfaceHolder* holder_ = nullptr;
+  JobQueue* job_queue_ = nullptr;
+}
+
+}  // namespace starboard
+
+#endif  // STARBOARD_ANDROID_SHARED_SURFACE_DESTROY_NOTIFIER_H_

--- a/starboard/android/shared/video_window.cc
+++ b/starboard/android/shared/video_window.cc
@@ -25,11 +25,13 @@
 
 #include "cobalt/android/jni_headers/VideoSurfaceView_jni.h"
 #include "starboard/android/shared/starboard_bridge.h"
+#include "starboard/android/shared/surface_destroy_notifier.h"
 #include "starboard/common/log.h"
 #include "starboard/common/no_destructor.h"
 #include "starboard/common/once.h"
 #include "starboard/configuration.h"
 #include "starboard/shared/gles/gl_call.h"
+#include "starboard/shared/starboard/features.h"
 #include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
@@ -45,6 +47,11 @@ SB_ONCE_INITIALIZE_FUNCTION(std::mutex, GetViewSurfaceMutex)
 jni_zero::ScopedJavaGlobalRef<jobject>& GetGlobalVideoSurface() {
   static NoDestructor<jni_zero::ScopedJavaGlobalRef<jobject>> instance;
   return *instance;
+}
+
+scoped_refptr<SurfaceDestroyNotifier>& GetGlobalSurfaceDestroyNotifier() {
+  static NoDestructor<scoped_refptr<SurfaceDestroyNotifier>> notifier;
+  return *notifier;
 }
 
 // Global pointer to the single video window.
@@ -146,6 +153,25 @@ void JNI_VideoSurfaceView_OnVideoSurfaceChanged(
     JNIEnv* env,
     const JavaParamRef<jobject>& surface) {
   if (IsSurfaceDestroyNotifierEnabled()) {
+    scoped_refptr<SurfaceDestroyNotifier> notifier_to_notify;
+    {
+      std::lock_guard local(*GetViewSurfaceMutex());
+      notifier_to_notify = GetGlobalSurfaceDestroyNotifier();
+      GetGlobalSurfaceDestroyNotifier() = nullptr;
+      GetGlobalVideoSurface().Reset();
+      if (g_native_video_window) {
+        ANativeWindow_release(g_native_video_window);
+        g_native_video_window = nullptr;
+      }
+      if (surface) {
+        GetGlobalVideoSurface().Reset(env, surface);
+        g_native_video_window = ANativeWindow_fromSurface(env, surface.obj());
+      }
+    }  // Lock released before Notify()
+    if (notifier_to_notify) {
+      notifier_to_notify->Notify();
+    }
+    return;
   } else {
     std::lock_guard lock(*GetViewSurfaceMutex());
     if (g_video_surface_holder) {
@@ -170,6 +196,9 @@ bool VideoSurfaceHolder::IsVideoSurfaceAvailable() {
   // surface and it is not held by any decoder, i.e.
   // g_video_surface_holder is NULL.
   std::lock_guard lock(*GetViewSurfaceMutex());
+  if (IsSurfaceDestroyNotifierEnabled()) {
+    return !GetGlobalSurfaceDestroyNotifier() && GetGlobalVideoSurface();
+  }
   return !g_video_surface_holder && GetGlobalVideoSurface();
 }
 
@@ -187,7 +216,44 @@ VideoSurfaceHolder::AcquireVideoSurface() {
   return jni_zero::ScopedJavaLocalRef<jobject>(env, GetGlobalVideoSurface());
 }
 
+VideoSurfaceHolder::AcquiredSurface VideoSurfaceHolder::AcquireVideoSurface(
+    JobQueue* job_queue) {
+  if (IsSurfaceDestroyNotifierEnabled()) {
+    std::lock_guard lock(*GetViewSurfaceMutex());
+    if (GetGlobalSurfaceDestroyNotifier() != nullptr ||
+        !GetGlobalVideoSurface()) {
+      return {};
+    }
+    GetGlobalSurfaceDestroyNotifier() =
+        make_scoped_refptr<SurfaceDestroyNotifier>(this, job_queue);
+    active_notifier_ = GetGlobalSurfaceDestroyNotifier();
+    return {active_notifier_, GetGlobalVideoSurface()};
+  }
+
+  // non-experiment fallback;
+  auto local_surface = AcquireVideoSurface();
+  if (!local_surface) {
+    return {};
+  }
+  return {nullptr, GetGlobalVideoSurface()};
+}
+
 void VideoSurfaceHolder::ReleaseVideoSurface() {
+  if (IsSurfaceDestroyNotifierEnabled()) {
+    scoped_refptr<SurfaceDestroyNotifier> notifier_to_disconnect;
+    {
+      std::lock_guard lock(*GetViewSurfaceMutex());
+      notifier_to_disconnect = std::move(active_notifier_);
+      auto& global_notifier = GetGlobalSurfaceDestroyNotifier();
+      if (global_notifier && global_notifier->IsCurrentHolder(this)) {
+        global_notifier = nullptr;
+      }
+      if (notifier_to_disconnect) {
+        notifier_to_disconnect->Disconnect();
+      }
+      return;
+    }
+  }
   std::lock_guard lock(*GetViewSurfaceMutex());
   if (g_video_surface_holder == this) {
     g_video_surface_holder = NULL;
@@ -225,11 +291,5 @@ void VideoSurfaceHolder::ResetVideoSurface() {
   StarboardBridge::GetInstance()->ResetVideoSurface(env);
   SB_LOG(INFO) << "Video surface has been reset.";
 }
-
-void SurfaceDestroyNotifier::Disconnect() {}
-
-void SurfaceDestroyNotifier::Notify() {}
-
-void SurfaceDestroyNotifier::NotifyDestroyed() {}
 
 }  // namespace starboard

--- a/starboard/android/shared/video_window.cc
+++ b/starboard/android/shared/video_window.cc
@@ -135,24 +135,32 @@ void ClearNativeWindow(void* raw_context) {
   EGL_CALL(eglDestroySurface(display, surface));
 }
 
+bool IsSurfaceDestroyNotifierEnabled() {
+  return features::FeatureList::IsEnabled(
+      features::kEnableSurfaceDestroyNotifier);
+}
+
 }  // namespace
 
 void JNI_VideoSurfaceView_OnVideoSurfaceChanged(
     JNIEnv* env,
     const JavaParamRef<jobject>& surface) {
-  std::lock_guard lock(*GetViewSurfaceMutex());
-  if (g_video_surface_holder) {
-    g_video_surface_holder->OnSurfaceDestroyed();
-    g_video_surface_holder = NULL;
-  }
-  GetGlobalVideoSurface().Reset();
-  if (g_native_video_window) {
-    ANativeWindow_release(g_native_video_window);
-    g_native_video_window = NULL;
-  }
-  if (surface) {
-    GetGlobalVideoSurface().Reset(env, surface);
-    g_native_video_window = ANativeWindow_fromSurface(env, surface.obj());
+  if (IsSurfaceDestroyNotifierEnabled()) {
+  } else {
+    std::lock_guard lock(*GetViewSurfaceMutex());
+    if (g_video_surface_holder) {
+      g_video_surface_holder->OnSurfaceDestroyed();
+      g_video_surface_holder = NULL;
+    }
+    GetGlobalVideoSurface().Reset();
+    if (g_native_video_window) {
+      ANativeWindow_release(g_native_video_window);
+      g_native_video_window = NULL;
+    }
+    if (surface) {
+      GetGlobalVideoSurface().Reset(env, surface);
+      g_native_video_window = ANativeWindow_fromSurface(env, surface.obj());
+    }
   }
 }
 
@@ -217,5 +225,11 @@ void VideoSurfaceHolder::ResetVideoSurface() {
   StarboardBridge::GetInstance()->ResetVideoSurface(env);
   SB_LOG(INFO) << "Video surface has been reset.";
 }
+
+void SurfaceDestroyNotifier::Disconnect() {}
+
+void SurfaceDestroyNotifier::Notify() {}
+
+void SurfaceDestroyNotifier::NotifyDestroyed() {}
 
 }  // namespace starboard

--- a/starboard/android/shared/video_window.cc
+++ b/starboard/android/shared/video_window.cc
@@ -176,12 +176,12 @@ void JNI_VideoSurfaceView_OnVideoSurfaceChanged(
     std::lock_guard lock(*GetViewSurfaceMutex());
     if (g_video_surface_holder) {
       g_video_surface_holder->OnSurfaceDestroyed();
-      g_video_surface_holder = NULL;
+      g_video_surface_holder = nullptr;
     }
     GetGlobalVideoSurface().Reset();
     if (g_native_video_window) {
       ANativeWindow_release(g_native_video_window);
-      g_native_video_window = NULL;
+      g_native_video_window = nullptr;
     }
     if (surface) {
       GetGlobalVideoSurface().Reset(env, surface);

--- a/starboard/android/shared/video_window.h
+++ b/starboard/android/shared/video_window.h
@@ -20,12 +20,12 @@
 
 #include "starboard/common/ref_counted.h"
 #include "starboard/decode_target.h"
-#include "starboard/shared/starboard/player/job_queue.h"
 #include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 
 class SurfaceDestroyNotifier;
+class JobQueue;
 
 class VideoSurfaceHolder {
  public:

--- a/starboard/android/shared/video_window.h
+++ b/starboard/android/shared/video_window.h
@@ -18,13 +18,24 @@
 #include <android/native_window.h>
 #include <jni.h>
 
+#include <condition_variable>
+#include <mutex>
+
+#include "starboard/common/ref_counted.h"
 #include "starboard/decode_target.h"
+#include "starboard/shared/starboard/player/job_queue.h"
 #include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 
+class SurfaceDestroyNotifier;
+
 class VideoSurfaceHolder {
  public:
+  struct AcquiredSurface {
+    scoped_refptr<SurfaceDestroyNotifier> destroy_notifier;
+    jni_zero::ScopedJavaGlobalRef<jobject> surface;
+  }
   // Return true only if the video surface is available.
   static bool IsVideoSurfaceAvailable();
 
@@ -37,9 +48,14 @@ class VideoSurfaceHolder {
  protected:
   ~VideoSurfaceHolder() {}
 
-  // Returns the surface which video should be rendered. Surface cannot be
-  // acquired before last holder release the surface.
-  jni_zero::ScopedJavaLocalRef<jobject> AcquireVideoSurface();
+  // Returns an AcquiredSurface to which video should be rendered.
+  // Surface cannot be acquired before last holder releases the surface.
+  // |job_queue| is used by SurfaceDestroyNotifier to schedule teardown task on
+  // the player worker thread.
+  jni_zero::ScopedJavaLocalRef<jobject> AcquireVideoSurface(
+      JobQueue* job_queue);
+
+  AcquiredSurface AcquireVideoSurface(JobQueue* job_queue);
 
   // Release the surface to make the surface available for other holder.
   void ReleaseVideoSurface();
@@ -50,6 +66,38 @@ class VideoSurfaceHolder {
   // Reset the video surface by re-creating video surface.
   void ResetVideoSurface();
 };
+
+class SurfaceDestroyNotifier : public RefCountedSafe<SurfaceDestroyNotifier> {
+ public:
+  SurfaceDestroyNotifier(VideoSurfaceHolder* holder, JobQueue* job_queue)
+      : holder_(holder), job_queue_(job_queue) {}
+
+  void Disconnect();
+  void Notify();
+
+  bool IsCurrentHolder(VideoSurfaceHolder* holder) {
+    std::lock_guard lock(mutex_);
+    return holder_ == holder;
+  }
+
+ private:
+  ~SurfaceDestroyNotifier() = default;
+
+  void NotifyDestroyed();
+
+  enum class State {
+    kIdle,       // initial state
+    kWaiting,    // JNI thread waiting  on cv_
+    kExecuting,  // NotifyDestroyed running on player
+    kDone,       // completed or disconnected
+  };
+
+  mutable std::mutex mutex_;
+  std::condition_variable cv_;
+  State state_ = State::kIdle;
+  VideoSurfaceHolder* holder_ = nullptr;
+  JobQueue* job_queue_ = nullptr;
+}
 
 }  // namespace starboard
 

--- a/starboard/android/shared/video_window.h
+++ b/starboard/android/shared/video_window.h
@@ -18,17 +18,13 @@
 #include <android/native_window.h>
 #include <jni.h>
 
-#include <condition_variable>
-#include <mutex>
-
+#include "starboard/android/surface_destroy_notifier.h"
 #include "starboard/common/ref_counted.h"
 #include "starboard/decode_target.h"
 #include "starboard/shared/starboard/player/job_queue.h"
 #include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
-
-class SurfaceDestroyNotifier;
 
 class VideoSurfaceHolder {
  public:
@@ -48,13 +44,14 @@ class VideoSurfaceHolder {
  protected:
   ~VideoSurfaceHolder() {}
 
+  // Returns the surface which video should be rendered. Surface cannot be
+  // acquired before last holder release the surface.
+  jni_zero::ScopedJavaLocalRef<jobject> AcquireVideoSurface();
+
   // Returns an AcquiredSurface to which video should be rendered.
   // Surface cannot be acquired before last holder releases the surface.
   // |job_queue| is used by SurfaceDestroyNotifier to schedule teardown task on
   // the player worker thread.
-  jni_zero::ScopedJavaLocalRef<jobject> AcquireVideoSurface(
-      JobQueue* job_queue);
-
   AcquiredSurface AcquireVideoSurface(JobQueue* job_queue);
 
   // Release the surface to make the surface available for other holder.
@@ -66,38 +63,6 @@ class VideoSurfaceHolder {
   // Reset the video surface by re-creating video surface.
   void ResetVideoSurface();
 };
-
-class SurfaceDestroyNotifier : public RefCountedSafe<SurfaceDestroyNotifier> {
- public:
-  SurfaceDestroyNotifier(VideoSurfaceHolder* holder, JobQueue* job_queue)
-      : holder_(holder), job_queue_(job_queue) {}
-
-  void Disconnect();
-  void Notify();
-
-  bool IsCurrentHolder(VideoSurfaceHolder* holder) {
-    std::lock_guard lock(mutex_);
-    return holder_ == holder;
-  }
-
- private:
-  ~SurfaceDestroyNotifier() = default;
-
-  void NotifyDestroyed();
-
-  enum class State {
-    kIdle,       // initial state
-    kWaiting,    // JNI thread waiting  on cv_
-    kExecuting,  // NotifyDestroyed running on player
-    kDone,       // completed or disconnected
-  };
-
-  mutable std::mutex mutex_;
-  std::condition_variable cv_;
-  State state_ = State::kIdle;
-  VideoSurfaceHolder* holder_ = nullptr;
-  JobQueue* job_queue_ = nullptr;
-}
 
 }  // namespace starboard
 

--- a/starboard/android/shared/video_window.h
+++ b/starboard/android/shared/video_window.h
@@ -18,7 +18,6 @@
 #include <android/native_window.h>
 #include <jni.h>
 
-#include "starboard/android/surface_destroy_notifier.h"
 #include "starboard/common/ref_counted.h"
 #include "starboard/decode_target.h"
 #include "starboard/shared/starboard/player/job_queue.h"
@@ -26,12 +25,14 @@
 
 namespace starboard {
 
+class SurfaceDestroyNotifier;
+
 class VideoSurfaceHolder {
  public:
   struct AcquiredSurface {
     scoped_refptr<SurfaceDestroyNotifier> destroy_notifier;
     jni_zero::ScopedJavaGlobalRef<jobject> surface;
-  }
+  };
   // Return true only if the video surface is available.
   static bool IsVideoSurfaceAvailable();
 
@@ -42,7 +43,7 @@ class VideoSurfaceHolder {
   virtual void OnSurfaceDestroyed() = 0;
 
  protected:
-  ~VideoSurfaceHolder() {}
+  ~VideoSurfaceHolder() = default;
 
   // Returns the surface which video should be rendered. Surface cannot be
   // acquired before last holder release the surface.
@@ -62,6 +63,9 @@ class VideoSurfaceHolder {
 
   // Reset the video surface by re-creating video surface.
   void ResetVideoSurface();
+
+ private:
+  scoped_refptr<SurfaceDestroyNotifier> active_notifier_;
 };
 
 }  // namespace starboard

--- a/starboard/extension/feature_config.h
+++ b/starboard/extension/feature_config.h
@@ -112,6 +112,12 @@ STARBOARD_FEATURE(kEnableAv1StartupOptimization,
                   "EnableAv1StartupOptimization",
                   false)
 
+// Set the following variable true to enable async surface destruction
+// via SurfaceDestroyNotifier to avoid deadlocks.
+STARBOARD_FEATURE(kEnableSurfaceDestroyNotifier,
+                  "EnableSurfaceDestroyNotifier",
+                  false)
+
 // By default, Cobalt destroys and recreates AudioTrack during Seek().
 // Set the following variable to true to force it to Flush() AudioTrack
 // during Seek().


### PR DESCRIPTION
There is a potential deadlock during Surface destruction whereby Android/JNI
thread destroys a surface, triggering OnSurfaceDestroyed(), which blocks waiting
on the worker thread. If the worker thread concurrently tries to TeardownCodec,
it would try to acquire the same mutex (GetViewSurfaceMutex())

This PR introduces SurfaceDestroyNotifier to minimize the time needed for the mutex
to be held, and only swaps out a pointer while held.

The change is guarded behind a feature flag.

This PR is cleaner implementation of https://github.com/youtube/cobalt/pull/11448
to try and make it easier to distinguish the behavior between the flag guarded code
and the original code.

Bug: 511329384