### PR TITLE
Prevent exit segmentation fault in ElfLoader by using NoDestructor

### DIFF
--- a/starboard/elf_loader/elf_loader_sandbox.cc
+++ b/starboard/elf_loader/elf_loader_sandbox.cc
@@ -34,10 +34,14 @@
 #include "starboard/shared/starboard/features_test_util.h"
 #endif
 
+namespace {
+
 elf_loader::ElfLoader& GetElfLoader() {
   static starboard::NoDestructor<elf_loader::ElfLoader> s_elf_loader;
   return *s_elf_loader;
 }
+
+}  // namespace
 
 void (*g_sb_event_func)(const SbEvent*) = NULL;
 

--- a/starboard/elf_loader/elf_loader_sandbox.cc
+++ b/starboard/elf_loader/elf_loader_sandbox.cc
@@ -19,6 +19,7 @@
 #include "starboard/common/check_op.h"
 #include "starboard/common/command_line.h"
 #include "starboard/common/log.h"
+#include "starboard/common/no_destructor.h"
 #include "starboard/common/paths.h"
 #include "starboard/common/string.h"
 #include "starboard/crashpad_wrapper/annotations.h"
@@ -33,7 +34,10 @@
 #include "starboard/shared/starboard/features_test_util.h"
 #endif
 
-elf_loader::ElfLoader g_elf_loader;
+elf_loader::ElfLoader& GetElfLoader() {
+  static starboard::NoDestructor<elf_loader::ElfLoader> s_elf_loader;
+  return *s_elf_loader;
+}
 
 void (*g_sb_event_func)(const SbEvent*) = NULL;
 
@@ -58,14 +62,15 @@ void LoadLibraryAndInitialize(const std::string& library_path,
   } else if (starboard::EndsWith(library_path, elf_loader::kZstdSuffix)) {
     compression_type = elf_loader::CompressionType::kZstd;
   }
-  if (!g_elf_loader.Load(library_path, content_path, /*is_relative_path=*/true,
-                         /*custom_get_extension=*/nullptr, compression_type)) {
+  if (!GetElfLoader().Load(
+          library_path, content_path, /*is_relative_path=*/true,
+          /*custom_get_extension=*/nullptr, compression_type)) {
     SB_NOTREACHED() << "Failed to load library at '"
-                    << g_elf_loader.GetLibraryPath() << "'.";
+                    << GetElfLoader().GetLibraryPath() << "'.";
     return;
   }
 
-  SB_LOG(INFO) << "Successfully loaded '" << g_elf_loader.GetLibraryPath()
+  SB_LOG(INFO) << "Successfully loaded '" << GetElfLoader().GetLibraryPath()
                << "'.";
 
   EvergreenInfo evergreen_info;
@@ -77,7 +82,7 @@ void LoadLibraryAndInitialize(const std::string& library_path,
   }
 
   auto get_evergreen_sabi_string_func = reinterpret_cast<const char* (*)()>(
-      g_elf_loader.LookupSymbol("GetEvergreenSabiString"));
+      GetElfLoader().LookupSymbol("GetEvergreenSabiString"));
 
   if (!CheckSabi(get_evergreen_sabi_string_func)) {
     SB_LOG(ERROR) << "CheckSabi failed";
@@ -85,10 +90,10 @@ void LoadLibraryAndInitialize(const std::string& library_path,
   }
 
   g_sb_event_func = reinterpret_cast<void (*)(const SbEvent*)>(
-      g_elf_loader.LookupSymbol("SbEventHandle"));
+      GetElfLoader().LookupSymbol("SbEventHandle"));
 
   auto get_user_agent_func = reinterpret_cast<const char* (*)()>(
-      g_elf_loader.LookupSymbol("GetCobaltUserAgentString"));
+      GetElfLoader().LookupSymbol("GetCobaltUserAgentString"));
   if (!get_user_agent_func) {
     SB_LOG(ERROR) << "Failed to get user agent string";
   } else {

--- a/starboard/loader_app/loader_app.cc
+++ b/starboard/loader_app/loader_app.cc
@@ -24,6 +24,7 @@
 #include "starboard/common/check_op.h"
 #include "starboard/common/command_line.h"
 #include "starboard/common/log.h"
+#include "starboard/common/no_destructor.h"
 #include "starboard/common/paths.h"
 #include "starboard/common/string.h"
 #include "starboard/configuration.h"
@@ -64,7 +65,10 @@ const char kSystemImageZstdCompressedLibraryPath[] =
 const char kSystemImageManifestPath[] = "app/cobalt/manifest.json";
 
 // Portable ELF loader.
-elf_loader::ElfLoader g_elf_loader;
+elf_loader::ElfLoader& GetElfLoader() {
+  static starboard::NoDestructor<elf_loader::ElfLoader> s_elf_loader;
+  return *s_elf_loader;
+}
 
 // Pointer to the |SbEventHandle| function in the
 // Cobalt binary.
@@ -76,12 +80,12 @@ class CobaltLibraryLoader : public loader_app::LibraryLoader {
                     const std::string& content_path,
                     elf_loader::CompressionType compression_type,
                     bool use_memory_mapped_file) {
-    return g_elf_loader.Load(library_path, content_path, false,
-                             &loader_app::SbSystemGetExtensionShim,
-                             compression_type, use_memory_mapped_file);
+    return GetElfLoader().Load(library_path, content_path, false,
+                               &loader_app::SbSystemGetExtensionShim,
+                               compression_type, use_memory_mapped_file);
   }
   virtual void* Resolve(const std::string& symbol) {
-    return g_elf_loader.LookupSymbol(symbol.c_str());
+    return GetElfLoader().LookupSymbol(symbol.c_str());
   }
 };
 
@@ -175,14 +179,14 @@ void LoadLibraryAndInitialize(const std::string& alternative_content_path,
     return;
   }
 
-  if (!g_elf_loader.Load(library_path, content_path, false, nullptr,
-                         compression_type, use_memory_mapped_file)) {
+  if (!GetElfLoader().Load(library_path, content_path, false, nullptr,
+                           compression_type, use_memory_mapped_file)) {
     SB_NOTREACHED() << "Failed to load library at '"
-                    << g_elf_loader.GetLibraryPath() << "'.";
+                    << GetElfLoader().GetLibraryPath() << "'.";
     return;
   }
 
-  SB_LOG(INFO) << "Successfully loaded '" << g_elf_loader.GetLibraryPath()
+  SB_LOG(INFO) << "Successfully loaded '" << GetElfLoader().GetLibraryPath()
                << "'.";
 
   EvergreenInfo evergreen_info;
@@ -194,7 +198,7 @@ void LoadLibraryAndInitialize(const std::string& alternative_content_path,
   }
 
   auto get_evergreen_sabi_string_func = reinterpret_cast<const char* (*)()>(
-      g_elf_loader.LookupSymbol("GetEvergreenSabiString"));
+      GetElfLoader().LookupSymbol("GetEvergreenSabiString"));
 
   if (!CheckSabi(get_evergreen_sabi_string_func)) {
     SB_LOG(ERROR) << "CheckSabi failed";
@@ -202,7 +206,7 @@ void LoadLibraryAndInitialize(const std::string& alternative_content_path,
   }
 
   auto get_user_agent_func = reinterpret_cast<const char* (*)()>(
-      g_elf_loader.LookupSymbol("GetCobaltUserAgentString"));
+      GetElfLoader().LookupSymbol("GetCobaltUserAgentString"));
   if (!get_user_agent_func) {
     SB_LOG(ERROR) << "Failed to get user agent string";
   } else {
@@ -218,7 +222,7 @@ void LoadLibraryAndInitialize(const std::string& alternative_content_path,
   }
 
   g_sb_event_func = reinterpret_cast<void (*)(const SbEvent*)>(
-      g_elf_loader.LookupSymbol("SbEventHandle"));
+      GetElfLoader().LookupSymbol("SbEventHandle"));
 
   if (!g_sb_event_func) {
     SB_LOG(ERROR) << "Failed to find SbEventHandle.";


### PR DESCRIPTION
### Summary
In single-process mode, InProcessRendererThread is intentionally released during termination (PR #11796) to avoid teardown deadlocks when task queues are throttled. However, because loader_app and elf_loader_sandbox held the global ElfLoader as a normal static object with automatic destruction, returning from main() caused ElfLoader's destructor to call munmap() on libcobalt.so's load range while InProcessRendererThread was still executing (e.g., handling V8 garbage collection triggered by memory pressure during conceal). This resulted in an instruction fetch page fault (SIGSEGV) on exit.

Wrapping the ElfLoader instance in starboard::NoDestructor prevents it from unmapping libcobalt.so during exit, allowing the operating system to cleanly reclaim the process memory space and terminate all threads.

### Testing
- Reproduced exit SIGSEGV and core dump on evergreen-x64_qa with loader_app.
- Symbolized crash trace pointing to v8::internal::Heap::IterateWeakRoots() on unmapped memory right after ProgramTable::~ProgramTable() unmapped libcobalt.so.
- Verified that with this change, loader_app exits cleanly with code 0 and zero segmentation faults or core dumps across multiple runs.
- Verified that loader_app and elf_loader_sandbox build cleanly.

Bug: 555199636
TAG=agy
CONV=ae349c26-3111-460f-a5f3-d2cb6fe2950c