### PR TITLE
autoroll: Add self-service instructions

### DIFF
--- a/.github/workflows/autoroll_chromium.yaml
+++ b/.github/workflows/autoroll_chromium.yaml
@@ -137,6 +137,14 @@ jobs:
             echo ""
             echo "Original pull requests:"
             echo "${PR_LINKS}"
+            echo ""
+            echo "To merge these changes, run the autoroll script:"
+            echo ""
+            echo '```bash'
+            echo "cobalt/devinfra/github/autoroll/merge_autoroll.py \\"
+            echo "  --source-branch ${SOURCE_BRANCH} \\"
+            echo "  --target-branch ${TARGET_BRANCH}"
+            echo '```'
           } > "${PR_BODY_FILE}"
 
           if [[ -f "${AUTOROLL_FILE}" ]] && grep -q "^CONFLICTED:" "${AUTOROLL_FILE}"; then

--- a/.github/workflows/autoroll_chromium.yaml
+++ b/.github/workflows/autoroll_chromium.yaml
@@ -141,7 +141,7 @@ jobs:
             echo "To merge these changes, run the autoroll script:"
             echo ""
             echo '```bash'
-            echo "cobalt/devinfra/github/autoroll/merge_autoroll.py \\"
+            echo "GITHUB_REPOSITORY=${GITHUB_REPOSITORY} python3 cobalt/devinfra/github/autoroll/merge_autoroll.py \\"
             echo "  --source-branch ${SOURCE_BRANCH} \\"
             echo "  --target-branch ${TARGET_BRANCH}"
             echo '```'

--- a/.github/workflows/autoroll_main.yaml
+++ b/.github/workflows/autoroll_main.yaml
@@ -136,7 +136,7 @@ jobs:
             echo "To merge these changes, run the autoroll script:"
             echo ""
             echo '```bash'
-            echo "cobalt/devinfra/github/autoroll/merge_autoroll.py \\"
+            echo "GITHUB_REPOSITORY=${GITHUB_REPOSITORY} python3 cobalt/devinfra/github/autoroll/merge_autoroll.py \\"
             echo "  --source-branch ${SOURCE_BRANCH} \\"
             echo "  --target-branch ${TARGET_BRANCH}"
             echo '```'

--- a/.github/workflows/autoroll_main.yaml
+++ b/.github/workflows/autoroll_main.yaml
@@ -132,6 +132,14 @@ jobs:
             echo ""
             echo "Original pull requests:"
             echo "${PR_LINKS}"
+            echo ""
+            echo "To merge these changes, run the autoroll script:"
+            echo ""
+            echo '```bash'
+            echo "cobalt/devinfra/github/autoroll/merge_autoroll.py \\"
+            echo "  --source-branch ${SOURCE_BRANCH} \\"
+            echo "  --target-branch ${TARGET_BRANCH}"
+            echo '```'
           } > "${PR_BODY_FILE}"
 
           if [[ -f "${AUTOROLL_FILE}" ]] && grep -q "^CONFLICTED:" "${AUTOROLL_FILE}"; then


### PR DESCRIPTION
This change adds instructions to the generated autoroll PR description body showing how to execute `cobalt/devinfra/github/autoroll/merge_autoroll.py` with the appropriate `--source-branch` and `--target-branch` arguments to merge the changes.

Tag: agy
Conv: 5d39f4b5-584e-4c07-b01e-6fc72ff0a054
Bug: 553046598