### PR TITLE
starboard: Revert PR 11809 and guard Android features with !IS_STARBOARD

### DIFF
--- a/starboard/android/shared/audio_track_audio_sink_type.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type.cc
@@ -22,6 +22,8 @@
 #include <vector>
 
 #include "base/memory/raw_ptr.h"
+#include "build/build_config.h"
+#include "build/buildflag.h"
 #include "starboard/android/shared/audio_output_manager.h"
 #include "starboard/android/shared/media_capabilities_cache.h"
 #include "starboard/android/shared/media_common.h"
@@ -266,8 +268,12 @@ void AudioTrackAudioSink::AudioThreadFunc() {
 
   int64_t last_playback_head_position = 0;
 
+#if !BUILDFLAG(IS_STARBOARD)
   bool release_frames_after_audio_starts = features::FeatureList::IsEnabled(
       features::kReleaseVideoFramesAfterAudioStarts);
+#else
+  bool release_frames_after_audio_starts = false;
+#endif
 
   while (!quit_) {
     if (flush_requested_) {

--- a/starboard/android/shared/media_capabilities_cache.cc
+++ b/starboard/android/shared/media_capabilities_cache.cc
@@ -21,6 +21,8 @@
 
 #include "base/android/jni_array.h"
 #include "base/android/jni_string.h"
+#include "build/build_config.h"
+#include "build/buildflag.h"
 #include "cobalt/android/jni_headers/MediaCodecUtil_jni.h"
 #include "starboard/android/shared/audio_output_manager.h"
 #include "starboard/android/shared/display_util.h"
@@ -338,8 +340,12 @@ bool MediaCapabilitiesCache::IsAv18kCappedAt30() {
     return true;
   }
 
+#if !BUILDFLAG(IS_STARBOARD)
   const bool enable_av1_startup_optimization =
       FeatureList::IsEnabled(features::kEnableAv1StartupOptimization);
+#else
+  const bool enable_av1_startup_optimization = false;
+#endif
   if (!enable_av1_startup_optimization && !is_av1_opt_enabled_) {
     return true;
   }

--- a/starboard/android/shared/media_get_video_buffer_budget.cc
+++ b/starboard/android/shared/media_get_video_buffer_budget.cc
@@ -14,6 +14,8 @@
 
 #include <algorithm>
 
+#include "build/build_config.h"
+#include "build/buildflag.h"
 #include "starboard/android/shared/runtime_resource_overlay.h"
 #include "starboard/common/log.h"
 #include "starboard/media.h"
@@ -74,8 +76,15 @@ int SbMediaGetVideoBufferBudget(SbMediaVideoCodec codec,
   int video_buffer_budget = 0;
   starboard::Size resolution(resolution_width, resolution_height);
 
-  if (starboard::features::FeatureList::IsEnabled(
-          starboard::features::kAreaBasedVideoBufferBudget)) {
+#if !BUILDFLAG(IS_STARBOARD)
+  const bool use_area_based_budget =
+      starboard::features::FeatureList::IsEnabled(
+          starboard::features::kAreaBasedVideoBufferBudget);
+#else
+  const bool use_area_based_budget = false;
+#endif
+
+  if (use_area_based_budget) {
     if (resolution.IsEmpty() ||
         resolution.GetArea() <= starboard::Resolution::k1080p.GetArea()) {
       video_buffer_budget = kVideoBufferBudget1080p;

--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -20,6 +20,8 @@
 #include <string>
 #include <utility>
 
+#include "build/build_config.h"
+#include "build/buildflag.h"
 #include "starboard/android/shared/audio_output_manager.h"
 #include "starboard/android/shared/audio_renderer_passthrough.h"
 #include "starboard/android/shared/audio_track.h"
@@ -62,6 +64,7 @@ using jni_zero::AttachCurrentThread;
 
 constexpr int kAndroidApiLevelU = 34;
 
+#if !BUILDFLAG(IS_STARBOARD)
 bool IsFeatureEnabledOrDefaultOnAndroidU(
     const SbFeature& feature,
     const ExperimentalFeatures& experimental_features,
@@ -70,19 +73,30 @@ bool IsFeatureEnabledOrDefaultOnAndroidU(
          FeatureList::IsEnabled(feature) ||
          experimental_features.GetBool(experimental_feature_key);
 }
+#endif
 
 bool ShouldEnableFlushDuringSeek(
     const ExperimentalFeatures& experimental_features) {
+#if !BUILDFLAG(IS_STARBOARD)
   return IsFeatureEnabledOrDefaultOnAndroidU(
       features::kForceFlushDecoderDuringReset, experimental_features,
       kMediaEnableFlushDuringSeek);
+#else
+  return android_get_device_api_level() >= kAndroidApiLevelU ||
+         experimental_features.GetBool(kMediaEnableFlushDuringSeek);
+#endif
 }
 
 bool ShouldEnableResetAudioDecoder(
     const ExperimentalFeatures& experimental_features) {
+#if !BUILDFLAG(IS_STARBOARD)
   return IsFeatureEnabledOrDefaultOnAndroidU(features::kForceResetAudioDecoder,
                                              experimental_features,
                                              kMediaEnableResetAudioDecoder);
+#else
+  return android_get_device_api_level() >= kAndroidApiLevelU ||
+         experimental_features.GetBool(kMediaEnableResetAudioDecoder);
+#endif
 }
 
 // On some platforms tunnel mode is only supported in the secure pipeline.  Set
@@ -334,11 +348,15 @@ class PlayerComponentsPassthrough : public PlayerComponents {
 class PlayerComponentsFactory : public PlayerComponents::Factory {
  public:
   PlayerComponentsFactory()
+#if !BUILDFLAG(IS_STARBOARD)
       : force_platform_opus_decoder_(features::FeatureList::IsEnabled(
             features::kForcePlatformOpusDecoder)) {
     SB_LOG_IF(INFO, force_platform_opus_decoder_)
         << "kForcePlatformOpusDecoder is set to true, force using platform opus"
         << " codec instead of libopus.";
+#else
+      : force_platform_opus_decoder_(false) {
+#endif
   }
 
   NonNullResult<std::unique_ptr<PlayerComponents>> CreateComponents(
@@ -465,8 +483,12 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
     bool enable_tunnel_mode = false;
     if (creation_parameters.audio_codec() != kSbMediaAudioCodecNone &&
         creation_parameters.video_codec() != kSbMediaVideoCodecNone) {
+#if !BUILDFLAG(IS_STARBOARD)
       const bool force_tunnel_mode =
           FeatureList::IsEnabled(features::kForceTunnelMode);
+#else
+      const bool force_tunnel_mode = false;
+#endif
       enable_tunnel_mode =
           force_tunnel_mode ||
           (video_mime_type &&
@@ -538,9 +560,14 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
                             : "<not provided>")
         << ".";
 
+#if !BUILDFLAG(IS_STARBOARD)
     bool allow_flush_audio_track_during_seek =
         FeatureList::IsEnabled(features::kForceFlushAudioTrackDuringReset) ||
         experimental_features.GetBool(kMediaFlushAudioTrackDuringSeek);
+#else
+    bool allow_flush_audio_track_during_seek =
+        experimental_features.GetBool(kMediaFlushAudioTrackDuringSeek);
+#endif
     SB_LOG_IF(INFO, allow_flush_audio_track_during_seek)
         << "`kForceFlushAudioTrackDuringReset` is set to true, force flushing"
         << " audio track during Reset().";
@@ -642,8 +669,13 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
 
     bool enable_flush_during_seek =
         ShouldEnableFlushDuringSeek(experimental_features);
+#if !BUILDFLAG(IS_STARBOARD)
     int64_t flush_delay_usec = features::kFlushDelayUsec.Get();
     int64_t reset_delay_usec = features::kResetDelayUsec.Get();
+#else
+    int64_t flush_delay_usec = 0;
+    int64_t reset_delay_usec = 0;
+#endif
 
     if (creation_parameters.video_codec() != kSbMediaVideoCodecNone &&
         !creation_parameters.video_mime().empty()) {

--- a/starboard/android/shared/video_render_algorithm_android.cc
+++ b/starboard/android/shared/video_render_algorithm_android.cc
@@ -17,6 +17,8 @@
 #include <algorithm>
 #include <list>
 
+#include "build/build_config.h"
+#include "build/buildflag.h"
 #include "cobalt/android/jni_headers/VideoFrameReleaseTimeHelper_jni.h"
 #include "starboard/android/shared/media_common.h"
 #include "starboard/common/check_op.h"
@@ -48,8 +50,12 @@ VideoRenderAlgorithmAndroid::VideoRenderAlgorithmAndroid(
     VideoFrameTracker* frame_tracker)
     : video_decoder_(video_decoder),
       frame_tracker_(frame_tracker),
+#if !BUILDFLAG(IS_STARBOARD)
       release_frames_after_audio_starts_(features::FeatureList::IsEnabled(
           features::kReleaseVideoFramesAfterAudioStarts)) {
+#else
+      release_frames_after_audio_starts_(false) {
+#endif
   SB_CHECK(video_decoder_);
   video_decoder_->SetPlaybackRate(playback_rate_);
 }

--- a/starboard/extension/feature_config.h
+++ b/starboard/extension/feature_config.h
@@ -100,7 +100,7 @@ FEATURE_LIST_START
 //   STARBOARD_FEATURE(kCobaltVideoDebug, "CobaltVideoDebug", false)
 // #endif // BUILDFLAG(IS_ANDROID) && (SB_API_VERSION >= 17)
 
-#if (BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_STARBOARD)) && (SB_API_VERSION >= 17)
+#if BUILDFLAG(IS_ANDROID) && (SB_API_VERSION >= 17)
 // keep-sorted start newline_separated=yes
 // Set to true to enable area-based video buffer budget calculation.
 STARBOARD_FEATURE(kAreaBasedVideoBufferBudget,
@@ -162,8 +162,7 @@ STARBOARD_FEATURE(kVideoDecoderDelayUsecOverride,
                   "VideoDecoderDelayUsecOverride",
                   false)
 // keep-sorted end
-#endif  // (BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_STARBOARD)) &&
-        // (SB_API_VERSION >= 17)
+#endif  // BUILDFLAG(IS_ANDROID) && (SB_API_VERSION >= 17)
 
 // Set the following variable to true to reduce android thread stack size.
 STARBOARD_FEATURE(kReduceAndroidThreadStackSize,
@@ -232,7 +231,7 @@ FEATURE_PARAM_LIST_START
 //                           "standard")
 // #endif // BUILDFLAG(IS_ANDROID) && (SB_API_VERSION >= 17)
 
-#if (BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_STARBOARD)) && (SB_API_VERSION >= 17)
+#if BUILDFLAG(IS_ANDROID) && (SB_API_VERSION >= 17)
 // By default, Cobalt restarts MediaCodec after stops/flushes during
 // Reset()/Flush(). Set the following variable to > 0 to force it to
 // wait during Reset()/Flush().
@@ -246,6 +245,5 @@ STARBOARD_FEATURE_PARAM(STARBOARD_FEATURE_PARAM_TIME_TYPE,
                         kVideoDecoderDelayUsecOverride,
                         "ResetDelayUsec",
                         base::Microseconds(0))
-#endif  // (BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_STARBOARD)) &&
-        // (SB_API_VERSION >= 17)
+#endif  // BUILDFLAG(IS_ANDROID) && (SB_API_VERSION >= 17)
 FEATURE_PARAM_LIST_END

--- a/starboard/shared/starboard/player/filter/player_components.cc
+++ b/starboard/shared/starboard/player/filter/player_components.cc
@@ -17,6 +17,8 @@
 #include <memory>
 #include <utility>
 
+#include "build/build_config.h"
+#include "build/buildflag.h"
 #include "starboard/common/check_op.h"
 #include "starboard/common/command_line.h"
 #include "starboard/common/time.h"
@@ -149,7 +151,7 @@ PlayerComponents::Factory::CreateComponents(
 
   bool use_stub_audio_decoder = false;
   bool use_stub_video_decoder = false;
-#if BUILDFLAG(IS_ANDROID)
+#if BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_STARBOARD)
   use_stub_audio_decoder =
       features::FeatureList::IsEnabled(features::kUseStubAudioDecoder);
   use_stub_video_decoder =
@@ -158,7 +160,7 @@ PlayerComponents::Factory::CreateComponents(
   auto command_line = Application::Get()->GetCommandLine();
   use_stub_audio_decoder = command_line->HasSwitch("use_stub_audio_decoder");
   use_stub_video_decoder = command_line->HasSwitch("use_stub_video_decoder");
-#endif  // BUILDFLAG(IS_ANDROID)
+#endif  // BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_STARBOARD)
 
   MediaComponents components;
   if (use_stub_audio_decoder && use_stub_video_decoder) {


### PR DESCRIPTION
Reverts PR 11809 (commit 90e0d6716e7791f28beb79cce547efff627742ef) which
guarded Android media Starboard features and params with IS_ANDROID || IS_STARBOARD.

Instead of registering Android-specific features across all Starboard platforms in the
Evergreen module, keep them guarded by BUILDFLAG(IS_ANDROID) in feature_config.h,
and guard their usages in Starboard code with !BUILDFLAG(IS_STARBOARD), assuming
their default values when BUILDFLAG(IS_STARBOARD) is true.

Bug: 532068409
TAG=agy
CONV=669e7421-f782-4f59-bd2d-9cad905a634e