### PR TITLE
Revert "tvos: Enable video splash by default"

### DIFF
--- a/cobalt/browser/features.cc
+++ b/cobalt/browser/features.cc
@@ -105,25 +105,18 @@ BASE_FEATURE(kDisableSplashScreen,
              "DisableSplashScreen",
              base::FEATURE_DISABLED_BY_DEFAULT);
 
-#if BUILDFLAG(IS_IOS_TVOS)
-BASE_FEATURE(kForceVideoSplashScreen,
-             "ForceVideoSplashScreen",
-             base::FEATURE_ENABLED_BY_DEFAULT);
-#else   // BUILDFLAG(IS_IOS_TVOS)
 BASE_FEATURE(kForceVideoSplashScreen,
              "ForceVideoSplashScreen",
              base::FEATURE_DISABLED_BY_DEFAULT);
-#endif  // BUILDFLAG(IS_IOS_TVOS)
 
+BASE_FEATURE(kEnablePictureInPicture,
+             "PictureInPicture",
 #if BUILDFLAG(IS_ANDROID)
-BASE_FEATURE(kEnablePictureInPicture,
-             "PictureInPicture",
-             base::FEATURE_ENABLED_BY_DEFAULT);
+             base::FEATURE_ENABLED_BY_DEFAULT
 #else   // BUILDFLAG(IS_ANDROID)
-BASE_FEATURE(kEnablePictureInPicture,
-             "PictureInPicture",
-             base::FEATURE_DISABLED_BY_DEFAULT);
+             base::FEATURE_DISABLED_BY_DEFAULT
 #endif  // BUILDFLAG(IS_ANDROID)
+);
 
 BASE_FEATURE(kCobaltNativeMemoryAblation,
              "CobaltNativeMemoryAblation",


### PR DESCRIPTION
Reverts youtube/cobalt#12312:

### Summary
Enables the `kForceVideoSplashScreen` feature by default on tvOS (`BUILDFLAG(IS_IOS_TVOS)`). This ensures video splash screens are used by default for Apple TV while keeping other platforms on the static splash screen default.

Additionally wraps entire `BASE_FEATURE` macro invocations in preprocessor conditionals for both `kForceVideoSplashScreen` and `kEnablePictureInPicture` to avoid directives within macro argument lists.

### Changes
* `cobalt/browser/features.cc`: Set default state of `kForceVideoSplashScreen` to enabled on tvOS.
* `cobalt/browser/features.cc`: Wrap entire `BASE_FEATURE` invocations in `#if` / `#else` / `#endif` blocks with proper trailing condition comments.
* Feature can still be dynamically overridden via Finch or command line arguments.

Bug: 555300007
TAG=agy
CONV=1cb38612-ff82-467d-94ed-daf0b6ed043f