### PR TITLE
ci: Add aosp_staging workflow

### DIFF
--- a/.github/workflows/aosp_staging.yaml
+++ b/.github/workflows/aosp_staging.yaml
@@ -1,0 +1,32 @@
+name: aosp_staging
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+    branches:
+      - staging
+      - autoroll-chromium/main-to-staging
+  push:
+    branches:
+      - staging
+  workflow_dispatch:
+    inputs:
+      nightly:
+        description: 'Nightly workflow.'
+        required: true
+        type: boolean
+        default: false
+
+permissions: read-all
+
+jobs:
+  aosp-arm:
+    uses: ./.github/workflows/main.yaml
+    permissions:
+      packages: write
+      pull-requests: write
+    with:
+      platform: aosp-arm
+      nightly: ${{ github.event.inputs.nightly }}
+    secrets:
+      datadog_api_key: ${{ secrets.DD_API_KEY }}


### PR DESCRIPTION
Add AOSP workflow configuration for the staging branch (`aosp_staging.yaml`) targeting `aosp-arm` so that CI workflows run on pull requests and pushes to `staging` and the `autoroll-chromium/main-to-staging` branch.

Bug: 495203133
TAG=agy
CONV=08574f7f-732d-4fdc-86b6-a88d2e511ac6