### PR TITLE
FIXES Cherry pick PR #12134: cobalt: Implement zero-copy in-process d…

### DIFF
--- a/gpu/config/gpu_finch_features.h
+++ b/gpu/config/gpu_finch_features.h
@@ -26,7 +26,7 @@ namespace features {
 GPU_CONFIG_EXPORT BASE_DECLARE_FEATURE(kUseGles2ForOopR);
 
 #if BUILDFLAG(IS_COBALT)
-GPU_EXPORT BASE_DECLARE_FEATURE(kCobaltInProcessDirectRaster);
+GPU_CONFIG_EXPORT BASE_DECLARE_FEATURE(kCobaltInProcessDirectRaster);
 #endif  // BUILDFLAG(IS_COBALT)
 
 // All features in alphabetical order. The features should be documented


### PR DESCRIPTION
…irect raster path

Refer to original PR: #12134

Introduce the kCobaltInProcessDirectRaster feature to bypass PaintOp serialization and deserialization when Cobalt is running in single- process mode. This reduces CPU overhead and memory usage by passing a pointer to the DisplayItemList directly to the GPU service via shared memory.

On the client side, RasterImplementation pre-uploads images to the transfer cache and packages the immutable display list into a payload. On the service side, RasterDecoderImpl performs direct rasterization on the canvas using a specialized image provider to resolve pre-uploaded textures.

Bug: 545866687

(cherry picked from commit 5c47f868d1f629b3ef500cdde540f77557473652)