### PR TITLE
media: Remove storage_type() from DecodedAudio

### DIFF
--- a/starboard/shared/starboard/player/decoded_audio_internal.cc
+++ b/starboard/shared/starboard/player/decoded_audio_internal.cc
@@ -294,7 +294,6 @@ bool operator==(const DecodedAudio& left, const DecodedAudio& right) {
   return left.timestamp() == right.timestamp() &&
          left.channels() == right.channels() &&
          left.sample_type() == right.sample_type() &&
-         left.storage_type() == right.storage_type() &&
          left.size_in_bytes() == right.size_in_bytes() &&
          memcmp(left.data(), right.data(), right.size_in_bytes()) == 0;
 }
@@ -310,8 +309,6 @@ std::ostream& operator<<(std::ostream& os, const DecodedAudio& decoded_audio) {
   return os << "timestamp: " << decoded_audio.timestamp()
             << ", channels: " << decoded_audio.channels() << ", sample type: "
             << GetMediaAudioSampleTypeName(decoded_audio.sample_type())
-            << ", storage type: "
-            << GetMediaAudioStorageTypeName(decoded_audio.storage_type())
             << ", frames: " << decoded_audio.frames();
 }
 

--- a/starboard/shared/starboard/player/decoded_audio_internal.h
+++ b/starboard/shared/starboard/player/decoded_audio_internal.h
@@ -52,10 +52,6 @@ class DecodedAudio {
 
   int channels() const { return channels_; }
   SbMediaAudioSampleType sample_type() const { return sample_type_; }
-  // TODO: b/272837615 - Remove temporary compatibility overloads.
-  SbMediaAudioFrameStorageType storage_type() const {
-    return kSbMediaAudioFrameStorageTypeInterleaved;
-  }
 
   bool is_end_of_stream() const { return channels_ == 0; }
   int64_t timestamp() const { return timestamp_; }

--- a/starboard/shared/starboard/player/decoded_audio_test_internal.cc
+++ b/starboard/shared/starboard/player/decoded_audio_test_internal.cc
@@ -164,8 +164,6 @@ TEST(DecodedAudioTest, CtorWithSize) {
     EXPECT_FALSE(decoded_audio.is_end_of_stream());
     EXPECT_EQ(decoded_audio.channels(), kChannels);
     EXPECT_EQ(decoded_audio.sample_type(), sample_type);
-    EXPECT_EQ(decoded_audio.storage_type(),
-              kSbMediaAudioFrameStorageTypeInterleaved);
     EXPECT_EQ(decoded_audio.size_in_bytes(), kSizeInBytes);
     EXPECT_EQ(decoded_audio.frames(),
               kSizeInBytes / GetBytesPerSample(decoded_audio.sample_type()) /
@@ -409,7 +407,6 @@ TEST(DecodedAudioTest, MoveConstructor) {
   const uint8_t* original_data = original.data();
   int original_channels = original.channels();
   auto original_sample_type = original.sample_type();
-  auto original_storage_type = original.storage_type();
   int64_t original_timestamp = original.timestamp();
   int original_size = original.size_in_bytes();
 
@@ -418,7 +415,6 @@ TEST(DecodedAudioTest, MoveConstructor) {
   EXPECT_EQ(moved.data(), original_data);
   EXPECT_EQ(moved.channels(), original_channels);
   EXPECT_EQ(moved.sample_type(), original_sample_type);
-  EXPECT_EQ(moved.storage_type(), original_storage_type);
   EXPECT_EQ(moved.timestamp(), original_timestamp);
   EXPECT_EQ(moved.size_in_bytes(), original_size);
   Verify(moved);
@@ -438,7 +434,6 @@ TEST(DecodedAudioTest, MoveAssignment) {
   const uint8_t* original_data = original.data();
   int original_channels = original.channels();
   auto original_sample_type = original.sample_type();
-  auto original_storage_type = original.storage_type();
   int64_t original_timestamp = original.timestamp();
   int original_size = original.size_in_bytes();
 
@@ -448,7 +443,6 @@ TEST(DecodedAudioTest, MoveAssignment) {
   EXPECT_EQ(moved.data(), original_data);
   EXPECT_EQ(moved.channels(), original_channels);
   EXPECT_EQ(moved.sample_type(), original_sample_type);
-  EXPECT_EQ(moved.storage_type(), original_storage_type);
   EXPECT_EQ(moved.timestamp(), original_timestamp);
   EXPECT_EQ(moved.size_in_bytes(), original_size);
   Verify(moved);

--- a/starboard/shared/starboard/player/filter/adaptive_audio_decoder_internal.cc
+++ b/starboard/shared/starboard/player/filter/adaptive_audio_decoder_internal.cc
@@ -162,8 +162,6 @@ std::optional<DecodedAudio> AdaptiveAudioDecoder::Read(
   SB_DCHECK(ret->is_end_of_stream() ||
             ret->sample_type() == output_sample_type_);
   SB_DCHECK(ret->is_end_of_stream() ||
-            ret->storage_type() == output_storage_type_);
-  SB_DCHECK(ret->is_end_of_stream() ||
             ret->channels() == output_number_of_channels_);
 
   SB_DCHECK(first_output_received_ || ret->is_end_of_stream());
@@ -237,10 +235,9 @@ void AdaptiveAudioDecoder::OnDecoderOutput() {
   if (!first_output_received_) {
     first_output_received_ = true;
     output_sample_type_ = decoded_audio->sample_type();
-    output_storage_type_ = decoded_audio->storage_type();
     output_samples_per_second_ = decoded_sample_rate;
     if (output_adjustment_callback_) {
-      output_adjustment_callback_(&output_sample_type_, &output_storage_type_,
+      output_adjustment_callback_(&output_sample_type_,
                                   &output_samples_per_second_,
                                   &output_number_of_channels_);
     }
@@ -289,8 +286,7 @@ void AdaptiveAudioDecoder::OnDecoderOutput() {
     if (input_audio_stream_info_.number_of_channels !=
         output_number_of_channels_) {
       channel_mixer_ = AudioChannelLayoutMixer::Create(
-          output_sample_type_, output_storage_type_,
-          output_number_of_channels_);
+          output_sample_type_, output_number_of_channels_);
     }
   }
   if (resampler_) {

--- a/starboard/shared/starboard/player/filter/adaptive_audio_decoder_internal.h
+++ b/starboard/shared/starboard/player/filter/adaptive_audio_decoder_internal.h
@@ -37,7 +37,6 @@ class AdaptiveAudioDecoder : public AudioDecoder, private JobQueue::JobOwner {
       AudioDecoderCreator;
 
   typedef std::function<void(SbMediaAudioSampleType* output_sample_type,
-                             SbMediaAudioFrameStorageType* output_storage_type,
                              int* output_samples_per_second,
                              int* output_number_of_channels)>
       OutputFormatAdjustmentCallback;
@@ -75,7 +74,6 @@ class AdaptiveAudioDecoder : public AudioDecoder, private JobQueue::JobOwner {
   const AudioDecoderCreator audio_decoder_creator_;
   const OutputFormatAdjustmentCallback output_adjustment_callback_;
   SbMediaAudioSampleType output_sample_type_;
-  SbMediaAudioFrameStorageType output_storage_type_;
   int output_samples_per_second_;
   int output_number_of_channels_;
   AudioStreamInfo input_audio_stream_info_;

--- a/starboard/shared/starboard/player/filter/audio_channel_layout_mixer.h
+++ b/starboard/shared/starboard/player/filter/audio_channel_layout_mixer.h
@@ -32,7 +32,6 @@ class AudioChannelLayoutMixer {
 
   static std::unique_ptr<AudioChannelLayoutMixer> Create(
       SbMediaAudioSampleType sample_type,
-      SbMediaAudioFrameStorageType storage_type,
       int output_channels);
 };
 

--- a/starboard/shared/starboard/player/filter/audio_channel_layout_mixer_impl.cc
+++ b/starboard/shared/starboard/player/filter/audio_channel_layout_mixer_impl.cc
@@ -157,27 +157,13 @@ const float kFivePointOneToQuadMatrix[] = {
     1.0f,
 };
 
-// Get the samples of frames at |frame_index|.  If |input| is already
-// interleaved, the return pointer points to the buffer contained inside
-// |input|. If |input| is planar, it will copy all samples into |aux_buffer| and
-// return |aux_buffer| instead.  Note that |aux_buffer| should be large enough
-// to hold samples from all channels of the frame.
+// Get the samples of frames at |frame_index|.
 template <typename SampleType>
 const SampleType* GetInterleavedSamplesOfFrame(const DecodedAudio& input,
-                                               int frame_index,
-                                               SampleType* aux_buffer) {
+                                               int frame_index) {
   const SampleType* input_buffer =
       reinterpret_cast<const SampleType*>(input.data());
-  if (input.storage_type() == kSbMediaAudioFrameStorageTypeInterleaved) {
-    return input_buffer + frame_index * input.channels();
-  }
-  SB_DCHECK_EQ(input.storage_type(), kSbMediaAudioFrameStorageTypePlanar);
-  for (int channel_index = 0; channel_index < input.channels();
-       channel_index++) {
-    aux_buffer[channel_index] =
-        input_buffer[channel_index * input.frames() + frame_index];
-  }
-  return aux_buffer;
+  return input_buffer + frame_index * input.channels();
 }
 
 template <typename SampleType>
@@ -187,16 +173,8 @@ void StoreInterleavedSamplesOfFrame(const SampleType* samples,
   SampleType* dest_buffer = reinterpret_cast<SampleType*>(destination->data());
   for (int channel_index = 0; channel_index < destination->channels();
        channel_index++) {
-    if (destination->storage_type() ==
-        kSbMediaAudioFrameStorageTypeInterleaved) {
-      dest_buffer[frame_index * destination->channels() + channel_index] =
-          samples[channel_index];
-    } else {
-      SB_DCHECK_EQ(destination->storage_type(),
-                   kSbMediaAudioFrameStorageTypePlanar);
-      dest_buffer[channel_index * destination->frames() + frame_index] =
-          samples[channel_index];
-    }
+    dest_buffer[frame_index * destination->channels() + channel_index] =
+        samples[channel_index];
   }
 }
 
@@ -243,7 +221,6 @@ void MixFrameWithMatrix(const SampleType* input_frame,
 class AudioChannelLayoutMixerImpl : public AudioChannelLayoutMixer {
  public:
   AudioChannelLayoutMixerImpl(SbMediaAudioSampleType sample_type,
-                              SbMediaAudioFrameStorageType storage_type,
                               int output_channels);
 
   DecodedAudio Mix(DecodedAudio input) override;
@@ -255,23 +232,16 @@ class AudioChannelLayoutMixerImpl : public AudioChannelLayoutMixer {
   DecodedAudio MixMonoToStereoOptimized(const DecodedAudio& input);
 
   SbMediaAudioSampleType sample_type_;
-  // TODO: b/272837615 - Remove storage_type_ and planar branches, once
-  // planar storage type cleanup is completed.
-  SbMediaAudioFrameStorageType storage_type_;
   int output_channels_;
 };
 
 AudioChannelLayoutMixerImpl::AudioChannelLayoutMixerImpl(
     SbMediaAudioSampleType sample_type,
-    SbMediaAudioFrameStorageType storage_type,
     int output_channels)
-    : sample_type_(sample_type),
-      storage_type_(storage_type),
-      output_channels_(output_channels) {}
+    : sample_type_(sample_type), output_channels_(output_channels) {}
 
 DecodedAudio AudioChannelLayoutMixerImpl::Mix(DecodedAudio input) {
   SB_DCHECK_EQ(input.sample_type(), sample_type_);
-  SB_DCHECK_EQ(input.storage_type(), storage_type_);
 
   if (input.channels() == output_channels_) {
     return input;
@@ -338,11 +308,10 @@ DecodedAudio AudioChannelLayoutMixerImpl::Mix(const DecodedAudio& input,
   DecodedAudio output(
       output_channels_, sample_type_, input.timestamp(),
       frames * output_channels_ * GetBytesPerSample(sample_type_));
-  SampleType aux_buffer[8];
   SampleType output_buffer[8];
   for (size_t frame_index = 0; frame_index < frames; frame_index++) {
     const SampleType* interleavedSamplesOfFrame =
-        GetInterleavedSamplesOfFrame(input, frame_index, aux_buffer);
+        GetInterleavedSamplesOfFrame<SampleType>(input, frame_index);
     MixFrameWithMatrix(interleavedSamplesOfFrame, input.channels(), matrix,
                        output_buffer, output_channels_);
     StoreInterleavedSamplesOfFrame(output_buffer, &output, frame_index);
@@ -357,24 +326,17 @@ DecodedAudio AudioChannelLayoutMixerImpl::MixMonoToStereoOptimized(
 
   DecodedAudio output(output_channels_, sample_type_, input.timestamp(),
                       input.size_in_bytes() * 2);
-  if (storage_type_ == kSbMediaAudioFrameStorageTypeInterleaved) {
-    size_t frames_left = input.frames();
-    size_t bytes_per_sample = GetBytesPerSample(sample_type_);
-    const uint8_t* src_buffer_ptr = input.data();
-    uint8_t* dest_buffer_ptr = output.data();
-    while (frames_left > 0) {
-      memcpy(dest_buffer_ptr, src_buffer_ptr, bytes_per_sample);
-      dest_buffer_ptr += bytes_per_sample;
-      memcpy(dest_buffer_ptr, src_buffer_ptr, bytes_per_sample);
-      dest_buffer_ptr += bytes_per_sample;
-      src_buffer_ptr += bytes_per_sample;
-      frames_left--;
-    }
-  } else {
-    SB_DCHECK_EQ(storage_type_, kSbMediaAudioFrameStorageTypePlanar);
-    memcpy(output.data(), input.data(), input.size_in_bytes());
-    memcpy(output.data() + input.size_in_bytes(), input.data(),
-           input.size_in_bytes());
+  size_t frames_left = input.frames();
+  size_t bytes_per_sample = GetBytesPerSample(sample_type_);
+  const uint8_t* src_buffer_ptr = input.data();
+  uint8_t* dest_buffer_ptr = output.data();
+  while (frames_left > 0) {
+    memcpy(dest_buffer_ptr, src_buffer_ptr, bytes_per_sample);
+    dest_buffer_ptr += bytes_per_sample;
+    memcpy(dest_buffer_ptr, src_buffer_ptr, bytes_per_sample);
+    dest_buffer_ptr += bytes_per_sample;
+    src_buffer_ptr += bytes_per_sample;
+    frames_left--;
   }
   return output;
 }
@@ -384,11 +346,9 @@ DecodedAudio AudioChannelLayoutMixerImpl::MixMonoToStereoOptimized(
 // static
 std::unique_ptr<AudioChannelLayoutMixer> AudioChannelLayoutMixer::Create(
     SbMediaAudioSampleType sample_type,
-    SbMediaAudioFrameStorageType storage_type,
     int output_channels) {
-  return std::unique_ptr<AudioChannelLayoutMixer>(
-      new AudioChannelLayoutMixerImpl(sample_type, storage_type,
-                                      output_channels));
+  return std::make_unique<AudioChannelLayoutMixerImpl>(sample_type,
+                                                       output_channels);
 }
 
 }  // namespace starboard

--- a/starboard/shared/starboard/player/filter/audio_renderer_pcm_internal.cc
+++ b/starboard/shared/starboard/player/filter/audio_renderer_pcm_internal.cc
@@ -568,7 +568,6 @@ void AudioRendererPcm::UpdateVariablesOnSinkThread_Locked(
 
 void AudioRendererPcm::OnFirstOutput(
     const SbMediaAudioSampleType decoded_sample_type,
-    const SbMediaAudioFrameStorageType decoded_storage_type,
     const int decoded_sample_rate) {
   SB_CHECK(BelongsToCurrentThread());
   SB_DCHECK(!decoder_sample_rate_);
@@ -667,8 +666,7 @@ void AudioRendererPcm::ProcessAudioData() {
         decoded_audio->AdjustForSeekTime(decoded_audio_sample_rate,
                                          seeking_to_time_);
       }
-      OnFirstOutput(decoded_audio->sample_type(), decoded_audio->storage_type(),
-                    decoded_audio_sample_rate);
+      OnFirstOutput(decoded_audio->sample_type(), decoded_audio_sample_rate);
     }
     SB_DCHECK(resampler_);
 

--- a/starboard/shared/starboard/player/filter/audio_renderer_pcm_internal.h
+++ b/starboard/shared/starboard/player/filter/audio_renderer_pcm_internal.h
@@ -149,7 +149,6 @@ class AudioRendererPcm : public AudioRenderer,
       int64_t system_time_on_consume_frames);
 
   void OnFirstOutput(const SbMediaAudioSampleType decoded_sample_type,
-                     const SbMediaAudioFrameStorageType decoded_storage_type,
                      const int decoded_sample_rate);
   bool IsEndOfStreamPlayed_Locked() const;
 

--- a/starboard/shared/starboard/player/filter/decoded_audio_queue.cc
+++ b/starboard/shared/starboard/player/filter/decoded_audio_queue.cc
@@ -39,8 +39,6 @@ void DecodedAudioQueue::Clear() {
 }
 
 void DecodedAudioQueue::Append(DecodedAudio&& decoded_audio) {
-  SB_DCHECK_EQ(decoded_audio.storage_type(),
-               kSbMediaAudioFrameStorageTypeInterleaved);
   // Update the |frames_| counter since we have added frames.
   frames_ += decoded_audio.frames();
   SB_CHECK_GT(frames_, 0);  // make sure it doesn't overflow.

--- a/starboard/shared/starboard/player/filter/testing/audio_channel_layout_mixer_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_channel_layout_mixer_test.cc
@@ -99,7 +99,6 @@ class AudioChannelLayoutMixerTest
                                     const float* expected_output) {
     ASSERT_EQ(output_num_of_channels, output.channels());
     ASSERT_EQ(input.sample_type(), output.sample_type());
-    ASSERT_EQ(input.storage_type(), output.storage_type());
     ASSERT_EQ(input.timestamp(), output.timestamp());
     ASSERT_EQ(input.size_in_bytes() * output.channels(),
               output.size_in_bytes() * input.channels());
@@ -134,8 +133,6 @@ class AudioChannelLayoutMixerTest
   }
 
   SbMediaAudioSampleType sample_type_;
-  SbMediaAudioFrameStorageType storage_type_ =
-      kSbMediaAudioFrameStorageTypeInterleaved;
 };
 
 std::string GetAudioChannelLayoutMixerTestConfigName(
@@ -147,7 +144,7 @@ std::string GetAudioChannelLayoutMixerTestConfigName(
 
 TEST_P(AudioChannelLayoutMixerTest, MixToMono) {
   std::unique_ptr<AudioChannelLayoutMixer> mixer =
-      AudioChannelLayoutMixer::Create(sample_type_, storage_type_, 1);
+      AudioChannelLayoutMixer::Create(sample_type_, 1);
   ASSERT_TRUE(mixer);
 
   const float kExpectedMonoToMonoOutput[] = {
@@ -186,7 +183,7 @@ TEST_P(AudioChannelLayoutMixerTest, MixToMono) {
 
 TEST_P(AudioChannelLayoutMixerTest, MixToStereo) {
   std::unique_ptr<AudioChannelLayoutMixer> mixer =
-      AudioChannelLayoutMixer::Create(sample_type_, storage_type_, 2);
+      AudioChannelLayoutMixer::Create(sample_type_, 2);
   ASSERT_TRUE(mixer);
 
   const float kExpectedMonoToStereoOutput[] = {
@@ -225,7 +222,7 @@ TEST_P(AudioChannelLayoutMixerTest, MixToStereo) {
 
 TEST_P(AudioChannelLayoutMixerTest, MixToQuad) {
   std::unique_ptr<AudioChannelLayoutMixer> mixer =
-      AudioChannelLayoutMixer::Create(sample_type_, storage_type_, 4);
+      AudioChannelLayoutMixer::Create(sample_type_, 4);
   ASSERT_TRUE(mixer);
 
   const float kExpectedMonoToQuadOutput[] = {
@@ -269,7 +266,7 @@ TEST_P(AudioChannelLayoutMixerTest, MixToQuad) {
 
 TEST_P(AudioChannelLayoutMixerTest, MixToFivePointOne) {
   std::unique_ptr<AudioChannelLayoutMixer> mixer =
-      AudioChannelLayoutMixer::Create(sample_type_, storage_type_, 6);
+      AudioChannelLayoutMixer::Create(sample_type_, 6);
   ASSERT_TRUE(mixer);
 
   const float kExpectedMonoToFivePointOneOutput[] = {

--- a/starboard/shared/starboard/player/filter/testing/audio_decoder_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_decoder_test.cc
@@ -66,8 +66,6 @@ DecodedAudio ConsolidateDecodedAudios(
   for (const auto& decoded_audio : decoded_audios) {
     SB_DCHECK_EQ(decoded_audio.channels(), channels);
     SB_DCHECK_EQ(decoded_audio.sample_type(), sample_type);
-    SB_DCHECK_EQ(decoded_audio.storage_type(),
-                 kSbMediaAudioFrameStorageTypeInterleaved);
     total_size_in_bytes += decoded_audio.size_in_bytes();
   }
 
@@ -826,8 +824,6 @@ TEST_P(AudioDecoderTest, PartialAudio) {
 
     ASSERT_EQ(reference_decoded_audio.sample_type(),
               partial_decoded_audio.sample_type());
-    ASSERT_EQ(reference_decoded_audio.storage_type(),
-              partial_decoded_audio.storage_type());
     ASSERT_GT(reference_decoded_audio.frames(), partial_decoded_audio.frames());
 
     auto bytes_per_frame = reference_decoded_audio.size_in_bytes() /


### PR DESCRIPTION
This is part of the effort to remove kSbMediaAudioFrameStorageTypePlanar from 1P implementation.

DecodedAudio is always in interleaved format. This change removes the storage_type() accessor method from DecodedAudio, removes unused output_storage_type_ from AdaptiveAudioDecoder, simplifies audio channel layout mixing to direct interleaved indexing, and cleans up all related call sites and test assertions.

Bug: 272837615