### PR TITLE
cobalt: Restore launch=preload query on startup

### DIFF
--- a/cobalt/shell/browser/lifecycle_unittest.cc
+++ b/cobalt/shell/browser/lifecycle_unittest.cc
@@ -12,11 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "base/containers/contains.h"
 #include "cobalt/shell/browser/shell.h"
+#include "cobalt/shell/browser/shell_browser_main_parts.h"
 #include "cobalt/shell/browser/shell_test_support.h"
 #include "content/test/test_web_contents.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
 
 using testing::_;
 
@@ -75,6 +78,14 @@ TEST_F(LifecycleTest, StartupHidden) {
   CreateTestShell(false /* is_visible */);
   EXPECT_FALSE(platform_->IsVisible());
   EXPECT_EQ(shell_->web_contents()->GetVisibility(), Visibility::HIDDEN);
+}
+
+TEST_F(LifecycleTest, StartupURLPreloadParameter) {
+  GURL normal_url = GetStartupURL(/*should_preload=*/false);
+  EXPECT_FALSE(base::Contains(normal_url.query(), "launch=preload"));
+
+  GURL preload_url = GetStartupURL(/*should_preload=*/true);
+  EXPECT_TRUE(base::Contains(preload_url.query(), "launch=preload"));
 }
 
 TEST_F(LifecycleTest, Reveal) {

--- a/cobalt/shell/browser/shell_browser_main_parts.cc
+++ b/cobalt/shell/browser/shell_browser_main_parts.cc
@@ -94,7 +94,9 @@ class NetworkChangeNotifierFactoryStarboard
 };
 #endif
 
-GURL GetStartupURL() {
+}  // namespace
+
+GURL GetStartupURL(bool should_preload) {
   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
   if (command_line->HasSwitch(switches::kBrowserTest)) {
     return GURL();
@@ -119,12 +121,18 @@ GURL GetStartupURL() {
     }
   }
 
+  if (should_preload) {
+    initial_url = net::AppendQueryParameter(initial_url, "launch", "preload");
+  }
+
 #if BUILDFLAG(IS_STARBOARD)
   initial_url = GetDeviceAuthenticationSignedURL(initial_url);
 #endif
   return initial_url;
 #endif
 }
+
+namespace {
 
 scoped_refptr<base::RefCountedMemory> PlatformResourceProvider(int key) {
   if (key == IDR_DIR_HEADER_HTML) {
@@ -168,8 +176,8 @@ void ShellBrowserMainParts::InitializeBrowserContexts() {
 }
 
 void ShellBrowserMainParts::InitializeMessageLoopContext() {
-  Shell::CreateNewWindow(browser_context_.get(), GetStartupURL(), nullptr,
-                         gfx::Size(),
+  Shell::CreateNewWindow(browser_context_.get(), GetStartupURL(!is_visible_),
+                         nullptr, gfx::Size(),
 #if BUILDFLAG(IS_ANDROID)
                          false /* create_splash_screen_web_contents */
 #else

--- a/cobalt/shell/browser/shell_browser_main_parts.h
+++ b/cobalt/shell/browser/shell_browser_main_parts.h
@@ -32,8 +32,12 @@ class ChildExitObserver;
 }
 #endif
 
+class GURL;
+
 namespace content {
 class ShellPlatformDelegate;
+
+GURL GetStartupURL(bool should_preload = false);
 
 class ShellBrowserMainParts : public BrowserMainParts {
  public:


### PR DESCRIPTION
Restore behavior from Cobalt 25. Append "launch=preload" to the document URL when the application is launched in preload mode.

As a result, this notifies Kabuki to start in background mode. This prevents potential wastage of TV resources, and allows instantaneous launching of the YouTube TV app.

Bug: 503025265