### PR TITLE
android: Revert default PauseUsingAudioTrackState

### DIFF
--- a/starboard/android/shared/audio_sink_min_required_frames_tester.cc
+++ b/starboard/android/shared/audio_sink_min_required_frames_tester.cc
@@ -135,7 +135,8 @@ void AudioSinkMinRequiredFramesTester::TesterThreadFunc() {
         /*start_media_time=*/0,
         /*tunnel_mode_audio_session_id=*/std::nullopt,
         /*is_web_audio=*/false,
-        /*allow_audio_writing_on_pause=*/false, this);
+        /*allow_audio_writing_on_pause=*/false,
+        /*pause_using_audio_track_state=*/false, this);
     {
       std::unique_lock lock(mutex_);
       bool notified = test_complete_cv_.wait_for(

--- a/starboard/android/shared/audio_track_audio_sink_type.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type.cc
@@ -127,6 +127,7 @@ std::unique_ptr<AudioTrackAudioSink> AudioTrackAudioSink::Create(
     std::optional<int> tunnel_mode_audio_session_id,
     bool is_web_audio,
     bool allow_audio_writing_on_pause,
+    bool pause_using_audio_track_state,
     void* context) {
   std::unique_ptr<AudioTrack> audio_track = AudioTrack::Create(
       kSbMediaAudioCodingTypePcm, sample_type, channels, sampling_frequency_hz,
@@ -139,7 +140,8 @@ std::unique_ptr<AudioTrackAudioSink> AudioTrackAudioSink::Create(
       PassKey<AudioTrackAudioSink>(), type, channels, sampling_frequency_hz,
       sample_type, frame_buffers, frames_per_channel, preferred_buffer_size,
       callbacks, start_media_time, tunnel_mode_audio_session_id,
-      allow_audio_writing_on_pause, std::move(audio_track), context);
+      allow_audio_writing_on_pause, pause_using_audio_track_state,
+      std::move(audio_track), context);
 
   audio_sink->SpawnThread();
   return audio_sink;
@@ -158,6 +160,7 @@ std::unique_ptr<AudioTrackAudioSink> AudioTrackAudioSink::CreateForTesting(
     int64_t start_media_time,
     std::optional<int> tunnel_mode_audio_session_id,
     bool allow_audio_writing_on_pause,
+    bool pause_using_audio_track_state,
     std::unique_ptr<AudioTrack> fake_audio_track,
     void* context) {
   if (!fake_audio_track) {
@@ -168,7 +171,8 @@ std::unique_ptr<AudioTrackAudioSink> AudioTrackAudioSink::CreateForTesting(
       PassKey<AudioTrackAudioSink>(), type, channels, sampling_frequency_hz,
       sample_type, frame_buffers, frames_per_channel, preferred_buffer_size,
       callbacks, start_media_time, tunnel_mode_audio_session_id,
-      allow_audio_writing_on_pause, std::move(fake_audio_track), context);
+      allow_audio_writing_on_pause, pause_using_audio_track_state,
+      std::move(fake_audio_track), context);
 
   audio_sink->SpawnThread();
   return audio_sink;
@@ -187,6 +191,7 @@ AudioTrackAudioSink::AudioTrackAudioSink(
     int64_t start_media_time,
     std::optional<int> tunnel_mode_audio_session_id,
     bool allow_audio_writing_on_pause,
+    bool pause_using_audio_track_state,
     std::unique_ptr<AudioTrack> audio_track,
     void* context)
     : type_(type),
@@ -203,6 +208,7 @@ AudioTrackAudioSink::AudioTrackAudioSink(
               : GetMaxFramesPerRequestForTunnelMode(sampling_frequency_hz_)),
       context_(context),
       allow_audio_writing_on_pause_(allow_audio_writing_on_pause),
+      pause_using_audio_track_state_(pause_using_audio_track_state),
       audio_track_(std::move(audio_track)),
       audio_out_thread_(std::make_unique<AudioTrackOutThread>(this)) {
   SB_DCHECK(callbacks_.update_source_status);
@@ -255,6 +261,7 @@ bool AudioTrackAudioSink::Flush() {
 
 // TODO: Break down the function into manageable pieces.
 void AudioTrackAudioSink::AudioThreadFunc() {
+  bool was_playing = false;
   int frames_in_audio_track = 0;
   AudioTrack::PlayState audio_track_play_state =
       AudioTrack::PlayState::kStopped;
@@ -293,23 +300,33 @@ void AudioTrackAudioSink::AudioThreadFunc() {
       break;
     }
 
-    // The audio data at the returned position by
-    // |audio_track_->GetAudioTimestamp()| may either (1) already have been
-    // presented, or (2) may have not yet been presented but is committed to
-    // be presented. It is possible after |audio_track_->Pause()|, the audio
-    // data is still committed to be presented as (2), which causes advancing
-    // media time gap when player resumes and dropping video frames, so
-    // player updates playback head positions when |audio_track_| doesn't stop.
-    audio_track_play_state = audio_track_->GetPlayState();
+    if (pause_using_audio_track_state_) {
+      // The audio data at the returned position by
+      // |audio_track_->GetAudioTimestamp()| may either (1) already have been
+      // presented, or (2) may have not yet been presented but is committed to
+      // be presented. It is possible after |audio_track_->Pause()|, the audio
+      // data is still committed to be presented as (2), which causes advancing
+      // media time gap when player resumes and dropping video frames, so
+      // player updates playback head positions when |audio_track_| doesn't
+      // stop.
+      audio_track_play_state = audio_track_->GetPlayState();
 
-    if (audio_track_play_state == AudioTrack::PlayState::kPlaying) {
-      is_flushed_ = false;
+      if (audio_track_play_state == AudioTrack::PlayState::kPlaying) {
+        is_flushed_ = false;
+      }
     }
 
-    bool should_update_media_time =
-        (audio_track_play_state == AudioTrack::PlayState::kPlaying ||
-         (audio_track_play_state == AudioTrack::PlayState::kPaused &&
-          !is_flushed_));
+    // |pause_using_audio_track_state_| is enabled: update media time if
+    // |audio_track_play_state| is PLAYSTATE_PLAYING or PLAYSTATE_PAUSED (unless
+    // flushed). |pause_using_audio_track_state_| is disabled: by default, only
+    // use |was_playing|.
+    bool should_update_media_time = was_playing;
+    if (pause_using_audio_track_state_) {
+      should_update_media_time =
+          (audio_track_play_state == AudioTrack::PlayState::kPlaying ||
+           (audio_track_play_state == AudioTrack::PlayState::kPaused &&
+            !is_flushed_));
+    }
     if (should_update_media_time) {
       playback_head_position =
           audio_track_->GetAudioTimestamp(&frames_consumed_at);
@@ -365,12 +382,21 @@ void AudioTrackAudioSink::AudioThreadFunc() {
       }
     }
 
-    bool is_currently_playing =
-        (audio_track_play_state == AudioTrack::PlayState::kPlaying);
+    // |pause_using_audio_track_state_| is enabled: pause/play AudioTrack
+    // depending on PLAYSTATE_PLAYING or not.
+    // |pause_using_audio_track_state_| is disabled: by default, only use
+    // |was_playing|.
+    bool is_currently_playing = was_playing;
+    if (pause_using_audio_track_state_) {
+      is_currently_playing =
+          (audio_track_play_state == AudioTrack::PlayState::kPlaying);
+    }
     if (is_currently_playing && !is_playing) {
+      was_playing = false;
       ScopedTimer timer("Pause");
       audio_track_->Pause();
     } else if (!is_currently_playing && is_playing) {
+      was_playing = true;
       last_playback_head_event_at = -1;
       ScopedTimer timer("Play");
       audio_track_->Play();
@@ -563,7 +589,8 @@ SbAudioSink AudioTrackAudioSinkType::Create(
                 /*start_media_time=*/0,
                 /*tunnel_mode_audio_session_id=*/std::nullopt,
                 /*is_web_audio=*/true,
-                /*allow_audio_writing_on_pause=*/false, context);
+                /*allow_audio_writing_on_pause=*/false,
+                /*pause_using_audio_track_state=*/false, context);
 }
 
 SbAudioSink AudioTrackAudioSinkType::Create(
@@ -578,6 +605,7 @@ SbAudioSink AudioTrackAudioSinkType::Create(
     std::optional<int> tunnel_mode_audio_session_id,
     bool is_web_audio,
     bool allow_audio_writing_on_pause,
+    bool pause_using_audio_track_state,
     void* context) {
   int min_required_frames = SbAudioSinkGetMinBufferSizeInFrames(
       channels, audio_sample_type, sampling_frequency_hz);
@@ -589,7 +617,7 @@ SbAudioSink AudioTrackAudioSinkType::Create(
       this, channels, sampling_frequency_hz, audio_sample_type, frame_buffers,
       frames_per_channel, preferred_buffer_size_in_bytes, callbacks,
       start_media_time, tunnel_mode_audio_session_id, is_web_audio,
-      allow_audio_writing_on_pause, context);
+      allow_audio_writing_on_pause, pause_using_audio_track_state, context);
   if (!audio_sink) {
     SB_DLOG(ERROR)
         << "AudioTrackAudioSinkType::Create failed to create audio track";

--- a/starboard/android/shared/audio_track_audio_sink_type.h
+++ b/starboard/android/shared/audio_track_audio_sink_type.h
@@ -73,6 +73,7 @@ class AudioTrackAudioSinkType : public SbAudioSinkPrivate::Type {
                      std::optional<int> tunnel_mode_audio_session_id,
                      bool is_web_audio,
                      bool allow_audio_writing_on_pause,
+                     bool pause_using_audio_track_state,
                      void* context);
 
   bool IsValid(SbAudioSink audio_sink) override {
@@ -118,6 +119,7 @@ class AudioTrackAudioSink : public SbAudioSinkImpl {
       std::optional<int> tunnel_mode_audio_session_id,
       bool is_web_audio,
       bool allow_audio_writing_on_pause,
+      bool pause_using_audio_track_state,
       void* context);
   static std::unique_ptr<AudioTrackAudioSink> CreateForTesting(
       Type* type,
@@ -131,6 +133,7 @@ class AudioTrackAudioSink : public SbAudioSinkImpl {
       int64_t start_media_time,
       std::optional<int> tunnel_mode_audio_session_id,
       bool allow_audio_writing_on_pause,
+      bool pause_using_audio_track_state,
       std::unique_ptr<AudioTrack> fake_audio_track,
       void* context);
 
@@ -146,6 +149,7 @@ class AudioTrackAudioSink : public SbAudioSinkImpl {
                       int64_t start_media_time,
                       std::optional<int> tunnel_mode_audio_session_id,
                       bool allow_audio_writing_on_pause,
+                      bool pause_using_audio_track_state,
                       std::unique_ptr<AudioTrack> audio_track,
                       void* context);
   ~AudioTrackAudioSink() override;
@@ -183,6 +187,7 @@ class AudioTrackAudioSink : public SbAudioSinkImpl {
   const raw_ptr<void> context_;
 
   const bool allow_audio_writing_on_pause_;
+  const bool pause_using_audio_track_state_;
 
   // Guaranteed to be non-null.
   const std::unique_ptr<AudioTrack> audio_track_;

--- a/starboard/android/shared/audio_track_audio_sink_type_test.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type_test.cc
@@ -99,7 +99,8 @@ TEST_F(AudioTrackAudioSinkTest, CreateAndDestroy) {
       &type, 2, 48000, kSbMediaAudioSampleTypeFloat32, frame_buffers_, 1024,
       512, callbacks, 0,
       /*tunnel_mode_audio_session_id=*/std::nullopt,
-      /*allow_audio_writing_on_pause=*/false, std::move(fake_track), this);
+      /*allow_audio_writing_on_pause=*/false,
+      /*pause_using_audio_track_state=*/false, std::move(fake_track), this);
 
   ASSERT_NE(sink, nullptr);
   EXPECT_TRUE(sink->IsType(&type));
@@ -131,7 +132,8 @@ TEST_F(AudioTrackAudioSinkTest, PauseAndResumePlayback) {
       &type, 2, 48000, kSbMediaAudioSampleTypeFloat32, frame_buffers_, 1024,
       512, callbacks, 0,
       /*tunnel_mode_audio_session_id=*/std::nullopt,
-      /*allow_audio_writing_on_pause=*/false, std::move(fake_track), this);
+      /*allow_audio_writing_on_pause=*/false,
+      /*pause_using_audio_track_state=*/false, std::move(fake_track), this);
 
   ASSERT_NE(sink, nullptr);
   int elapsed_ms = 0;
@@ -177,7 +179,8 @@ TEST_F(AudioTrackAudioSinkTest, FlushAndResumePlayback) {
       &type, 2, 48000, kSbMediaAudioSampleTypeFloat32, frame_buffers_, 1024,
       512, callbacks, 0,
       /*tunnel_mode_audio_session_id=*/std::nullopt,
-      /*allow_audio_writing_on_pause=*/false, std::move(fake_track), this);
+      /*allow_audio_writing_on_pause=*/false,
+      /*pause_using_audio_track_state=*/false, std::move(fake_track), this);
 
   ASSERT_NE(sink, nullptr);
   int elapsed_ms = 0;
@@ -233,7 +236,8 @@ TEST_F(AudioTrackAudioSinkTest,
       &type, 2, 48000, kSbMediaAudioSampleTypeFloat32, frame_buffers_, 1024,
       512, callbacks, 0,
       /*tunnel_mode_audio_session_id=*/std::nullopt,
-      /*allow_audio_writing_on_pause=*/false, std::move(fake_track), this);
+      /*allow_audio_writing_on_pause=*/false,
+      /*pause_using_audio_track_state=*/false, std::move(fake_track), this);
 
   ASSERT_NE(sink, nullptr);
 

--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -137,7 +137,8 @@ class AudioRendererSinkAndroid : public AudioRendererSinkImpl {
       std::optional<int> tunnel_mode_audio_session_id,
       bool allow_audio_writing_on_pause,
       bool enable_video_renderer_vsp_adjustment,
-      bool allow_flush_during_seek)
+      bool allow_flush_during_seek,
+      bool pause_using_audio_track_state)
       : AudioRendererSinkImpl(
             [=](int64_t start_media_time,
                 int channels,
@@ -160,7 +161,7 @@ class AudioRendererSinkAndroid : public AudioRendererSinkImpl {
                   {update_source_status_func, consume_frames_func, error_func},
                   start_media_time, tunnel_mode_audio_session_id,
                   /*is_web_audio=*/false, allow_audio_writing_on_pause,
-                  context);
+                  pause_using_audio_track_state, context);
             }),
         is_tunnel_mode_enabled_(tunnel_mode_audio_session_id.has_value()),
         enable_video_renderer_vsp_adjustment_(
@@ -560,6 +561,11 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
       SB_LOG_IF(INFO, enable_video_renderer_vsp_adjustment)
           << "enable_video_renderer_vsp_adjustment is set to true.";
 
+      const bool pause_using_audio_track_state =
+          experimental_features.GetBool(kMediaPauseUsingAudioTrackState);
+      SB_LOG_IF(INFO, pause_using_audio_track_state)
+          << "pause_using_audio_track_state is set to true.";
+
       const bool force_platform_opus_decoder = force_platform_opus_decoder_;
       auto decoder_creator =
           [enable_flush_during_seek, force_platform_opus_decoder, job_queue](
@@ -592,7 +598,8 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
           std::make_unique<AudioRendererSinkAndroid>(
               tunnel_mode_audio_session_id, allow_audio_writing_on_pause,
               enable_video_renderer_vsp_adjustment,
-              allow_flush_audio_track_during_seek);
+              allow_flush_audio_track_during_seek,
+              pause_using_audio_track_state);
     }
 
     if (creation_parameters.video_codec() != kSbMediaVideoCodecNone) {

--- a/starboard/shared/starboard/experimental_features.h
+++ b/starboard/shared/starboard/experimental_features.h
@@ -217,6 +217,9 @@ inline constexpr ExperimentalFeatureKey<bool> kMediaNdkAudioTrack(
 
 inline constexpr ExperimentalFeatureKey<bool> kMediaNdkVideo("Media.NdkVideo");
 
+inline constexpr ExperimentalFeatureKey<bool> kMediaPauseUsingAudioTrackState(
+    "Media.PauseUsingAudioTrackState");
+
 inline constexpr ExperimentalFeatureKey<bool> kMediaSkipFlushOnDecoderTeardown(
     "Media.SkipFlushOnDecoderTeardown");
 


### PR DESCRIPTION
Revert the default enablement of PauseUsingAudioTrackState on Android
by https://github.com/youtube/cobalt/pull/10287.
The feature was found to cause time drift between the UI media time
and the video media time.

This revert also handles merge conflicts from recent refactoring
by https://github.com/youtube/cobalt/pull/11026
and ensures that related fixes (https://github.com/youtube/cobalt/pull/11403)
are maintained in the codebase.

Issue: 349854301
Issue: 544962204