### PR TITLE
Move include in content_browser_client.h

### DIFF
--- a/content/public/browser/content_browser_client.h
+++ b/content/public/browser/content_browser_client.h
@@ -84,9 +84,6 @@
 #include "services/network/public/mojom/websocket.mojom-forward.h"
 #include "services/video_effects/public/cpp/buildflags.h"
 #include "storage/browser/file_system/file_system_context.h"
-#if BUILDFLAG(IS_COBALT)
-#include "storage/browser/quota/quota_settings.h"
-#endif
 #include "third_party/blink/public/common/mediastream/media_devices.h"
 #include "third_party/blink/public/common/user_agent/user_agent_metadata.h"
 #include "third_party/blink/public/mojom/ai/ai_manager.mojom-forward.h"
@@ -117,6 +114,10 @@
 #if !BUILDFLAG(IS_ANDROID)
 #include "third_party/blink/public/mojom/installedapp/related_application.mojom-forward.h"
 #endif  // !BUILDFLAG(IS_ANDROID)
+
+#if BUILDFLAG(IS_COBALT)
+#include "storage/browser/quota/quota_settings.h"
+#endif
 
 namespace net {
 class SiteForCookies;


### PR DESCRIPTION
This is a followup to PR #12209 that moves a guarded #include to below the main block

Bug: 532240315