### PR TITLE
cobalt: Eliminate startup and resume white/red flashes

### DIFF
--- a/components/viz/service/display_embedder/image_context_impl.cc
+++ b/components/viz/service/display_embedder/image_context_impl.cc
@@ -6,6 +6,7 @@
 
 #include <utility>
 
+#include "build/build_config.h"
 #include "base/check.h"
 #include "base/check_op.h"
 #include "base/metrics/histogram_functions.h"
@@ -91,6 +92,34 @@ bool DawnYCbCrVkDescriptorsAreCompatible(const wgpu::YCbCrVkDescriptor& left,
 SkColor4f GetFallbackColorForPlane(viz::SharedImageFormat format,
                                    int plane_index) {
   DCHECK(format.IsValidPlaneIndex(plane_index));
+#if BUILDFLAG(IS_COBALT)
+  // In single-planar RGBA textures, SkColors::kBlack (0.0, 0.0, 0.0, 1.0) is
+  // opaque black.
+  // In multiplanar YUV formats, plane 0 is luma (Y), while subsequent planes
+  // are chroma (U, V) and optionally alpha (A). In normalized YUV, Y=0 is
+  // minimum brightness, but neutral chroma is at U=0.5, V=0.5. Filling chroma
+  // with 0.0 would introduce a strong green color cast in RGB. Filling Y with
+  // SkColors::kBlack (0.0), U/V with SkColors::kGray (0.5), and A with
+  // SkColors::kWhite (1.0) ensures multiplanar fallback textures decode to
+  // neutral opaque black.
+  if (format.is_single_plane()) {
+    return SkColors::kBlack;
+  }
+  switch (format.plane_config()) {
+    case viz::SharedImageFormat::PlaneConfig::kY_U_V:
+    case viz::SharedImageFormat::PlaneConfig::kY_V_U:
+    case viz::SharedImageFormat::PlaneConfig::kY_UV:
+      return plane_index == 0 ? SkColors::kBlack : SkColors::kGray;
+    case viz::SharedImageFormat::PlaneConfig::kY_U_V_A:
+      return plane_index == 0 ? SkColors::kBlack
+             : plane_index == 3 ? SkColors::kWhite
+                                : SkColors::kGray;
+    case viz::SharedImageFormat::PlaneConfig::kY_UV_A:
+      return plane_index == 0 ? SkColors::kBlack
+             : plane_index == 1 ? SkColors::kGray
+                                : SkColors::kWhite;
+  }
+#else
   // For DCHECKed builds return: 1) kRed for single planar formats; 2) kWhite
   // for all multiplanar format planes that translates to Purple/Magenta color
   // in RGB space. For non-DCHECKed builds return: 1) kWhite for single planar
@@ -113,6 +142,7 @@ SkColor4f GetFallbackColorForPlane(viz::SharedImageFormat format,
     case viz::SharedImageFormat::PlaneConfig::kY_UV_A:
       return plane_index == 1 ? SkColors::kGray : SkColors::kWhite;
   }
+#endif
 #endif
 }
 

--- a/content/browser/renderer_host/render_widget_host_view_base.cc
+++ b/content/browser/renderer_host/render_widget_host_view_base.cc
@@ -307,7 +307,11 @@ void RenderWidgetHostViewBase::SetBackgroundColor(SkColor color) {
 std::optional<SkColor> RenderWidgetHostViewBase::GetBackgroundColor() {
   if (content_background_color_)
     return content_background_color_;
+#if BUILDFLAG(IS_COBALT)
+  return default_background_color_.value_or(SK_ColorBLACK);
+#else
   return default_background_color_;
+#endif
 }
 
 bool RenderWidgetHostViewBase::IsBackgroundColorOpaque() {


### PR DESCRIPTION
Change the default background color in RenderWidgetHostViewBase and
the fallback texture color in ImageContextImpl to black.

On TV platforms, white flashes occur during cold starts before the
first layout is calculated. Additionally, red or white flashes
appear on resume when the Viz compositor lacks valid mailboxes
during reinitialization. Forcing these defaults to black ensures
a seamless transition until web content is ready to be displayed.

Bug: 489291655
Bug: 490989945
Bug: 549496958
Bug: 553317436
