### PR TITLE
media: Increase VideoFrameTracker capacity

### DIFF
--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -145,6 +145,11 @@ constexpr int kDefaultMaxPendingInputsSize = 128;
 // frames in the codec and renderer.
 constexpr int kVideoFrameTrackerMargin = 100;
 
+// Temporary capacity increase for VideoFrameTracker until the experiment for
+// backpressure fix (kMediaFixNeedMoreInputBackpressure) is completed.
+// TODO: b/539672039 - Remove this once the experiment is completed.
+constexpr int kVideoFrameTrackerCapacityWithoutBackpressureFix = 3'000;
+
 const int kFpsGuesstimateRequiredInputBufferCount = 3;
 
 // kPoolSize (20) is chosen to accommodate the maximum number of video frames
@@ -429,7 +434,9 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
 
   if (is_video_frame_tracker_enabled_) {
     video_frame_tracker_ = std::make_unique<VideoFrameTracker>(
-        max_pending_inputs_size_ + kVideoFrameTrackerMargin,
+        fix_need_more_input_backpressure_
+            ? max_pending_inputs_size_ + kVideoFrameTrackerMargin
+            : kVideoFrameTrackerCapacityWithoutBackpressureFix,
         ignore_stale_rendered_frames_after_seek_);
   }
 


### PR DESCRIPTION
When the backpressure fix experiment is disabled, the number of pending
input frames can reach approximately 2400+. This causes
VideoFrameTracker to overflow, leading to early frame eviction, log
spam regarding removed unexpected timestamps, and skewed dropped frame
telemetry.

This change increases the capacity to 3000 as a temporary workaround
until the experiment is completed.

Memory increase on 32-bit ARM (16 B per node):
- Previous capacity: 228 frames (228 * 16 B ≈ 3.6 KB)
- New capacity: 3,000 frames (3,000 * 16 B = 48 KB)
- Net memory increase: (3,000 - 228) * 16 B ≈ 44 KB

Bug: 515102461
