### PR TITLE
evergreen: Build cobalt_loaded_content in Kokoro

### DIFF
--- a/cobalt/devinfra/kokoro/build/evergreen/arm-softfp/common.gcl
+++ b/cobalt/devinfra/kokoro/build/evergreen/arm-softfp/common.gcl
@@ -17,7 +17,7 @@ build = common.build {
     },
     {
       key = 'GN_TARGET'
-      value = 'cobalt copy_cobalt_lib crash_sandbox_loaded_content noop_sandbox_loaded_content one_app_only_sandbox_loaded_content'
+      value = 'cobalt cobalt_loaded_content crash_sandbox_loaded_content noop_sandbox_loaded_content one_app_only_sandbox_loaded_content'
     },
     {
       key = 'TARGET_CPU'

--- a/cobalt/devinfra/kokoro/build/evergreen/arm64/common.gcl
+++ b/cobalt/devinfra/kokoro/build/evergreen/arm64/common.gcl
@@ -13,7 +13,7 @@ build = common.build {
     },
     {
       key = 'GN_TARGET'
-      value = 'cobalt copy_cobalt_lib crash_sandbox_loaded_content noop_sandbox_loaded_content one_app_only_sandbox_loaded_content'
+      value = 'cobalt cobalt_loaded_content crash_sandbox_loaded_content noop_sandbox_loaded_content one_app_only_sandbox_loaded_content'
     },
     {
       key = 'PLATFORM'


### PR DESCRIPTION
This replaces the copy_cobalt_lib Kokoro build target with cobalt_loaded_content for evergreen's arm-softfp and arm64 architectures.

Unlike arm-hardfp-rdk and x64, these evergreen architectures do not have reference Starboard platforms and so cannot build cobalt:gn_all.

The copy_cobalt_lib action only generates libcobalt.lz4. cobalt_loaded_content is a group target that also runs the action to generate libcobalt.zst. With this change we should be able to revert PRs #12275 and #12290 and unblock our efforts to release Crx packages with libcobalt.zst binaries.

Issue: 534315298