### PR TITLE
android/jni-zero: Support PrimitiveConvert on C++17

### DIFF
--- a/third_party/jni_zero/type_conversions.h
+++ b/third_party/jni_zero/type_conversions.h
@@ -26,8 +26,8 @@ namespace jni_zero {
   "the header that declares the specialization is #included before the "   \
   "_jni.h one."
 
-#if defined(__cpp_concepts) && __cpp_concepts >= 201907L
 namespace internal {
+#if defined(__cpp_concepts) && __cpp_concepts >= 201907L
 template <typename T>
 concept IsJavaRef = std::is_base_of_v<JavaRef<jobject>, T>;
 
@@ -70,6 +70,7 @@ template <typename T>
 concept HasSpecificSpecialization = requires(T t) {
   requires IsMap<T> || IsObjectContainer<T> || IsOptional<T> || IsPrimitive<T>;
 };
+#endif
 
 // Used to allow for the c++ type to be non-primitive even if the java type is
 // primitive, when doing type conversions. primitive<->primitive conversions use
@@ -79,22 +80,27 @@ struct PrimitiveConvert {
   static constexpr CppType FromJniType(JNIEnv* env, JavaType v) {
     if constexpr (std::is_arithmetic_v<CppType> || std::is_enum_v<CppType>) {
       return static_cast<CppType>(v);
-    } else {
+    }
+#if defined(__cpp_concepts) && __cpp_concepts >= 201907L
+    else {
       return FromJniType<CppType>(env, v);
     }
+#endif
   }
 
   static constexpr JavaType ToJniType(JNIEnv* env, CppType v) {
     if constexpr (std::is_arithmetic_v<CppType> || std::is_enum_v<CppType>) {
       return static_cast<JavaType>(v);
-    } else {
+    }
+#if defined(__cpp_concepts) && __cpp_concepts >= 201907L
+    else {
       return ToJniType<JavaType>(env, v);
     }
+#endif
   }
 };
 
 }  // namespace internal
-#endif
 
 template <typename T>
 inline T FromJniType(JNIEnv* env, const JavaRef<jobject>& obj) {


### PR DESCRIPTION
Enable jni_zero::internal::PrimitiveConvert for C++17 toolchains. This
change allows @JniType annotations on primitive Java types, such as
enums mapped to integers, to compile on platforms that do not yet
support C++20 concepts. This ensures compatibility for JNI type
conversions when concepts are unavailable.

Bug: 520007952