### PR TITLE
starboard: Replace SB_UNREFERENCED_PARAMETER with commented-out parameters

### DIFF
--- a/starboard/android/shared/media_codec_audio_decoder.cc
+++ b/starboard/android/shared/media_codec_audio_decoder.cc
@@ -236,8 +236,7 @@ Result<void> MediaCodecAudioDecoder::InitializeCodec() {
 void MediaCodecAudioDecoder::ProcessOutputBuffer(
     MediaCodec* media_codec_bridge,
     const DequeueOutputResult& dequeue_output_result,
-    int number_of_pending_inputs) {
-  SB_UNREFERENCED_PARAMETER(number_of_pending_inputs);
+    int /*number_of_pending_inputs*/) {
   SB_DCHECK(media_codec_bridge);
   SB_DCHECK(output_cb_);
   SB_DCHECK_GE(dequeue_output_result.index, 0);

--- a/starboard/configuration.h
+++ b/starboard/configuration.h
@@ -128,6 +128,9 @@ struct CompileAssert {};
 #endif
 #endif  // SB_PRINTF_FORMAT
 
+// Deprecated: Per the Google C++ Style Guide, comment out unused parameter
+// names (e.g., `void* /*context*/` or `Type /*param_name*/`), or use
+// `[[maybe_unused]]` if conditionally unused.
 // Trivially references a parameter that is otherwise unreferenced, preventing a
 // compiler warning on some platforms.
 #if !defined(SB_UNREFERENCED_PARAMETER)

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/audio_sink/gstreamer_audio_sink_type.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/audio_sink/gstreamer_audio_sink_type.cc
@@ -289,11 +289,9 @@ void* GStreamerAudioSink::AudioThreadEntryPoint(void* context) {
 }
 
 // static
-gboolean GStreamerAudioSink::BusMessageCallback(GstBus* bus,
+gboolean GStreamerAudioSink::BusMessageCallback(GstBus* /*bus*/,
                                                 GstMessage* message,
                                                 gpointer user_data) {
-  SB_UNREFERENCED_PARAMETER(bus);
-
   GStreamerAudioSink* sink = static_cast<GStreamerAudioSink*>(user_data);
 
   GST_TRACE_OBJECT(sink->pipeline_, "TID: %d", gettid());
@@ -353,11 +351,9 @@ gboolean GStreamerAudioSink::BusMessageCallback(GstBus* bus,
 }
 
 // static
-void GStreamerAudioSink::AppSrcNeedData(GstAppSrc* src,
+void GStreamerAudioSink::AppSrcNeedData(GstAppSrc* /*src*/,
                                         guint length,
                                         gpointer user_data) {
-  SB_UNREFERENCED_PARAMETER(src);
-
   GStreamerAudioSink* sink = reinterpret_cast<GStreamerAudioSink*>(user_data);
 
   GST_TRACE_OBJECT(sink->pipeline_, "TID: %d", gettid());
@@ -461,8 +457,8 @@ void GStreamerAudioSink::AppSrcNeedData(GstAppSrc* src,
 }
 
 // static
-void GStreamerAudioSink::AppSrcEnoughData(GstAppSrc* src, gpointer user_data) {
-  SB_UNREFERENCED_PARAMETER(src);
+void GStreamerAudioSink::AppSrcEnoughData(GstAppSrc* /*src*/,
+                                          gpointer user_data) {
   GStreamerAudioSink* sink = static_cast<GStreamerAudioSink*>(user_data);
 
   sink->enough_data_ = true;
@@ -470,12 +466,11 @@ void GStreamerAudioSink::AppSrcEnoughData(GstAppSrc* src, gpointer user_data) {
 }
 
 // static
-void GStreamerAudioSink::AutoAudioSinkChildAddedCallback(GstChildProxy* obj,
-                                                         GObject* object,
-                                                         gchar* name,
-                                                         gpointer user_data) {
-  SB_UNREFERENCED_PARAMETER(obj);
-  SB_UNREFERENCED_PARAMETER(name);
+void GStreamerAudioSink::AutoAudioSinkChildAddedCallback(
+    GstChildProxy* /*obj*/,
+    GObject* object,
+    gchar* /*name*/,
+    gpointer user_data) {
   GStreamerAudioSink* sink = static_cast<GStreamerAudioSink*>(user_data);
   if (GST_IS_AUDIO_BASE_SINK(object)) {
     static constexpr int kLatencyTimeValue = 50;

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/media/media_get_video_buffer_budget.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/media/media_get_video_buffer_budget.cc
@@ -16,11 +16,10 @@
 
 #include "starboard/common/log.h"
 
-int SbMediaGetVideoBufferBudget(SbMediaVideoCodec codec,
+int SbMediaGetVideoBufferBudget(SbMediaVideoCodec /*codec*/,
                                 int resolution_width,
                                 int resolution_height,
                                 int bits_per_pixel) {
-  SB_UNREFERENCED_PARAMETER(codec);
   if ((resolution_width <= 1920 && resolution_height <= 1080) ||
       resolution_width == kSbMediaVideoResolutionDimensionInvalid ||
       resolution_height == kSbMediaVideoResolutionDimensionInvalid) {

--- a/starboard/shared/starboard/audio_sink/audio_sink_internal.cc
+++ b/starboard/shared/starboard/audio_sink/audio_sink_internal.cc
@@ -38,9 +38,8 @@ const char kUseStubAudioSink[] = "use_stub_audio_sink";
 
 void WrapConsumeFramesFunc(SbAudioSinkConsumeFramesFunc sb_consume_frames_func,
                            int frames_consumed,
-                           int64_t frames_consumed_at,
+                           int64_t /*frames_consumed_at*/,
                            void* context) {
-  SB_UNREFERENCED_PARAMETER(frames_consumed_at);
   sb_consume_frames_func(frames_consumed, context);
 }
 


### PR DESCRIPTION
Per the Google C++ Style Guide, parameters that are definitely unused should have their parameter names commented out in the function definition (e.g. `void* /*context*/` or `Type /*param_name*/`).

This change replaces occurrences of SB_UNREFERENCED_PARAMETER in parameter declarations with commented-out parameter names, and deprecates the SB_UNREFERENCED_PARAMETER macro in configuration.h.

Bug: 556312247