### PR TITLE
FIXES Cherry pick PR #12134: cobalt: Implement zero-copy in-process d…

### DIFF
--- a/cc/paint/image_transfer_cache_entry.cc
+++ b/cc/paint/image_transfer_cache_entry.cc
@@ -1001,7 +1001,9 @@ bool ServiceImageTransferCacheEntry::DeserializeInProcess(
 
   // Perform color conversion (if no tone mapping is needed).
   if (payload->target_color_space && !is_tone_mapped) {
-    image_ = image_->makeColorSpace(nullptr, payload->target_color_space, {});
+    image_ = image_->makeColorSpace(
+          gr_context ? gr_context>asRecorder() : skcpu::Recorder::TODO(),
+          payload->target_color_space, {});
     if (payload->needs_mips && gr_context && image_ &&
         image_->isTextureBacked()) {
       image_ = SkImages::TextureFromImage(


### PR DESCRIPTION
…irect raster path

Refer to original PR: #12134

Introduce the kCobaltInProcessDirectRaster feature to bypass PaintOp serialization and deserialization when Cobalt is running in single- process mode. This reduces CPU overhead and memory usage by passing a pointer to the DisplayItemList directly to the GPU service via shared memory.

On the client side, RasterImplementation pre-uploads images to the transfer cache and packages the immutable display list into a payload. On the service side, RasterDecoderImpl performs direct rasterization on the canvas using a specialized image provider to resolve pre-uploaded textures.

Bug: 545866687

(cherry picked from commit 5c47f868d1f629b3ef500cdde540f77557473652)