### PR TITLE
tvos: Filter failing NavigationBaseBrowserTest

### DIFF
--- a/cobalt/testing/filters/tvos-arm64-simulator/cobalt_browsertests_filter.json
+++ b/cobalt/testing/filters/tvos-arm64-simulator/cobalt_browsertests_filter.json
@@ -23,6 +23,7 @@
     "NavigationBaseBrowserTest.AddRequestHeaderModifyOnRedirect",
     "NavigationBaseBrowserTest.AddRequestHeaderOnRedirect",
     "NavigationBaseBrowserTest.ReplacingDocumentLoaderFiresLoadEvent",
+    "NavigationBaseBrowserTest.SrcDocCSPInheritedAfterCrossSiteHistoryNavigation",
     "NavigationBaseBrowserTest.SrcDocCSPInheritedAfterSameSiteHistoryNavigation",
     "NavigationBrowserTest*",
     "NavigationCookiesBrowserTest*",


### PR DESCRIPTION
### Summary
Temporarily disable `NavigationBaseBrowserTest.SrcDocCSPInheritedAfterCrossSiteHistoryNavigation` on the tvOS simulator (`tvos-arm64-simulator/cobalt_browsertests_filter.json`).

### Context & Root Cause
In commit 07dac0d2862937d17c3ba2129015d9d520e1a5eb (#12312), `kForceVideoSplashScreen` was enabled by default on tvOS (`BUILDFLAG(IS_IOS_TVOS)`). This causes video splash screen playback during browser tests, leading to an asynchronous teardown race on `BrowserProcessIOThread` with Mojo `SequenceLocalSyncEventWatcher` (`DCHECK failed: rv == 0 || rv == EBUSY. Invalid argument`).

Its same-site counterpart (`NavigationBaseBrowserTest.SrcDocCSPInheritedAfterSameSiteHistoryNavigation`) was previously disabled under b/433354983, but the cross-site variant was not included. Disabling this test unblocks the tvOS presubmit pipeline while the underlying splash video teardown issue is addressed.

Bug: 433354983
Bug: 555300007