### PR TITLE
cobalt: Fix OSPlatformName regression in UserAgent logic

### DIFF
--- a/base/system/sys_info_starboard.cc
+++ b/base/system/sys_info_starboard.cc
@@ -14,6 +14,7 @@
 
 #include "base/system/sys_info_starboard.h"
 
+#include "base/notimplemented.h"
 #include "build/build_config.h"
 
 #if BUILDFLAG(IS_ANDROID)
@@ -26,9 +27,6 @@ using starboard::GetSystemPropertyString;
 #include <map>
 
 #include <sys/utsname.h>
-
-#include "base/containers/contains.h"
-#include "base/notimplemented.h"
 #endif  // BUILDFLAG(IS_ANDROID)
 
 #if BUILDFLAG(IS_STARBOARD)
@@ -84,6 +82,11 @@ std::string SbSysInfo::OSFriendlyName() {
   return "AOSP";
 }
 
+std::string SbSysInfo::OSPlatformName() {
+  NOTIMPLEMENTED();
+  return "";
+}
+
 #elif BUILDFLAG(IS_STARBOARD)
 std::string SbSysInfo::OriginalDesignManufacturer() {
   return GetSystemPropertyString(kSbSystemPropertySystemIntegratorName);
@@ -103,6 +106,15 @@ std::string SbSysInfo::Brand() {
 
 std::string SbSysInfo::OSFriendlyName() {
   return GetSystemPropertyString(kSbSystemPropertyFriendlyName);
+}
+
+std::string SbSysInfo::OSPlatformName() {
+  std::string platform_name =
+      GetSystemPropertyString(kSbSystemPropertyPlatformName);
+  if (platform_name.empty()) {
+    return GetSystemPropertyString(kSbSystemPropertyFriendlyName);
+  }
+  return platform_name;
 }
 
 #elif BUILDFLAG(IS_IOS_TVOS)
@@ -163,6 +175,11 @@ std::string SbSysInfo::Brand() {
 }
 
 std::string SbSysInfo::OSFriendlyName() {
+  NOTIMPLEMENTED();
+  return "";
+}
+
+std::string SbSysInfo::OSPlatformName() {
   NOTIMPLEMENTED();
   return "";
 }

--- a/base/system/sys_info_starboard.h
+++ b/base/system/sys_info_starboard.h
@@ -33,6 +33,8 @@ class BASE_EXPORT SbSysInfo {
   static std::string Brand();
 
   static std::string OSFriendlyName();
+
+  static std::string OSPlatformName();
 };
 
 }  // namespace starboard

--- a/base/system/sys_info_starboard_unittest.cc
+++ b/base/system/sys_info_starboard_unittest.cc
@@ -49,8 +49,16 @@ TEST_F(SbSysInfoTest, Brand) {
 
 #if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_STARBOARD)
 TEST_F(SbSysInfoTest, OSFriendlyName) {
-  std::string os_name_str = SbSysInfo::OSFriendlyName();
-  EXPECT_NE(os_name_str, "");
+  // OSFriendlyName is kept for backward compatibility, may be legitimately empty.
+  (void)SbSysInfo::OSFriendlyName();
+}
+#endif
+
+#if BUILDFLAG(IS_STARBOARD) && !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS_TVOS)
+TEST_F(SbSysInfoTest, OSPlatformName) {
+  // OSPlatformName can legitimately be empty if kSbSystemPropertyPlatformName
+  // is not set.
+  (void)SbSysInfo::OSPlatformName();
 }
 #endif
 

--- a/cobalt/browser/user_agent/user_agent_platform_info.cc
+++ b/cobalt/browser/user_agent/user_agent_platform_info.cc
@@ -193,10 +193,10 @@ void UserAgentPlatformInfo::InitializePlatformDependentFieldsAndroid() {
 #elif BUILDFLAG(IS_STARBOARD)
 void UserAgentPlatformInfo::InitializePlatformDependentFieldsStarboard() {
   std::string os_name = base::SysInfo::OperatingSystemName();
-  const std::string os_friendly_name =
-      base::starboard::SbSysInfo::OSFriendlyName();
-  if (!os_friendly_name.empty()) {
-    os_name = os_friendly_name + "; " + os_name;
+  const std::string os_platform_name =
+      base::starboard::SbSysInfo::OSPlatformName();
+  if (!os_platform_name.empty()) {
+    os_name = os_platform_name + "; " + os_name;
   }
   const std::string os_version = base::SysInfo::OperatingSystemVersion();
   set_os_name_and_version(


### PR DESCRIPTION
Fix a regression where the OS friendly name was incorrectly used instead of the platform name in the UserAgent string.

PR 8706 (Bug 475670748) incorrectly switched the target Starboard property when constructing the User Agent OS platform name. In InitializePlatformDependentFieldsStarboard(), the implementation was invoking SbSysInfo::OSFriendlyName(), which queried kSbSystemPropertyFriendlyName.

This resulted in the UA string returning the device's friendly name (e.g., Roku_TV_H102X) instead of the standardized platform ID expected by YTS, which caused certification and integration testing regressions across partner devices (Bug 527960653).

This change fixes the regression by introducing a new SbSysInfo::OSPlatformName() accessor, which properly queries kSbSystemPropertyPlatformName and retains kSbSystemPropertyFriendlyName as a backward-compatible fallback for legacy partners. The User Agent generation now uses this new accessor instead of OSFriendlyName().

Bug: 527960653
Bug: 475670748
TAG=agy
CONV=b48c1cf8-919f-40eb-9cd3-8383c0115796