### PR TITLE
starboard: Add unit tests for AudioRendererPassthrough

### DIFF
--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -439,6 +439,7 @@ test("starboard_platform_tests") {
 
   sources = media_tests_sources + player_tests_sources + [
               "//starboard/common/test_main.cc",
+              "audio_renderer_passthrough_test.cc",
               "audio_track_audio_sink_type_test.cc",
               "drm_session_id_mapper_test.cc",
               "features_extension_test.cc",

--- a/starboard/android/shared/audio_renderer_passthrough.cc
+++ b/starboard/android/shared/audio_renderer_passthrough.cc
@@ -38,11 +38,16 @@ constexpr int64_t kAudioTrackUpdateInternal = 5'000;  // 5ms
 
 constexpr int kPreferredBufferSizeInBytes = 16 * 1024;
 
+}  // namespace
+
 // C++ rewrite of ExoPlayer function parseAc3SyncframeAudioSampleCount(), it
 // works for AC-3, E-AC-3, and E-AC-3-JOC.
 // The ExoPlayer implementation is based on
 // https://www.etsi.org/deliver/etsi_ts/102300_102399/102366/01.04.01_60/ts_102366v010401p.pdf.
-int ParseAc3SyncframeAudioSampleCount(const uint8_t* buffer, int size) {
+// static
+int AudioRendererPassthrough::ParseAc3SyncframeAudioSampleCount(
+    const uint8_t* buffer,
+    int size) {
   SB_CHECK(buffer);
 
   constexpr int kAudioSamplesPerAudioBlock = 256;
@@ -70,8 +75,6 @@ int ParseAc3SyncframeAudioSampleCount(const uint8_t* buffer, int size) {
   }
 }
 
-}  // namespace
-
 // static
 NonNullResult<std::unique_ptr<AudioRendererPassthrough>>
 AudioRendererPassthrough::Create(JobQueue* job_queue,
@@ -97,20 +100,36 @@ AudioRendererPassthrough::Create(JobQueue* job_queue,
 
   return std::make_unique<AudioRendererPassthrough>(
       PassKey<AudioRendererPassthrough>(), job_queue, audio_stream_info,
-      std::move(decoder));
+      std::move(decoder), &AudioTrack::Create);
+}
+
+// static
+std::unique_ptr<AudioRendererPassthrough>
+AudioRendererPassthrough::CreateForTesting(
+    JobQueue* job_queue,
+    const AudioStreamInfo& audio_stream_info,
+    std::unique_ptr<AudioDecoder> decoder,
+    AudioTrackFactory audio_track_factory) {
+  SB_CHECK(audio_track_factory);
+  return std::make_unique<AudioRendererPassthrough>(
+      PassKey<AudioRendererPassthrough>(), job_queue, audio_stream_info,
+      std::move(decoder), std::move(audio_track_factory));
 }
 
 AudioRendererPassthrough::AudioRendererPassthrough(
     PassKey<AudioRendererPassthrough>,
     JobQueue* job_queue,
     const AudioStreamInfo& audio_stream_info,
-    std::unique_ptr<AudioDecoder> decoder)
+    std::unique_ptr<AudioDecoder> decoder,
+    AudioTrackFactory audio_track_factory)
     : JobOwner(job_queue),
       audio_stream_info_(audio_stream_info),
-      decoder_(std::move(decoder)) {
+      decoder_(std::move(decoder)),
+      audio_track_factory_(std::move(audio_track_factory)) {
   SB_CHECK(decoder_);
-  SB_DCHECK(audio_stream_info_.codec == kSbMediaAudioCodecAc3 ||
-            audio_stream_info_.codec == kSbMediaAudioCodecEac3);
+  SB_CHECK(audio_track_factory_);
+  SB_CHECK(audio_stream_info_.codec == kSbMediaAudioCodecAc3 ||
+           audio_stream_info_.codec == kSbMediaAudioCodecEac3);
 }
 
 AudioRendererPassthrough::~AudioRendererPassthrough() {
@@ -411,25 +430,24 @@ void AudioRendererPassthrough::CreateAudioTrackAndStartProcessing() {
     return;
   }
 
-  std::unique_ptr<AudioTrackBridge> audio_track_bridge =
-      AudioTrackBridge::Create(
-          audio_stream_info_.codec == kSbMediaAudioCodecAc3
-              ? kSbMediaAudioCodingTypeAc3
-              : kSbMediaAudioCodingTypeDolbyDigitalPlus,
-          /*sample_type=*/std::nullopt,  // Not required in passthrough mode
-          audio_stream_info_.number_of_channels,
-          audio_stream_info_.samples_per_second, kPreferredBufferSizeInBytes,
-          /*tunnel_mode_audio_session_id=*/std::nullopt,
-          /*is_web_audio=*/false);
+  std::unique_ptr<AudioTrack> audio_track = audio_track_factory_(
+      audio_stream_info_.codec == kSbMediaAudioCodecAc3
+          ? kSbMediaAudioCodingTypeAc3
+          : kSbMediaAudioCodingTypeDolbyDigitalPlus,
+      /*sample_type=*/std::nullopt,  // Not required in passthrough mode
+      audio_stream_info_.number_of_channels,
+      audio_stream_info_.samples_per_second, kPreferredBufferSizeInBytes,
+      /*tunnel_mode_audio_session_id=*/std::nullopt,
+      /*is_web_audio=*/false);
 
-  if (!audio_track_bridge) {
-    error_cb_(kSbPlayerErrorDecode, "Error creating AudioTrackBridge");
+  if (!audio_track) {
+    error_cb_(kSbPlayerErrorDecode, "Error creating AudioTrack");
     return;
   }
 
   {
     std::lock_guard scoped_lock(mutex_);
-    audio_track_bridge_ = std::move(audio_track_bridge);
+    audio_track_bridge_ = std::move(audio_track);
   }
 
   AudioTrackState initial_state;
@@ -551,7 +569,7 @@ void AudioRendererPassthrough::UpdateStatusAndWriteData(
           MakeSpan(sample_buffer, samples_to_write), sync_time);
       // Error code returned as negative value, like kAudioTrackErrorDeadObject.
       if (samples_written < 0) {
-        if (samples_written == AudioTrackBridge::kAudioTrackErrorDeadObject) {
+        if (samples_written == AudioTrack::kAudioTrackErrorDeadObject) {
           // Inform the audio end point change.
           SB_LOG(INFO)
               << "Write error for dead audio track, audio device capability "

--- a/starboard/android/shared/audio_renderer_passthrough.cc
+++ b/starboard/android/shared/audio_renderer_passthrough.cc
@@ -350,7 +350,7 @@ int64_t AudioRendererPassthrough::GetCurrentMediaTime(bool* is_playing,
   *is_underflow = false;  // TODO: Support underflow
   *playback_rate = playback_rate_;
 
-  if (!audio_track_bridge_) {
+  if (!audio_track_) {
     return seek_to_time_;
   }
 
@@ -363,7 +363,7 @@ int64_t AudioRendererPassthrough::GetCurrentMediaTime(bool* is_playing,
 
   int64_t playback_time;
   if (stop_called_) {
-    // When AudioTrackBridge::Stop() is called, the playback will continue until
+    // When AudioTrack::Stop() is called, the playback will continue until
     // all the frames written are played, as the AudioTrack is created in
     // MODE_STREAM.
     auto now = CurrentMonotonicTime();
@@ -381,8 +381,7 @@ int64_t AudioRendererPassthrough::GetCurrentMediaTime(bool* is_playing,
   }
 
   int64_t updated_at;
-  auto playback_head_position =
-      audio_track_bridge_->GetAudioTimestamp(&updated_at);
+  auto playback_head_position = audio_track_->GetAudioTimestamp(&updated_at);
   if (playback_head_position <= 0) {
     // The playback is warming up, don't adjust the media time by the monotonic
     // system time.
@@ -425,13 +424,13 @@ void AudioRendererPassthrough::CreateAudioTrackAndStartProcessing() {
   SB_DCHECK(audio_track_thread_->BelongsToCurrentThread());
   SB_DCHECK(error_cb_);
 
-  if (audio_track_bridge_) {
+  if (audio_track_) {
     SB_DCHECK(!update_status_and_write_data_token_);
     AudioTrackState initial_state;
     update_status_and_write_data_token_ = audio_track_thread_->Schedule(
         std::bind(&AudioRendererPassthrough::UpdateStatusAndWriteData, this,
                   initial_state));
-    SB_LOG(INFO) << "|audio_track_bridge_| already created, start processing.";
+    SB_LOG(INFO) << "|audio_track_| already created, start processing.";
     return;
   }
 
@@ -452,14 +451,14 @@ void AudioRendererPassthrough::CreateAudioTrackAndStartProcessing() {
 
   {
     std::lock_guard scoped_lock(mutex_);
-    audio_track_bridge_ = std::move(audio_track);
+    audio_track_ = std::move(audio_track);
   }
 
   AudioTrackState initial_state;
   update_status_and_write_data_token_ = audio_track_thread_->Schedule(
       std::bind(&AudioRendererPassthrough::UpdateStatusAndWriteData, this,
                 initial_state));
-  SB_LOG(INFO) << "|audio_track_bridge_| created, start processing.";
+  SB_LOG(INFO) << "|audio_track_| created, start processing.";
 }
 
 void AudioRendererPassthrough::FlushAudioTrackAndStopProcessing(
@@ -469,18 +468,18 @@ void AudioRendererPassthrough::FlushAudioTrackAndStopProcessing(
 
   SB_LOG(INFO) << "Pause audio track and stop processing.";
 
-  // Flushing of |audio_track_bridge_| and updating of |seek_to_time_| have to
+  // Flushing of |audio_track_| and updating of |seek_to_time_| have to
   // be done together under lock to avoid |seek_to_time_| being added to a stale
   // playback head or vice versa in GetCurrentMediaTime().
   std::lock_guard scoped_lock(mutex_);
 
-  // We have to reuse |audio_track_bridge_| instead of creating a new one, to
+  // We have to reuse |audio_track_| instead of creating a new one, to
   // reduce output mode switching between PCM and e/ac3.  Otherwise a noticeable
   // silence can be observed after seeking on some audio receivers.
   // TODO: Consider reusing audio sink for non-passthrough playbacks, to see if
   //       it reduces latency after seeking.
-  if (audio_track_bridge_) {
-    audio_track_bridge_->PauseAndFlush();
+  if (audio_track_) {
+    audio_track_->PauseAndFlush();
   }
   seek_to_time_ = seek_to_time;
   paused_ = true;
@@ -494,17 +493,17 @@ void AudioRendererPassthrough::UpdateStatusAndWriteData(
   SB_DCHECK(audio_track_thread_);
   SB_DCHECK(audio_track_thread_->BelongsToCurrentThread());
   SB_DCHECK(error_cb_);
-  SB_DCHECK(audio_track_bridge_);
+  SB_DCHECK(audio_track_);
 
   // Encoded passthrough bitstreams (e.g. AC3/E-AC3) cannot be seamlessly routed
   // across different sinks (e.g. Bluetooth or built-in speakers), so any device
   // change requires recreating the player to renegotiate audio capabilities.
-  if (audio_track_bridge_->GetAndResetAudioDeviceChange() !=
+  if (audio_track_->GetAndResetAudioDeviceChange() !=
       AudioDeviceChange::kNone) {
     SB_LOG(INFO) << "Audio device changed, raising a capability changed error "
                     "to restart playback.";
     ReportCapabilityChanged();
-    audio_track_bridge_->PauseAndFlush();
+    audio_track_->PauseAndFlush();
     return;
   }
 
@@ -524,17 +523,17 @@ void AudioRendererPassthrough::UpdateStatusAndWriteData(
   }
 
   if (previous_state.volume != current_state.volume) {
-    audio_track_bridge_->SetVolume(current_state.volume);
+    audio_track_->SetVolume(current_state.volume);
   }
   if (previous_state.playing() != current_state.playing()) {
     if (current_state.playing()) {
-      audio_track_bridge_->Play();
+      audio_track_->Play();
       audio_track_paused_ = false;
       SB_LOG(INFO) << "Played on AudioTrack thread.";
       std::lock_guard scoped_lock(mutex_);
       stop_called_ = false;
     } else {
-      audio_track_bridge_->Pause();
+      audio_track_->Pause();
       audio_track_paused_ = true;
       SB_LOG(INFO) << "Paused on AudioTrack thread.";
     }
@@ -550,10 +549,10 @@ void AudioRendererPassthrough::UpdateStatusAndWriteData(
       std::lock_guard scoped_lock(mutex_);
       if (current_state.playing() && !stop_called_) {
         // TODO: Check if we can apply the same stop logic to non-passthrough.
-        audio_track_bridge_->Stop();
+        audio_track_->Stop();
         stop_called_ = true;
         playback_head_position_when_stopped_ =
-            audio_track_bridge_->GetAudioTimestamp(&stopped_at_);
+            audio_track_->GetAudioTimestamp(&stopped_at_);
         total_frames_written_ = total_frames_written_on_audio_track_thread_;
         decoded_audio_writing_in_progress_ = std::nullopt;
         SB_LOG(INFO) << "Audio track stopped at " << stopped_at_
@@ -570,7 +569,7 @@ void AudioRendererPassthrough::UpdateStatusAndWriteData(
       //       It is not used in non-tunneled mode so it doesn't matter, but we
       //       should revisit this.
       auto sync_time = decoded_audio_writing_in_progress_->timestamp();
-      int samples_written = audio_track_bridge_->WriteSample(
+      int samples_written = audio_track_->WriteSample(
           MakeSpan(sample_buffer, samples_to_write), sync_time);
       // Error code returned as negative value, like kAudioTrackErrorDeadObject.
       if (samples_written < 0) {
@@ -590,7 +589,7 @@ void AudioRendererPassthrough::UpdateStatusAndWriteData(
                           "frames, error: "
                        << samples_written;
         }
-        audio_track_bridge_->PauseAndFlush();
+        audio_track_->PauseAndFlush();
         return;
       }
 

--- a/starboard/android/shared/audio_renderer_passthrough.cc
+++ b/starboard/android/shared/audio_renderer_passthrough.cc
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <utility>
+#include <vector>
 
 #include "starboard/android/shared/audio_decoder_passthrough.h"
 #include "starboard/android/shared/media_capabilities_cache.h"
@@ -38,16 +39,11 @@ constexpr int64_t kAudioTrackUpdateInternal = 5'000;  // 5ms
 
 constexpr int kPreferredBufferSizeInBytes = 16 * 1024;
 
-}  // namespace
-
 // C++ rewrite of ExoPlayer function parseAc3SyncframeAudioSampleCount(), it
 // works for AC-3, E-AC-3, and E-AC-3-JOC.
 // The ExoPlayer implementation is based on
 // https://www.etsi.org/deliver/etsi_ts/102300_102399/102366/01.04.01_60/ts_102366v010401p.pdf.
-// static
-int AudioRendererPassthrough::ParseAc3SyncframeAudioSampleCount(
-    const uint8_t* buffer,
-    int size) {
+int ParseAc3SyncframeAudioSampleCount(const uint8_t* buffer, int size) {
   SB_CHECK(buffer);
 
   constexpr int kAudioSamplesPerAudioBlock = 256;
@@ -74,6 +70,8 @@ int AudioRendererPassthrough::ParseAc3SyncframeAudioSampleCount(
     return kAc3SyncFrameAudioSampleCount;
   }
 }
+
+}  // namespace
 
 // static
 NonNullResult<std::unique_ptr<AudioRendererPassthrough>>
@@ -114,6 +112,13 @@ AudioRendererPassthrough::CreateForTesting(
   return std::make_unique<AudioRendererPassthrough>(
       PassKey<AudioRendererPassthrough>(), job_queue, audio_stream_info,
       std::move(decoder), std::move(audio_track_factory));
+}
+
+// static
+int AudioRendererPassthrough::ParseAc3SyncframeAudioSampleCountForTesting(
+    const std::vector<uint8_t>& buffer) {
+  return ParseAc3SyncframeAudioSampleCount(buffer.data(),
+                                           static_cast<int>(buffer.size()));
 }
 
 AudioRendererPassthrough::AudioRendererPassthrough(

--- a/starboard/android/shared/audio_renderer_passthrough.h
+++ b/starboard/android/shared/audio_renderer_passthrough.h
@@ -16,11 +16,12 @@
 #define STARBOARD_ANDROID_SHARED_AUDIO_RENDERER_PASSTHROUGH_H_
 
 #include <atomic>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <queue>
 
-#include "starboard/android/shared/audio_track_bridge.h"
+#include "starboard/android/shared/audio_track.h"
 #include "starboard/android/shared/drm_system.h"
 #include "starboard/common/pass_key.h"
 #include "starboard/common/ref_counted.h"
@@ -47,16 +48,34 @@ class AudioRendererPassthrough : public AudioRenderer,
                                  public MediaTimeProvider,
                                  private JobQueue::JobOwner {
  public:
+  static int ParseAc3SyncframeAudioSampleCount(const uint8_t* buffer, int size);
+
+  using AudioTrackFactory = std::function<std::unique_ptr<AudioTrack>(
+      SbMediaAudioCodingType coding_type,
+      std::optional<SbMediaAudioSampleType> sample_type,
+      int channels,
+      int sampling_frequency_hz,
+      int preferred_buffer_size_in_bytes,
+      std::optional<int> tunnel_mode_audio_session_id,
+      bool is_web_audio)>;
+
   static NonNullResult<std::unique_ptr<AudioRendererPassthrough>> Create(
       JobQueue* job_queue,
       const AudioStreamInfo& audio_stream_info,
       SbDrmSystem drm_system,
       bool enable_flush_during_seek);
 
+  static std::unique_ptr<AudioRendererPassthrough> CreateForTesting(
+      JobQueue* job_queue,
+      const AudioStreamInfo& audio_stream_info,
+      std::unique_ptr<AudioDecoder> decoder,
+      AudioTrackFactory audio_track_factory);
+
   AudioRendererPassthrough(PassKey<AudioRendererPassthrough>,
                            JobQueue* job_queue,
                            const AudioStreamInfo& audio_stream_info,
-                           std::unique_ptr<AudioDecoder> decoder);
+                           std::unique_ptr<AudioDecoder> decoder,
+                           AudioTrackFactory audio_track_factory);
   ~AudioRendererPassthrough() override;
 
   // AudioRenderer methods
@@ -144,10 +163,12 @@ class AudioRendererPassthrough : public AudioRenderer,
 
   std::atomic_bool audio_track_paused_{true};
 
+  const AudioTrackFactory audio_track_factory_;
+
   // |audio_track_thread_| must be declared after |audio_track_bridge_| to
   // ensure the thread completes all tasks before |audio_track_bridge_| is
   // invalidated.
-  std::unique_ptr<AudioTrackBridge> audio_track_bridge_;
+  std::unique_ptr<AudioTrack> audio_track_bridge_;
   std::unique_ptr<JobThread> audio_track_thread_;
 };
 

--- a/starboard/android/shared/audio_renderer_passthrough.h
+++ b/starboard/android/shared/audio_renderer_passthrough.h
@@ -20,6 +20,7 @@
 #include <memory>
 #include <mutex>
 #include <queue>
+#include <vector>
 
 #include "starboard/android/shared/audio_track.h"
 #include "starboard/android/shared/drm_system.h"
@@ -48,8 +49,6 @@ class AudioRendererPassthrough : public AudioRenderer,
                                  public MediaTimeProvider,
                                  private JobQueue::JobOwner {
  public:
-  static int ParseAc3SyncframeAudioSampleCount(const uint8_t* buffer, int size);
-
   using AudioTrackFactory = std::function<std::unique_ptr<AudioTrack>(
       SbMediaAudioCodingType coding_type,
       std::optional<SbMediaAudioSampleType> sample_type,
@@ -77,6 +76,9 @@ class AudioRendererPassthrough : public AudioRenderer,
                            std::unique_ptr<AudioDecoder> decoder,
                            AudioTrackFactory audio_track_factory);
   ~AudioRendererPassthrough() override;
+
+  static int ParseAc3SyncframeAudioSampleCountForTesting(
+      const std::vector<uint8_t>& buffer);
 
   // AudioRenderer methods
   void Initialize(const ErrorCB& error_cb,

--- a/starboard/android/shared/audio_renderer_passthrough.h
+++ b/starboard/android/shared/audio_renderer_passthrough.h
@@ -167,10 +167,10 @@ class AudioRendererPassthrough : public AudioRenderer,
 
   const AudioTrackFactory audio_track_factory_;
 
-  // |audio_track_thread_| must be declared after |audio_track_bridge_| to
-  // ensure the thread completes all tasks before |audio_track_bridge_| is
+  // |audio_track_thread_| must be declared after |audio_track_| to
+  // ensure the thread completes all tasks before |audio_track_| is
   // invalidated.
-  std::unique_ptr<AudioTrack> audio_track_bridge_;
+  std::unique_ptr<AudioTrack> audio_track_;
   std::unique_ptr<JobThread> audio_track_thread_;
 };
 

--- a/starboard/android/shared/audio_renderer_passthrough_test.cc
+++ b/starboard/android/shared/audio_renderer_passthrough_test.cc
@@ -1,0 +1,473 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/android/shared/audio_renderer_passthrough.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "starboard/android/shared/audio_decoder_passthrough.h"
+#include "starboard/android/shared/audio_track.h"
+#include "starboard/android/shared/fake_audio_track.h"
+#include "starboard/common/ref_counted.h"
+#include "starboard/drm.h"
+#include "starboard/media.h"
+#include "starboard/player.h"
+#include "starboard/shared/starboard/player/filter/testing/test_util.h"
+#include "starboard/shared/starboard/player/input_buffer_internal.h"
+#include "starboard/shared/starboard/player/job_queue.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace starboard {
+namespace {
+
+AudioStreamInfo CreateAudioStreamInfo(
+    SbMediaAudioCodec codec = kSbMediaAudioCodecAc3,
+    int channels = 6,
+    int samples_per_second = 48000) {
+  AudioStreamInfo info = {};
+  info.codec = codec;
+  info.number_of_channels = channels;
+  info.samples_per_second = samples_per_second;
+  return info;
+}
+
+std::vector<uint8_t> CreateAc3Frame(bool is_eac3,
+                                    int numblkscod,
+                                    int fscod = 0) {
+  std::vector<uint8_t> buffer(64, 0);
+  buffer[0] = 0x0B;
+  buffer[1] = 0x77;
+  if (is_eac3) {
+    // E-AC-3: bitstream ID > 10 (e.g. 16: (16 << 3) = 0x80)
+    buffer[5] = 0x80;
+    buffer[4] = static_cast<uint8_t>(((fscod & 0x03) << 6) |
+                                     ((numblkscod & 0x03) << 4));
+  } else {
+    // AC-3: bitstream ID <= 10 (e.g. 8: (8 << 3) = 0x40)
+    buffer[5] = 0x40;
+  }
+  return buffer;
+}
+
+// Note: |frame_data| must outlive the returned InputBuffer because
+// StubDeallocateSampleFunc does not take ownership or copy the buffer.
+scoped_refptr<InputBuffer> CreateInputBuffer(
+    const std::vector<uint8_t>& frame_data,
+    int64_t timestamp) {
+  SbPlayerSampleInfo sample_info = {};
+  sample_info.type = kSbMediaTypeAudio;
+  sample_info.buffer = frame_data.data();
+  sample_info.buffer_size = static_cast<int>(frame_data.size());
+  sample_info.timestamp = timestamp;
+  CreateAudioStreamInfo().ConvertTo(&sample_info.audio_sample_info.stream_info);
+  return make_scoped_refptr<InputBuffer>(StubDeallocateSampleFunc, nullptr,
+                                         nullptr, sample_info);
+}
+
+class ThrottledAudioTrack : public FakeAudioTrack {
+ public:
+  ThrottledAudioTrack(int channels,
+                      int sampling_frequency_hz,
+                      SbMediaAudioSampleType sample_type,
+                      size_t max_bytes_per_write)
+      : FakeAudioTrack(channels, sampling_frequency_hz, sample_type),
+        max_bytes_per_write_(max_bytes_per_write) {}
+
+  int WriteSample(Span<const uint8_t> buffer, int64_t sync_time) override {
+    size_t bytes_to_write = std::min(buffer.size(), max_bytes_per_write_);
+    return FakeAudioTrack::WriteSample(MakeSpan(buffer.data(), bytes_to_write),
+                                       sync_time);
+  }
+
+ private:
+  const size_t max_bytes_per_write_;
+};
+
+TEST(AudioRendererPassthroughStaticTest, ParseAc3SyncframeAudioSampleCount) {
+  // Too small buffer (< 6 bytes) returns default 1536 samples.
+  uint8_t short_buffer[5] = {0x0B, 0x77, 0, 0, 0};
+  EXPECT_EQ(AudioRendererPassthrough::ParseAc3SyncframeAudioSampleCount(
+                short_buffer, 5),
+            1536);
+
+  // AC-3 bitstream ID <= 10 (e.g. 8) returns 1536 samples.
+  auto ac3_frame = CreateAc3Frame(/*is_eac3=*/false, /*numblkscod=*/0);
+  EXPECT_EQ(AudioRendererPassthrough::ParseAc3SyncframeAudioSampleCount(
+                ac3_frame.data(), ac3_frame.size()),
+            1536);
+
+  // E-AC-3: numblkscod 0, 1, 2, 3 correspond to 1, 2, 3, 6 blocks of 256
+  // samples.
+  auto eac3_block1 = CreateAc3Frame(/*is_eac3=*/true, /*numblkscod=*/0);
+  EXPECT_EQ(AudioRendererPassthrough::ParseAc3SyncframeAudioSampleCount(
+                eac3_block1.data(), eac3_block1.size()),
+            256);
+
+  auto eac3_block2 = CreateAc3Frame(/*is_eac3=*/true, /*numblkscod=*/1);
+  EXPECT_EQ(AudioRendererPassthrough::ParseAc3SyncframeAudioSampleCount(
+                eac3_block2.data(), eac3_block2.size()),
+            512);
+
+  auto eac3_block3 = CreateAc3Frame(/*is_eac3=*/true, /*numblkscod=*/2);
+  EXPECT_EQ(AudioRendererPassthrough::ParseAc3SyncframeAudioSampleCount(
+                eac3_block3.data(), eac3_block3.size()),
+            768);
+
+  auto eac3_block6 = CreateAc3Frame(/*is_eac3=*/true, /*numblkscod=*/3);
+  EXPECT_EQ(AudioRendererPassthrough::ParseAc3SyncframeAudioSampleCount(
+                eac3_block6.data(), eac3_block6.size()),
+            1536);
+
+  // E-AC-3 with fscod == 3 returns 6 blocks (1536 samples).
+  auto eac3_fscod3 = CreateAc3Frame(/*is_eac3=*/true, /*numblkscod=*/0,
+                                    /*fscod=*/3);
+  EXPECT_EQ(AudioRendererPassthrough::ParseAc3SyncframeAudioSampleCount(
+                eac3_fscod3.data(), eac3_fscod3.size()),
+            1536);
+}
+
+class AudioRendererPassthroughTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    audio_stream_info_ = CreateAudioStreamInfo();
+    pending_audio_track_ = std::make_unique<FakeAudioTrack>(
+        audio_stream_info_.number_of_channels,
+        audio_stream_info_.samples_per_second,
+        kSbMediaAudioSampleTypeInt16Deprecated);
+    fake_audio_track_ = pending_audio_track_.get();
+
+    auto decoder = std::make_unique<AudioDecoderPassthrough>(
+        audio_stream_info_.samples_per_second);
+
+    renderer_ = AudioRendererPassthrough::CreateForTesting(
+        &job_queue_, audio_stream_info_, std::move(decoder),
+        [this](SbMediaAudioCodingType, std::optional<SbMediaAudioSampleType>,
+               int, int, int, std::optional<int>,
+               bool) { return std::move(pending_audio_track_); });
+    ASSERT_NE(renderer_, nullptr);
+
+    renderer_->Initialize(
+        std::bind(&AudioRendererPassthroughTest::OnError, this,
+                  std::placeholders::_1, std::placeholders::_2),
+        std::bind(&AudioRendererPassthroughTest::OnPrerolled, this),
+        std::bind(&AudioRendererPassthroughTest::OnEnded, this));
+
+    frame_ = CreateAc3Frame(/*is_eac3=*/false, /*numblkscod=*/0);
+  }
+
+  void OnError(SbPlayerError error, const std::string& error_message) {
+    last_error_ = error;
+    last_error_message_ = error_message;
+    error_count_++;
+  }
+
+  void OnPrerolled() { prerolled_count_++; }
+
+  void OnEnded() { ended_count_++; }
+
+  bool WaitForCondition(const std::function<bool()>& condition,
+                        int timeout_ms = 1000) {
+    int elapsed_ms = 0;
+    while (!condition() && elapsed_ms < timeout_ms) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      elapsed_ms += 10;
+    }
+    return condition();
+  }
+
+  JobQueue job_queue_;
+  AudioStreamInfo audio_stream_info_;
+  std::unique_ptr<FakeAudioTrack> pending_audio_track_;
+  FakeAudioTrack* fake_audio_track_ = nullptr;
+  std::unique_ptr<AudioRendererPassthrough> renderer_;
+  std::vector<uint8_t> frame_;
+
+  std::atomic<int> error_count_ = 0;
+  std::atomic<SbPlayerError> last_error_ = kSbPlayerErrorDecode;
+  std::string last_error_message_;
+  std::atomic<int> prerolled_count_ = 0;
+  std::atomic<int> ended_count_ = 0;
+};
+
+TEST_F(AudioRendererPassthroughTest, InitialState) {
+  EXPECT_FALSE(renderer_->IsEndOfStreamWritten());
+  EXPECT_FALSE(renderer_->IsEndOfStreamPlayed());
+  EXPECT_TRUE(renderer_->CanAcceptMoreData());
+  EXPECT_EQ(renderer_->GetAudioWriteHead(), 0);
+  EXPECT_EQ(renderer_->AdjustTimestampToAudioClock(12345), 12345);
+
+  bool is_playing = true;
+  bool is_eos_played = true;
+  bool is_underflow = true;
+  double playback_rate = 0.0;
+  int64_t media_time = renderer_->GetCurrentMediaTime(
+      &is_playing, &is_eos_played, &is_underflow, &playback_rate);
+
+  EXPECT_EQ(media_time, 0);
+  EXPECT_FALSE(is_playing);
+  EXPECT_FALSE(is_eos_played);
+  EXPECT_FALSE(is_underflow);
+  EXPECT_DOUBLE_EQ(playback_rate, 1.0);
+}
+
+TEST_F(AudioRendererPassthroughTest, AudioTrackCreationFailure) {
+  auto decoder = std::make_unique<AudioDecoderPassthrough>(
+      audio_stream_info_.samples_per_second);
+
+  auto failing_factory = [](SbMediaAudioCodingType,
+                            std::optional<SbMediaAudioSampleType>, int, int,
+                            int, std::optional<int>, bool) {
+    return std::unique_ptr<AudioTrack>(nullptr);
+  };
+
+  auto renderer = AudioRendererPassthrough::CreateForTesting(
+      &job_queue_, audio_stream_info_, std::move(decoder), failing_factory);
+  ASSERT_NE(renderer, nullptr);
+
+  std::atomic<int> error_received = 0;
+  std::atomic<SbPlayerError> received_code = kSbPlayerErrorCapabilityChanged;
+  renderer->Initialize(
+      [&](SbPlayerError error, const std::string&) {
+        error_received++;
+        received_code = error;
+      },
+      [] {}, [] {});
+
+  renderer->WriteSamples({CreateInputBuffer(frame_, 0)});
+  ASSERT_TRUE(WaitForCondition([&] { return error_received > 0; }));
+
+  EXPECT_EQ(received_code, kSbPlayerErrorDecode);
+}
+
+TEST_F(AudioRendererPassthroughTest, WriteSamplesAndConsume) {
+  renderer_->WriteSamples({CreateInputBuffer(frame_, 0)});
+
+  ASSERT_TRUE(WaitForCondition(
+      [&] { return fake_audio_track_->written_frames() > 0; }));
+
+  EXPECT_TRUE(WaitForCondition([&] { return renderer_->CanAcceptMoreData(); }));
+  EXPECT_EQ(error_count_, 0);
+}
+
+TEST_F(AudioRendererPassthroughTest, PrerollOnPartialWrite) {
+  // Create a separate renderer with a ThrottledAudioTrack that only accepts up
+  // to 16 bytes per write. The frame size is 64 bytes, so it cannot be written
+  // in a single pass. A partial write triggers the prerolled callback.
+  auto decoder = std::make_unique<AudioDecoderPassthrough>(
+      audio_stream_info_.samples_per_second);
+
+  auto renderer = AudioRendererPassthrough::CreateForTesting(
+      &job_queue_, audio_stream_info_, std::move(decoder),
+      [](SbMediaAudioCodingType, std::optional<SbMediaAudioSampleType>,
+         int channels, int sample_rate, int, std::optional<int>, bool) {
+        return std::make_unique<ThrottledAudioTrack>(
+            channels, sample_rate, kSbMediaAudioSampleTypeInt16Deprecated,
+            /*max_bytes_per_write=*/16);
+      });
+  ASSERT_NE(renderer, nullptr);
+
+  std::atomic<int> prerolled = 0;
+  renderer->Initialize([](SbPlayerError, const std::string&) {},
+                       [&] { prerolled++; }, [] {});
+
+  renderer->WriteSamples({CreateInputBuffer(frame_, 0)});
+
+  EXPECT_TRUE(WaitForCondition([&] { return prerolled > 0; }));
+}
+
+TEST_F(AudioRendererPassthroughTest, PrerollOnEos) {
+  renderer_->WriteSamples({CreateInputBuffer(frame_, 0)});
+  renderer_->WriteEndOfStream();
+
+  EXPECT_TRUE(WaitForCondition([&] { return prerolled_count_ > 0; }));
+}
+
+TEST_F(AudioRendererPassthroughTest, PlayAndPause) {
+  renderer_->WriteSamples({CreateInputBuffer(frame_, 0)});
+  renderer_->Play();
+  ASSERT_TRUE(WaitForCondition([&] {
+    return fake_audio_track_->play_state() == AudioTrack::PlayState::kPlaying;
+  }));
+
+  bool is_playing = false;
+  bool is_eos_played = false;
+  bool is_underflow = false;
+  double playback_rate = 0.0;
+  renderer_->GetCurrentMediaTime(&is_playing, &is_eos_played, &is_underflow,
+                                 &playback_rate);
+  EXPECT_TRUE(is_playing);
+
+  renderer_->Pause();
+  ASSERT_TRUE(WaitForCondition([&] {
+    return fake_audio_track_->play_state() == AudioTrack::PlayState::kPaused;
+  }));
+
+  renderer_->GetCurrentMediaTime(&is_playing, &is_eos_played, &is_underflow,
+                                 &playback_rate);
+  EXPECT_FALSE(is_playing);
+}
+
+TEST_F(AudioRendererPassthroughTest, SetVolume) {
+  renderer_->SetVolume(0.5);
+
+  // Write a sample to trigger the processing thread update.
+  renderer_->WriteSamples({CreateInputBuffer(frame_, 0)});
+
+  EXPECT_TRUE(
+      WaitForCondition([&] { return fake_audio_track_->volume() == 0.5; }));
+}
+
+TEST_F(AudioRendererPassthroughTest, SetPlaybackRate) {
+  renderer_->SetPlaybackRate(0.0);
+  bool is_playing = false;
+  bool is_eos_played = false;
+  bool is_underflow = false;
+  double playback_rate = -1.0;
+  renderer_->GetCurrentMediaTime(&is_playing, &is_eos_played, &is_underflow,
+                                 &playback_rate);
+  EXPECT_DOUBLE_EQ(playback_rate, 0.0);
+
+  // Unsupported rates (> 0 and != 1.0) are clamped to 1.0.
+  renderer_->SetPlaybackRate(1.5);
+  renderer_->GetCurrentMediaTime(&is_playing, &is_eos_played, &is_underflow,
+                                 &playback_rate);
+  EXPECT_DOUBLE_EQ(playback_rate, 1.0);
+}
+
+TEST_F(AudioRendererPassthroughTest, EndOfStreamWithoutSamples) {
+  renderer_->WriteEndOfStream();
+
+  EXPECT_TRUE(renderer_->IsEndOfStreamWritten());
+  EXPECT_TRUE(renderer_->IsEndOfStreamPlayed());
+  EXPECT_EQ(ended_count_, 1);
+}
+
+TEST_F(AudioRendererPassthroughTest, EndOfStreamPlaybackDrain) {
+  renderer_->WriteSamples({CreateInputBuffer(frame_, 0)});
+  renderer_->Play();
+
+  ASSERT_TRUE(WaitForCondition(
+      [&] { return fake_audio_track_->written_frames() > 0; }));
+
+  renderer_->WriteEndOfStream();
+  ASSERT_TRUE(renderer_->IsEndOfStreamWritten());
+  ASSERT_TRUE(WaitForCondition([&] { return ended_count_ > 0; }, 2000));
+
+  EXPECT_TRUE(renderer_->IsEndOfStreamPlayed());
+}
+
+TEST_F(AudioRendererPassthroughTest, DuplicateEndOfStream) {
+  renderer_->WriteEndOfStream();
+  renderer_->WriteEndOfStream();
+
+  EXPECT_EQ(ended_count_, 1);
+}
+
+TEST_F(AudioRendererPassthroughTest, SeekAndReuseAudioTrack) {
+  renderer_->WriteSamples({CreateInputBuffer(frame_, 0)});
+  renderer_->Play();
+  ASSERT_TRUE(WaitForCondition([&] {
+    return fake_audio_track_->play_state() == AudioTrack::PlayState::kPlaying;
+  }));
+
+  const int64_t kSeekTime = 500'000;
+  renderer_->Seek(kSeekTime);
+
+  EXPECT_FALSE(renderer_->IsEndOfStreamWritten());
+  EXPECT_FALSE(renderer_->IsEndOfStreamPlayed());
+  EXPECT_TRUE(renderer_->CanAcceptMoreData());
+  EXPECT_EQ(fake_audio_track_->play_state(), AudioTrack::PlayState::kPaused);
+
+  bool is_playing = true;
+  bool is_eos_played = true;
+  bool is_underflow = false;
+  double playback_rate = 0.0;
+  int64_t media_time = renderer_->GetCurrentMediaTime(
+      &is_playing, &is_eos_played, &is_underflow, &playback_rate);
+
+  EXPECT_EQ(media_time, kSeekTime);
+  EXPECT_FALSE(is_playing);
+
+  // Resume playback by writing new samples. The existing FakeAudioTrack should
+  // be reused.
+  renderer_->WriteSamples({CreateInputBuffer(frame_, kSeekTime)});
+  renderer_->Play();
+
+  EXPECT_TRUE(WaitForCondition([&] {
+    return fake_audio_track_->play_state() == AudioTrack::PlayState::kPlaying;
+  }));
+}
+
+TEST_F(AudioRendererPassthroughTest, AudioDeviceCapabilityChanged) {
+  renderer_->WriteSamples({CreateInputBuffer(frame_, 0)});
+  ASSERT_TRUE(WaitForCondition(
+      [&] { return fake_audio_track_->written_frames() > 0; }));
+
+  fake_audio_track_->simulate_device_change(true);
+  ASSERT_TRUE(WaitForCondition([&] { return error_count_ > 0; }));
+
+  EXPECT_EQ(last_error_, kSbPlayerErrorCapabilityChanged);
+}
+
+TEST_F(AudioRendererPassthroughTest, DeadObjectError) {
+  fake_audio_track_->set_write_error(AudioTrack::kAudioTrackErrorDeadObject);
+
+  renderer_->WriteSamples({CreateInputBuffer(frame_, 0)});
+  ASSERT_TRUE(WaitForCondition([&] { return error_count_ > 0; }));
+
+  EXPECT_EQ(last_error_, kSbPlayerErrorCapabilityChanged);
+}
+
+TEST_F(AudioRendererPassthroughTest, GeneralWriteError) {
+  fake_audio_track_->set_write_error(-1);
+
+  renderer_->WriteSamples({CreateInputBuffer(frame_, 0)});
+  ASSERT_TRUE(WaitForCondition([&] { return error_count_ > 0; }));
+
+  EXPECT_EQ(last_error_, kSbPlayerErrorDecode);
+}
+
+TEST_F(AudioRendererPassthroughTest, GetCurrentMediaTimePausedAndPlaying) {
+  const int64_t kSampleTimestamp = 100'000;
+  renderer_->WriteSamples({CreateInputBuffer(frame_, kSampleTimestamp)});
+  ASSERT_TRUE(WaitForCondition(
+      [&] { return fake_audio_track_->written_frames() > 0; }));
+
+  // Simulate 4800 frames consumed (100ms at 48000 Hz).
+  fake_audio_track_->set_consumed_frames(4800);
+
+  bool is_playing = true;
+  bool is_eos_played = true;
+  bool is_underflow = true;
+  double playback_rate = 0.0;
+
+  // When paused, monotonic clock interpolation is not applied.
+  // Playback time = audio_start_time (100,000) + 4800 * 1,000,000 / 48000
+  // (100,000) = 200,000 us.
+  int64_t media_time = renderer_->GetCurrentMediaTime(
+      &is_playing, &is_eos_played, &is_underflow, &playback_rate);
+  EXPECT_EQ(media_time, 200'000);
+  EXPECT_FALSE(is_playing);
+}
+
+}  // namespace
+}  // namespace starboard

--- a/starboard/android/shared/audio_renderer_passthrough_test.cc
+++ b/starboard/android/shared/audio_renderer_passthrough_test.cc
@@ -28,6 +28,7 @@
 #include "starboard/android/shared/audio_track.h"
 #include "starboard/android/shared/fake_audio_track.h"
 #include "starboard/common/ref_counted.h"
+#include "starboard/common/span.h"
 #include "starboard/drm.h"
 #include "starboard/media.h"
 #include "starboard/player.h"
@@ -104,45 +105,52 @@ class ThrottledAudioTrack : public FakeAudioTrack {
 
 TEST(AudioRendererPassthroughStaticTest, ParseAc3SyncframeAudioSampleCount) {
   // Too small buffer (< 6 bytes) returns default 1536 samples.
-  uint8_t short_buffer[5] = {0x0B, 0x77, 0, 0, 0};
-  EXPECT_EQ(AudioRendererPassthrough::ParseAc3SyncframeAudioSampleCount(
-                short_buffer, 5),
-            1536);
+  std::vector<uint8_t> short_buffer = {0x0B, 0x77, 0, 0, 0};
+  EXPECT_EQ(
+      AudioRendererPassthrough::ParseAc3SyncframeAudioSampleCountForTesting(
+          short_buffer),
+      1536);
 
   // AC-3 bitstream ID <= 10 (e.g. 8) returns 1536 samples.
   auto ac3_frame = CreateAc3Frame(/*is_eac3=*/false, /*numblkscod=*/0);
-  EXPECT_EQ(AudioRendererPassthrough::ParseAc3SyncframeAudioSampleCount(
-                ac3_frame.data(), ac3_frame.size()),
-            1536);
+  EXPECT_EQ(
+      AudioRendererPassthrough::ParseAc3SyncframeAudioSampleCountForTesting(
+          ac3_frame),
+      1536);
 
   // E-AC-3: numblkscod 0, 1, 2, 3 correspond to 1, 2, 3, 6 blocks of 256
   // samples.
   auto eac3_block1 = CreateAc3Frame(/*is_eac3=*/true, /*numblkscod=*/0);
-  EXPECT_EQ(AudioRendererPassthrough::ParseAc3SyncframeAudioSampleCount(
-                eac3_block1.data(), eac3_block1.size()),
-            256);
+  EXPECT_EQ(
+      AudioRendererPassthrough::ParseAc3SyncframeAudioSampleCountForTesting(
+          eac3_block1),
+      256);
 
   auto eac3_block2 = CreateAc3Frame(/*is_eac3=*/true, /*numblkscod=*/1);
-  EXPECT_EQ(AudioRendererPassthrough::ParseAc3SyncframeAudioSampleCount(
-                eac3_block2.data(), eac3_block2.size()),
-            512);
+  EXPECT_EQ(
+      AudioRendererPassthrough::ParseAc3SyncframeAudioSampleCountForTesting(
+          eac3_block2),
+      512);
 
   auto eac3_block3 = CreateAc3Frame(/*is_eac3=*/true, /*numblkscod=*/2);
-  EXPECT_EQ(AudioRendererPassthrough::ParseAc3SyncframeAudioSampleCount(
-                eac3_block3.data(), eac3_block3.size()),
-            768);
+  EXPECT_EQ(
+      AudioRendererPassthrough::ParseAc3SyncframeAudioSampleCountForTesting(
+          eac3_block3),
+      768);
 
   auto eac3_block6 = CreateAc3Frame(/*is_eac3=*/true, /*numblkscod=*/3);
-  EXPECT_EQ(AudioRendererPassthrough::ParseAc3SyncframeAudioSampleCount(
-                eac3_block6.data(), eac3_block6.size()),
-            1536);
+  EXPECT_EQ(
+      AudioRendererPassthrough::ParseAc3SyncframeAudioSampleCountForTesting(
+          eac3_block6),
+      1536);
 
   // E-AC-3 with fscod == 3 returns 6 blocks (1536 samples).
   auto eac3_fscod3 = CreateAc3Frame(/*is_eac3=*/true, /*numblkscod=*/0,
                                     /*fscod=*/3);
-  EXPECT_EQ(AudioRendererPassthrough::ParseAc3SyncframeAudioSampleCount(
-                eac3_fscod3.data(), eac3_fscod3.size()),
-            1536);
+  EXPECT_EQ(
+      AudioRendererPassthrough::ParseAc3SyncframeAudioSampleCountForTesting(
+          eac3_fscod3),
+      1536);
 }
 
 class AudioRendererPassthroughTest : public ::testing::Test {


### PR DESCRIPTION
Refactor AudioRendererPassthrough to decouple it from the concrete
AudioTrackBridge by introducing dependency injection via
AudioTrackFactory and an abstract AudioTrack. This allows unit
testing the renderer in native environments using a fake audio track.

The new test suite covers AC-3 and E-AC-3 sample count parsing,
track life cycle, flow control, state transitions, EOS handling,
and error propagation.

Bug: 512137801