### PR TITLE
Check GL_RENDERER for ANGLE when querying requestable extensions

### DIFF
--- a/ui/gl/gl_implementation.cc
+++ b/ui/gl/gl_implementation.cc
@@ -503,8 +503,15 @@ gfx::ExtensionSet GetRequestableGLExtensionsFromCurrentContext() {
 
 gfx::ExtensionSet GetRequestableGLExtensionsFromCurrentContext(GLApi* api) {
 #if BUILDFLAG(IS_COBALT)
-  if (!api || GetGLImplementation() != kGLImplementationEGLANGLE)
+  if (!api)
     return gfx::ExtensionSet();
+
+  const char* renderer_str =
+      reinterpret_cast<const char*>(api->glGetStringFn(GL_RENDERER));
+  if (!renderer_str ||
+      !base::StartsWith(renderer_str, "ANGLE", base::CompareCase::SENSITIVE)) {
+    return gfx::ExtensionSet();
+  }
 #endif
   return GetGLExtensionsFromCurrentContext(api,
                                            GL_REQUESTABLE_EXTENSIONS_ANGLE);


### PR DESCRIPTION
Starboard Ozone reports kGLImplementationEGLANGLE to satisfy passthrough
command decoder constraints even when running directly on native GLES
drivers (such as ARM Mali). Checking GetGLImplementation() therefore
incorrectly identifies native GLES contexts as ANGLE and attempts to
query GL_REQUESTABLE_EXTENSIONS_ANGLE (0x93A8), generating a GL_INVALID_ENUM
error.

Inspect glGetString(GL_RENDERER) directly to determine whether the
underlying driver is truly ANGLE before querying requestable extensions.
This keeps the GL error state clean and prevents subsequent fatal
glGetError() DCHECK aborts during context initialization.

Bug: 537056801