### PR TITLE
Refactor command line switch parsing and sanitization in JavaSwitches

### DIFF
--- a/cobalt/android/BUILD.gn
+++ b/cobalt/android/BUILD.gn
@@ -325,6 +325,7 @@ robolectric_binary("cobalt_coat_junit_tests") {
     "apk/app/src/test/java/dev/cobalt/coat/PlatformErrorTest.java",
     "apk/app/src/test/java/dev/cobalt/coat/ShellManagerTest.java",
     "apk/app/src/test/java/dev/cobalt/media/MediaCodecOutputTrackerTest.java",
+    "apk/app/src/test/java/dev/cobalt/util/JavaSwitchesTest.java",
     "apk/app/src/test/java/dev/cobalt/util/StartupGuardTest.java",
   ]
   deps = [

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -15,6 +15,7 @@
 package dev.cobalt.util;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
@@ -22,6 +23,10 @@ import org.chromium.base.BuildInfo;
 
 /** Defines the constant names for feature switches used in Kimono. */
 public class JavaSwitches {
+  public static final String DEFAULT_INITIAL_OLD_SPACE_SIZE = "64";
+  public static final String DEFAULT_MAX_OLD_SPACE_SIZE = "512";
+  public static final String DEFAULT_FORCE_GPU_MEM_AVAILABLE_MB = "64";
+
   public static final String ENABLE_QUIC = "EnableQUIC";
   public static final String DISABLE_STARTUP_GUARD = "DisableStartupGuard";
   public static final String STARTUP_GUARD_INTERVAL_IN_SECONDS = "StartupGuardIntervalInSeconds";
@@ -139,6 +144,9 @@ public class JavaSwitches {
   public static final String V8_DISABLE_SPARKPLUG = "V8DisableSparkplug";
 
   public static List<String> getExtraCommandLineArgs(Map<String, String> javaSwitches) {
+    if (javaSwitches == null) {
+      javaSwitches = Collections.emptyMap();
+    }
     List<String> extraCommandLineArgs = new ArrayList<>();
     StringJoiner jsFlags = new StringJoiner(";");
 
@@ -155,62 +163,56 @@ public class JavaSwitches {
       jsFlags.add("--minor-ms-min-new-space-capacity-for-concurrent-marking-mb=0");
     }
 
-    String oldTimeStr = javaSwitches.get(JavaSwitches.V8_SET_BYTECODE_OLD_TIME);
-    if (oldTimeStr != null) {
-      String oldTime = oldTimeStr.replaceAll("[^0-9]", "");
-      if (!oldTime.isEmpty()) {
-        jsFlags.add("--flush-bytecode");
-        jsFlags.add("--bytecode-old-time=" + oldTime);
-      }
+    String oldTime = getSanitizedNumericValue(javaSwitches, JavaSwitches.V8_SET_BYTECODE_OLD_TIME);
+    if (oldTime != null) {
+      jsFlags.add("--flush-bytecode");
+      jsFlags.add("--bytecode-old-time=" + oldTime);
     }
 
-    if (javaSwitches.containsKey(JavaSwitches.V8_INITIAL_OLD_SPACE_SIZE)) {
-      jsFlags.add(
-          "--initial-old-space-size="
-              + javaSwitches.get(JavaSwitches.V8_INITIAL_OLD_SPACE_SIZE).replaceAll("[^0-9]", ""));
+    String initialOldSpace =
+        getSanitizedNumericValue(javaSwitches, JavaSwitches.V8_INITIAL_OLD_SPACE_SIZE);
+    if (initialOldSpace != null) {
+      jsFlags.add("--initial-old-space-size=" + initialOldSpace);
     } else {
-      jsFlags.add("--initial-old-space-size=64");
+      jsFlags.add("--initial-old-space-size=" + DEFAULT_INITIAL_OLD_SPACE_SIZE);
     }
 
     if (javaSwitches.containsKey(JavaSwitches.V8_DISABLE_SPARKPLUG)) {
       jsFlags.add("--no-sparkplug");
     }
 
-    if (javaSwitches.containsKey(JavaSwitches.V8_MAX_OLD_SPACE_SIZE)) {
-      jsFlags.add(
-          "--max-old-space-size="
-              + javaSwitches.get(JavaSwitches.V8_MAX_OLD_SPACE_SIZE).replaceAll("[^0-9]", ""));
+    String maxOldSpace = getSanitizedNumericValue(javaSwitches, JavaSwitches.V8_MAX_OLD_SPACE_SIZE);
+    if (maxOldSpace != null) {
+      jsFlags.add("--max-old-space-size=" + maxOldSpace);
     } else {
-      jsFlags.add("--max-old-space-size=512");
+      jsFlags.add("--max-old-space-size=" + DEFAULT_MAX_OLD_SPACE_SIZE);
     }
 
-    if (javaSwitches.containsKey(JavaSwitches.FORCE_GPU_MEM_AVAILABLE_MB)) {
-      extraCommandLineArgs.add(
-          "--force-gpu-mem-available-mb="
-              + javaSwitches.get(JavaSwitches.FORCE_GPU_MEM_AVAILABLE_MB).replaceAll("[^0-9]", ""));
+    String forceGpuMem =
+        getSanitizedNumericValue(javaSwitches, JavaSwitches.FORCE_GPU_MEM_AVAILABLE_MB);
+    if (forceGpuMem != null) {
+      extraCommandLineArgs.add("--force-gpu-mem-available-mb=" + forceGpuMem);
     } else if (!"arm64".equals(BuildInfo.getArch()) && !"x86_64".equals(BuildInfo.getArch())) {
-      extraCommandLineArgs.add("--force-gpu-mem-available-mb=64");
+      extraCommandLineArgs.add(
+          "--force-gpu-mem-available-mb=" + DEFAULT_FORCE_GPU_MEM_AVAILABLE_MB);
     }
 
     if (javaSwitches.containsKey(JavaSwitches.DISABLE_GPU_MEMORY_BUFFER_COMPOSITOR_RESOURCES)) {
       extraCommandLineArgs.add("--disable-gpu-memory-buffer-compositor-resources");
     }
 
-    if (javaSwitches.containsKey(JavaSwitches.GPU_IMAGE_CACHE_LIMIT_ITEMS)) {
-      String limit =
-          javaSwitches.get(JavaSwitches.GPU_IMAGE_CACHE_LIMIT_ITEMS).replaceAll("[^0-9]", "");
+    String limit = getSanitizedNumericValue(javaSwitches, JavaSwitches.GPU_IMAGE_CACHE_LIMIT_ITEMS);
+    if (limit != null) {
       extraCommandLineArgs.add("--cc-image-cache-limit-items=" + limit);
     }
-    if (javaSwitches.containsKey(JavaSwitches.LIMIT_IMAGE_DECODE_CACHE_SIZE_MB)) {
-      String limit =
-          javaSwitches.get(JavaSwitches.LIMIT_IMAGE_DECODE_CACHE_SIZE_MB).replaceAll("[^0-9]", "");
-      extraCommandLineArgs.add("--cc-image-cache-limit-mbs=" + limit);
+    String decodeLimit =
+        getSanitizedNumericValue(javaSwitches, JavaSwitches.LIMIT_IMAGE_DECODE_CACHE_SIZE_MB);
+    if (decodeLimit != null) {
+      extraCommandLineArgs.add("--cc-image-cache-limit-mbs=" + decodeLimit);
     }
-    if (javaSwitches.containsKey(JavaSwitches.DECODED_IMAGE_WORKING_SET_BUDGET_BYTES)) {
-      String budget =
-          javaSwitches
-              .get(JavaSwitches.DECODED_IMAGE_WORKING_SET_BUDGET_BYTES)
-              .replaceAll("[^0-9]", "");
+    String budget =
+        getSanitizedNumericValue(javaSwitches, JavaSwitches.DECODED_IMAGE_WORKING_SET_BUDGET_BYTES);
+    if (budget != null) {
       extraCommandLineArgs.add("--decoded-image-working-set-budget-bytes=" + budget);
     }
 
@@ -220,20 +222,16 @@ public class JavaSwitches {
 
     StringJoiner mojoPipeParams = new StringJoiner("/");
     String subresourceSize =
-        javaSwitches.get(JavaSwitches.COBALT_DYNAMIC_MOJO_PIPE_SUBRESOURCE_SIZE);
+        getSanitizedNumericValue(
+            javaSwitches, JavaSwitches.COBALT_DYNAMIC_MOJO_PIPE_SUBRESOURCE_SIZE);
     if (subresourceSize != null) {
-      String size = subresourceSize.replaceAll("[^0-9]", "");
-      if (!size.isEmpty()) {
-        mojoPipeParams.add("subresource_size/" + size);
-      }
+      mojoPipeParams.add("subresource_size/" + subresourceSize);
     }
 
-    String mediaSize = javaSwitches.get(JavaSwitches.COBALT_DYNAMIC_MOJO_PIPE_MEDIA_SIZE);
+    String mediaSize =
+        getSanitizedNumericValue(javaSwitches, JavaSwitches.COBALT_DYNAMIC_MOJO_PIPE_MEDIA_SIZE);
     if (mediaSize != null) {
-      String size = mediaSize.replaceAll("[^0-9]", "");
-      if (!size.isEmpty()) {
-        mojoPipeParams.add("media_size/" + size);
-      }
+      mojoPipeParams.add("media_size/" + mediaSize);
     }
 
     if (javaSwitches.containsKey(JavaSwitches.ENABLE_COBALT_DYNAMIC_MOJO_PIPE_SIZING)
@@ -247,16 +245,16 @@ public class JavaSwitches {
     }
 
     StringJoiner featureParams = new StringJoiner("/");
-    if (javaSwitches.containsKey(JavaSwitches.INTEREST_AREA_SIZE_IN_PIXELS)) {
-      String size =
-          javaSwitches.get(JavaSwitches.INTEREST_AREA_SIZE_IN_PIXELS).replaceAll("[^0-9]", "");
-      featureParams.add("size_in_pixels/" + size);
+    String interestAreaSize =
+        getSanitizedNumericValue(javaSwitches, JavaSwitches.INTEREST_AREA_SIZE_IN_PIXELS);
+    if (interestAreaSize != null) {
+      featureParams.add("size_in_pixels/" + interestAreaSize);
     }
 
-    if (javaSwitches.containsKey(JavaSwitches.RECLAIM_DELAY_IN_SECONDS)) {
-      String delay =
-          javaSwitches.get(JavaSwitches.RECLAIM_DELAY_IN_SECONDS).replaceAll("[^0-9]", "");
-      featureParams.add("reclaim_delay_s/" + delay);
+    String reclaimDelay =
+        getSanitizedNumericValue(javaSwitches, JavaSwitches.RECLAIM_DELAY_IN_SECONDS);
+    if (reclaimDelay != null) {
+      featureParams.add("reclaim_delay_s/" + reclaimDelay);
     }
 
     if (featureParams.length() > 0) {
@@ -275,14 +273,10 @@ public class JavaSwitches {
       extraCommandLineArgs.add("--enable-gpu-shader-disk-cache");
     }
 
-    if (javaSwitches.containsKey(JavaSwitches.MAX_HTTP_CACHE_SIZE)) {
-      String rawSize = javaSwitches.get(JavaSwitches.MAX_HTTP_CACHE_SIZE);
-      if (rawSize != null) {
-        String size = rawSize.replaceAll("[^0-9]", "");
-        if (!size.isEmpty()) {
-          extraCommandLineArgs.add("--max-http-cache-size=" + size);
-        }
-      }
+    String maxHttpCacheSize =
+        getSanitizedNumericValue(javaSwitches, JavaSwitches.MAX_HTTP_CACHE_SIZE);
+    if (maxHttpCacheSize != null) {
+      extraCommandLineArgs.add("--max-http-cache-size=" + maxHttpCacheSize);
     }
 
     if (javaSwitches.containsKey(JavaSwitches.ENABLE_CSS_AND_WASM_FOR_HTTP_CACHE)) {
@@ -342,5 +336,17 @@ public class JavaSwitches {
     }
 
     return extraCommandLineArgs;
+  }
+
+  private static String getSanitizedNumericValue(Map<String, String> javaSwitches, String key) {
+    if (javaSwitches == null) {
+      return null;
+    }
+    String val = javaSwitches.get(key);
+    if (val == null) {
+      return null;
+    }
+    String digits = val.replaceAll("[^0-9]", "");
+    return digits.isEmpty() ? null : digits;
   }
 }

--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/util/JavaSwitchesTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/util/JavaSwitchesTest.java
@@ -1,0 +1,172 @@
+// Copyright 2025 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dev.cobalt.util;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+/** Unit tests for {@link JavaSwitches}. */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class JavaSwitchesTest {
+
+  @Test
+  public void testGetExtraCommandLineArgs_NullSwitches() {
+    List<String> args = JavaSwitches.getExtraCommandLineArgs(null);
+    assertThat(args).isNotNull();
+    assertThat(args).contains("--disable-quic");
+  }
+
+  @Test
+  public void testGetExtraCommandLineArgs_EmptySwitches() {
+    Map<String, String> switches = new HashMap<>();
+    List<String> args = JavaSwitches.getExtraCommandLineArgs(switches);
+    assertThat(args).isNotNull();
+    assertThat(args).contains("--disable-quic");
+  }
+
+  @Test
+  public void testGetExtraCommandLineArgs_AppliesAllConfigs() {
+    Map<String, String> switches = new HashMap<>();
+    switches.put(JavaSwitches.ENABLE_DOM_STORAGE_SMART_FLUSHING, "1");
+    switches.put(JavaSwitches.ENABLE_QUIC, "1");
+    switches.put(JavaSwitches.USE_MINOR_MS_FOR_MINOR_GC, "1");
+    switches.put(JavaSwitches.V8_SET_BYTECODE_OLD_TIME, "10");
+    switches.put(JavaSwitches.V8_INITIAL_OLD_SPACE_SIZE, "128");
+    switches.put(JavaSwitches.V8_DISABLE_SPARKPLUG, "1");
+    switches.put(JavaSwitches.V8_MAX_OLD_SPACE_SIZE, "1024");
+    switches.put(JavaSwitches.FORCE_GPU_MEM_AVAILABLE_MB, "256");
+    switches.put(JavaSwitches.DISABLE_GPU_MEMORY_BUFFER_COMPOSITOR_RESOURCES, "1");
+    switches.put(JavaSwitches.GPU_IMAGE_CACHE_LIMIT_ITEMS, "500");
+    switches.put(JavaSwitches.LIMIT_IMAGE_DECODE_CACHE_SIZE_MB, "32");
+    switches.put(JavaSwitches.DECODED_IMAGE_WORKING_SET_BUDGET_BYTES, "1000000");
+    switches.put(JavaSwitches.ENABLE_SCALING_CLIPPED_IMAGES, "1");
+    switches.put(JavaSwitches.ENABLE_COBALT_DYNAMIC_MOJO_PIPE_SIZING, "1");
+    switches.put(JavaSwitches.COBALT_DYNAMIC_MOJO_PIPE_SUBRESOURCE_SIZE, "1024");
+    switches.put(JavaSwitches.COBALT_DYNAMIC_MOJO_PIPE_MEDIA_SIZE, "2048");
+    switches.put(JavaSwitches.INTEREST_AREA_SIZE_IN_PIXELS, "400");
+    switches.put(JavaSwitches.RECLAIM_DELAY_IN_SECONDS, "5");
+    switches.put(JavaSwitches.ENABLE_OPTIMIZED_FONT_LOADING, "1");
+    switches.put(JavaSwitches.DEFER_V8_CODE_CACHE_WRITE, "1");
+    switches.put(JavaSwitches.ENABLE_GPU_SHADER_DISK_CACHE, "1");
+    switches.put(JavaSwitches.MAX_HTTP_CACHE_SIZE, "50000000");
+    switches.put(JavaSwitches.ENABLE_CSS_AND_WASM_FOR_HTTP_CACHE, "1");
+    switches.put(JavaSwitches.ENABLE_HTTP_AND_V8_CACHE_TUNING, "1");
+    switches.put(JavaSwitches.AVOID_CC_REUSE_RESOURCE, "1");
+    switches.put(JavaSwitches.COBALT_BYPASS_RESOURCE_LOAD_SCHEDULER, "1");
+    switches.put(JavaSwitches.COBALT_BYPASS_HTML_PRELOAD_SCANNER, "1");
+    switches.put(JavaSwitches.ENABLE_COBALT_MMAP_FONT_CACHE, "1");
+    switches.put(JavaSwitches.DIRECT_WINDOW_RENDERING, "1");
+    switches.put(JavaSwitches.AREA_BASED_VIDEO_BUFFER_BUDGET, "1");
+    switches.put(JavaSwitches.ALLOW_CRITICAL_MEMORY_PRESSURE_HANDLING_IN_FOREGROUND, "1");
+    switches.put(JavaSwitches.EVICT_MEMORY_CACHE_ON_CRITICAL_MEMORY_PRESSURE, "1");
+    switches.put(JavaSwitches.DISABLE_LESS_AGGRESSIVE_PARKABLE_STRING, "1");
+    switches.put(JavaSwitches.DISABLE_BACK_FORWARD_CACHE, "1");
+
+    List<String> args = JavaSwitches.getExtraCommandLineArgs(switches);
+
+    assertThat(args).doesNotContain("--disable-quic");
+    assertThat(args).contains("--enable-features=DomStorageSmartFlushing");
+    assertThat(args).contains("--disable-gpu-memory-buffer-compositor-resources");
+    assertThat(args).contains("--force-gpu-mem-available-mb=256");
+    assertThat(args).contains("--cc-image-cache-limit-items=500");
+    assertThat(args).contains("--cc-image-cache-limit-mbs=32");
+    assertThat(args).contains("--decoded-image-working-set-budget-bytes=1000000");
+    assertThat(args).contains("--enable-scaling-clipped-images");
+    assertThat(args)
+        .contains(
+            "--enable-features=CobaltDynamicMojoPipeSizing:subresource_size/1024/media_size/2048");
+    assertThat(args)
+        .contains("--enable-features=SmallerInterestArea:size_in_pixels/400/reclaim_delay_s/5");
+    assertThat(args).contains("--enable-optimized-font-loading");
+    assertThat(args).contains("--defer-v8-code-cache-write");
+    assertThat(args).contains("--enable-gpu-shader-disk-cache");
+    assertThat(args).contains("--max-http-cache-size=50000000");
+    assertThat(args).contains("--enable-css-and-wasm-for-http-cache");
+    assertThat(args).contains("--enable-http-and-v8-cache-tuning");
+    assertThat(args).contains("--avoid-cc-reuse-resource");
+    assertThat(args).contains("--enable-features=CobaltBypassResourceLoadScheduler");
+    assertThat(args).contains("--enable-features=CobaltBypassHTMLPreloadScanner");
+    assertThat(args).contains("--enable-features=CobaltMmapFontCache");
+    assertThat(args).contains("--use-window-surface-for-ui");
+    assertThat(args).contains("--enable-features=AreaBasedVideoBufferBudget");
+    assertThat(args).contains("--allow-critical-memory-pressure-handling-in-foreground");
+    assertThat(args).contains("--enable-features=EvictMemoryCacheOnCriticalMemoryPressure");
+    assertThat(args).contains("--disable-features=LessAggressiveParkableString");
+    assertThat(args).contains("--disable-back-forward-cache");
+
+    // Check js-flags
+    boolean foundJsFlags = false;
+    for (String arg : args) {
+      if (arg.startsWith("--js-flags=")) {
+        foundJsFlags = true;
+        assertThat(arg).contains("--minor-ms");
+        assertThat(arg).contains("--minor-ms-min-new-space-capacity-for-concurrent-marking-mb=0");
+        assertThat(arg).contains("--flush-bytecode");
+        assertThat(arg).contains("--bytecode-old-time=10");
+        assertThat(arg).contains("--initial-old-space-size=128");
+        assertThat(arg).contains("--no-sparkplug");
+        assertThat(arg).contains("--max-old-space-size=1024");
+      }
+    }
+    assertThat(foundJsFlags).isTrue();
+  }
+
+  @Test
+  public void testGetExtraCommandLineArgs_NonNumericValuesInMap() {
+    Map<String, String> switches = new HashMap<>();
+    switches.put(JavaSwitches.V8_INITIAL_OLD_SPACE_SIZE, "invalid_128mb");
+    switches.put(JavaSwitches.MAX_HTTP_CACHE_SIZE, "xyz");
+
+    List<String> args = JavaSwitches.getExtraCommandLineArgs(switches);
+
+    boolean foundJsFlags = false;
+    for (String arg : args) {
+      if (arg.startsWith("--js-flags=")) {
+        foundJsFlags = true;
+        assertThat(arg).contains("--initial-old-space-size=128");
+      }
+    }
+    assertThat(foundJsFlags).isTrue();
+    for (String arg : args) {
+      assertThat(arg).doesNotContain("--max-http-cache-size=");
+    }
+  }
+
+  @Test
+  public void testGetExtraCommandLineArgs_NullValuesInMap() {
+    Map<String, String> switches = new HashMap<>();
+    switches.put(JavaSwitches.V8_INITIAL_OLD_SPACE_SIZE, null);
+    switches.put(JavaSwitches.COBALT_DYNAMIC_MOJO_PIPE_SUBRESOURCE_SIZE, null);
+
+    List<String> args = JavaSwitches.getExtraCommandLineArgs(switches);
+    boolean foundJsFlags = false;
+    for (String arg : args) {
+      if (arg.startsWith("--js-flags=")) {
+        foundJsFlags = true;
+        assertThat(arg)
+            .contains("--initial-old-space-size=" + JavaSwitches.DEFAULT_INITIAL_OLD_SPACE_SIZE);
+      }
+    }
+    assertThat(foundJsFlags).isTrue();
+  }
+}


### PR DESCRIPTION
Consolidate numeric switch sanitization using a helper method getSanitizedNumericValue(), define default switch constants, and add unit test coverage in JavaSwitchesTest.

Bug: 552583161