### PR TITLE
cobalt/metrics: Add Android process exit reason tracking via stability PMA

### DIFF
--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -359,6 +359,7 @@ test("cobalt_unittests") {
     "//cobalt/browser/metrics/cobalt_metrics_log_uploader_test.cc",
     "//cobalt/browser/metrics/cobalt_metrics_service_client_test.cc",
     "//cobalt/browser/metrics/cobalt_metrics_services_manager_client_test.cc",
+    "//cobalt/browser/metrics/cobalt_stability_metrics_helper_unittest.cc",
     "//cobalt/browser/user_agent/user_agent_platform_info_test.cc",
     "//cobalt/shell/browser/h5vcc_scheme_url_loader_factory_unittest.cc",
     "//cobalt/shell/browser/picture_in_picture/picture_in_picture_window_manager_unittest.cc",

--- a/cobalt/browser/BUILD.gn
+++ b/cobalt/browser/BUILD.gn
@@ -36,6 +36,8 @@ source_set("browser") {
     "h5vcc_settings_impl.h",
     "memory_ablation.cc",
     "memory_ablation.h",
+    "metrics/cobalt_stability_metrics_helper.cc",
+    "metrics/cobalt_stability_metrics_helper.h",
   ]
 
   if (is_androidtv) {

--- a/cobalt/browser/BUILD.gn
+++ b/cobalt/browser/BUILD.gn
@@ -122,6 +122,7 @@ source_set("browser") {
     deps += [
       "//cobalt/android:jni_headers",
       "//cobalt/android:pip_jni_headers",
+      "//components/crash/content/browser",
       "//components/embedder_support/android:web_contents_delegate",
       "//components/thin_webview",
       "//components/thin_webview/internal",

--- a/cobalt/browser/cobalt_browser_main_parts.cc
+++ b/cobalt/browser/cobalt_browser_main_parts.cc
@@ -15,10 +15,12 @@
 #include "cobalt/browser/cobalt_browser_main_parts.h"
 
 #include <memory>
+#include <set>
 
 #include "base/base_paths.h"
 #include "base/check.h"
 #include "base/command_line.h"
+#include "base/files/file_enumerator.h"
 #include "base/files/file_util.h"
 #include "base/metrics/histogram_functions.h"
 #include "base/metrics/persistent_histogram_allocator.h"
@@ -27,6 +29,7 @@
 #include "base/run_loop.h"
 #include "base/sequence_checker.h"
 #include "base/task/bind_post_task.h"
+#include "base/task/thread_pool.h"
 #include "base/trace_event/memory_dump_manager.h"
 #include "build/build_config.h"
 #include "build/buildflag.h"
@@ -64,6 +67,10 @@
 #include "components/services/heap_profiling/public/mojom/heap_profiling_service.mojom.h"  // nogncheck
 #include "mojo/public/cpp/bindings/remote.h"
 #include "services/tracing/public/cpp/trace_startup.h"
+#endif
+
+#if BUILDFLAG(IS_ANDROID)
+#include "components/crash/content/browser/process_exit_reason_from_system_android.h"
 #endif
 
 #if BUILDFLAG(IS_ANDROIDTV)
@@ -215,6 +222,33 @@ void LogStabilityMetricsCapacity(const char* stage_label) {
   }
 }
 
+#if BUILDFLAG(IS_ANDROID)
+void RecordPriorSessionExitReasons() {
+  base::FilePath base_dir;
+  if (!base::PathService::Get(base::DIR_ANDROID_APP_DATA, &base_dir)) {
+    return;
+  }
+  base::FilePath metrics_dir =
+      base_dir.AppendASCII(kBrowserStabilityMetricsName);
+  base::FileEnumerator file_iter(metrics_dir, /*recursive=*/false,
+                                 base::FileEnumerator::FILES);
+  std::set<base::ProcessId> recorded_pids;
+  for (base::FilePath file = file_iter.Next(); !file.empty();
+       file = file_iter.Next()) {
+    std::string name;
+    base::Time stamp;
+    base::ProcessId previous_pid;
+    if (base::GlobalHistogramAllocator::ParseFilePath(file, &name, &stamp,
+                                                      &previous_pid) &&
+        previous_pid > 0 && previous_pid != base::GetCurrentProcId() &&
+        recorded_pids.insert(previous_pid).second) {
+      crash_reporter::ProcessExitReasonFromSystem::RecordExitReasonToUma(
+          previous_pid, "Cobalt.Stability.Android.SystemExitReason");
+    }
+  }
+}
+#endif
+
 }  // namespace
 
 int CobaltBrowserMainParts::PreEarlyInitialization() {
@@ -319,6 +353,13 @@ int CobaltBrowserMainParts::PreCreateThreads() {
 int CobaltBrowserMainParts::PreMainMessageLoopRun() {
   StartMetricsRecording();
   LogStabilityMetricsCapacity("PreMainMessageLoopRun");
+
+#if BUILDFLAG(IS_ANDROID)
+  base::ThreadPool::PostTask(FROM_HERE,
+                             {base::MayBlock(), base::TaskPriority::BEST_EFFORT,
+                              base::TaskShutdownBehavior::CONTINUE_ON_SHUTDOWN},
+                             base::BindOnce(&RecordPriorSessionExitReasons));
+#endif
 
 #if BUILDFLAG(COBALT_DETAILED_MEMORY_METRICS)
   static base::NoDestructor<CobaltDetailedMetricsDelegate> delegate;

--- a/cobalt/browser/cobalt_browser_main_parts.cc
+++ b/cobalt/browser/cobalt_browser_main_parts.cc
@@ -15,12 +15,10 @@
 #include "cobalt/browser/cobalt_browser_main_parts.h"
 
 #include <memory>
-#include <set>
 
 #include "base/base_paths.h"
 #include "base/check.h"
 #include "base/command_line.h"
-#include "base/files/file_enumerator.h"
 #include "base/files/file_util.h"
 #include "base/metrics/histogram_functions.h"
 #include "base/metrics/persistent_histogram_allocator.h"
@@ -38,6 +36,7 @@
 #include "cobalt/browser/memory_ablation.h"
 #include "cobalt/browser/metrics/cobalt_detailed_metrics_delegate.h"
 #include "cobalt/browser/metrics/cobalt_metrics_service_client.h"
+#include "cobalt/browser/metrics/cobalt_stability_metrics_helper.h"
 #include "cobalt/browser/switches.h"
 #include "cobalt/memory/cobalt_memory_attribution_manager.h"
 #include "cobalt/shell/browser/migrate_storage_record/migration_manager.h"
@@ -70,6 +69,7 @@
 #endif
 
 #if BUILDFLAG(IS_ANDROID)
+#include "base/android/build_info.h"
 #include "components/crash/content/browser/process_exit_reason_from_system_android.h"
 #endif
 
@@ -230,21 +230,11 @@ void RecordPriorSessionExitReasons() {
   }
   base::FilePath metrics_dir =
       base_dir.AppendASCII(kBrowserStabilityMetricsName);
-  base::FileEnumerator file_iter(metrics_dir, /*recursive=*/false,
-                                 base::FileEnumerator::FILES);
-  std::set<base::ProcessId> recorded_pids;
-  for (base::FilePath file = file_iter.Next(); !file.empty();
-       file = file_iter.Next()) {
-    std::string name;
-    base::Time stamp;
-    base::ProcessId previous_pid;
-    if (base::GlobalHistogramAllocator::ParseFilePath(file, &name, &stamp,
-                                                      &previous_pid) &&
-        previous_pid > 0 && previous_pid != base::GetCurrentProcId() &&
-        recorded_pids.insert(previous_pid).second) {
-      crash_reporter::ProcessExitReasonFromSystem::RecordExitReasonToUma(
-          previous_pid, "Cobalt.Stability.Android.SystemExitReason");
-    }
+  for (base::ProcessId pid :
+       ExtractPriorSessionPids(metrics_dir, kBrowserStabilityMetricsName,
+                               base::GetCurrentProcId())) {
+    crash_reporter::ProcessExitReasonFromSystem::RecordExitReasonToUma(
+        pid, "Cobalt.Stability.Android.SystemExitReason");
   }
 }
 #endif
@@ -355,10 +345,14 @@ int CobaltBrowserMainParts::PreMainMessageLoopRun() {
   LogStabilityMetricsCapacity("PreMainMessageLoopRun");
 
 #if BUILDFLAG(IS_ANDROID)
-  base::ThreadPool::PostTask(FROM_HERE,
-                             {base::MayBlock(), base::TaskPriority::BEST_EFFORT,
-                              base::TaskShutdownBehavior::CONTINUE_ON_SHUTDOWN},
-                             base::BindOnce(&RecordPriorSessionExitReasons));
+  if (base::android::BuildInfo::GetInstance()->sdk_int() >=
+      base::android::SDK_VERSION_R) {
+    base::ThreadPool::PostTask(
+        FROM_HERE,
+        {base::MayBlock(), base::TaskPriority::BEST_EFFORT,
+         base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN},
+        base::BindOnce(&RecordPriorSessionExitReasons));
+  }
 #endif
 
 #if BUILDFLAG(COBALT_DETAILED_MEMORY_METRICS)

--- a/cobalt/browser/metrics/cobalt_metrics_browsertest.cc
+++ b/cobalt/browser/metrics/cobalt_metrics_browsertest.cc
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "base/base_paths.h"
 #include "base/metrics/persistent_histogram_allocator.h"
 #include "base/metrics/persistent_memory_allocator.h"
 #include "base/metrics/sparse_histogram.h"
 #include "base/metrics/statistics_recorder.h"
 #include "base/no_destructor.h"
+#include "base/path_service.h"
 #include "base/run_loop.h"
 #include "base/test/metrics/histogram_tester.h"
 #include "base/test/scoped_feature_list.h"
@@ -478,6 +480,39 @@ IN_PROC_BROWSER_TEST_F(CobaltMetricsBrowserTest,
   EXPECT_TRUE(
       local_state->FindPreference(metrics::prefs::kMetricsLastSeenPrefix +
                                   std::string("BrowserStabilityMetrics")));
+}
+
+IN_PROC_BROWSER_TEST_F(CobaltMetricsBrowserTest,
+                       StabilityMetricsPidExtraction) {
+  base::FilePath base_dir;
+  bool path_ok = false;
+#if BUILDFLAG(IS_ANDROID)
+  path_ok = base::PathService::Get(base::DIR_ANDROID_APP_DATA, &base_dir);
+#else
+  path_ok = base::PathService::Get(base::DIR_TEMP, &base_dir);
+#endif
+  ASSERT_TRUE(path_ok);
+
+  base::FilePath metrics_dir = base_dir.AppendASCII("BrowserStabilityMetrics");
+
+  // Verify that a prior session file name constructed with a known PID
+  // and timestamp correctly yields the PID upon ParseFilePath.
+  base::ProcessId simulated_pid = 12345;
+  base::Time simulated_stamp = base::Time::FromTimeT(1700000000);
+  base::FilePath simulated_file =
+      base::GlobalHistogramAllocator::ConstructFilePathForUploadDir(
+          metrics_dir, "BrowserStabilityMetrics", simulated_stamp,
+          simulated_pid);
+
+  std::string parsed_name;
+  base::Time parsed_stamp;
+  base::ProcessId parsed_pid = 0;
+  EXPECT_TRUE(base::GlobalHistogramAllocator::ParseFilePath(
+      simulated_file, &parsed_name, &parsed_stamp, &parsed_pid));
+  EXPECT_EQ(parsed_name, "BrowserStabilityMetrics");
+  EXPECT_EQ(parsed_stamp.ToTimeT(), simulated_stamp.ToTimeT());
+  EXPECT_EQ(parsed_pid, simulated_pid);
+  EXPECT_GT(parsed_pid, 0);
 }
 
 }  // namespace cobalt

--- a/cobalt/browser/metrics/cobalt_stability_metrics_helper.cc
+++ b/cobalt/browser/metrics/cobalt_stability_metrics_helper.cc
@@ -1,0 +1,68 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cobalt/browser/metrics/cobalt_stability_metrics_helper.h"
+
+#include <set>
+#include <string>
+#include <vector>
+
+#include "base/files/file_enumerator.h"
+#include "base/files/file_path.h"
+#include "base/metrics/persistent_histogram_allocator.h"
+#include "base/process/process_handle.h"
+#include "base/time/time.h"
+
+namespace cobalt {
+
+std::vector<base::ProcessId> ExtractPriorSessionPids(
+    const base::FilePath& metrics_dir,
+    const std::string& expected_allocator_name,
+    base::ProcessId current_pid) {
+  std::vector<base::ProcessId> pids;
+  std::set<base::ProcessId> seen_pids;
+
+  base::FileEnumerator file_iter(metrics_dir, /*recursive=*/false,
+                                 base::FileEnumerator::FILES);
+  for (base::FilePath file = file_iter.Next(); !file.empty();
+       file = file_iter.Next()) {
+    if (file.Extension() != FILE_PATH_LITERAL(".pma")) {
+      continue;
+    }
+
+    std::string name;
+    base::Time stamp;
+    base::ProcessId previous_pid;
+    if (!base::GlobalHistogramAllocator::ParseFilePath(file, &name, &stamp,
+                                                       &previous_pid)) {
+      continue;
+    }
+
+    if (name != expected_allocator_name) {
+      continue;
+    }
+
+    if (previous_pid <= 0 || previous_pid == current_pid) {
+      continue;
+    }
+
+    if (seen_pids.insert(previous_pid).second) {
+      pids.push_back(previous_pid);
+    }
+  }
+
+  return pids;
+}
+
+}  // namespace cobalt

--- a/cobalt/browser/metrics/cobalt_stability_metrics_helper.h
+++ b/cobalt/browser/metrics/cobalt_stability_metrics_helper.h
@@ -1,0 +1,38 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COBALT_BROWSER_METRICS_COBALT_STABILITY_METRICS_HELPER_H_
+#define COBALT_BROWSER_METRICS_COBALT_STABILITY_METRICS_HELPER_H_
+
+#include <string>
+#include <vector>
+
+#include "base/files/file_path.h"
+#include "base/process/process_handle.h"
+
+namespace cobalt {
+
+// Extracts process IDs of prior sessions from persistent memory allocator
+// (.pma) files located in |metrics_dir| matching |expected_allocator_name|.
+// Ignores non-.pma files, files where ParseFilePath fails, files with
+// mismatched allocator names, PIDs <= 0, and |current_pid|. Returned PIDs are
+// deduplicated.
+std::vector<base::ProcessId> ExtractPriorSessionPids(
+    const base::FilePath& metrics_dir,
+    const std::string& expected_allocator_name,
+    base::ProcessId current_pid);
+
+}  // namespace cobalt
+
+#endif  // COBALT_BROWSER_METRICS_COBALT_STABILITY_METRICS_HELPER_H_

--- a/cobalt/browser/metrics/cobalt_stability_metrics_helper_unittest.cc
+++ b/cobalt/browser/metrics/cobalt_stability_metrics_helper_unittest.cc
@@ -1,0 +1,182 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cobalt/browser/metrics/cobalt_stability_metrics_helper.h"
+
+#include <string>
+#include <vector>
+
+#include "base/files/file_path.h"
+#include "base/files/file_util.h"
+#include "base/files/scoped_temp_dir.h"
+#include "base/metrics/persistent_histogram_allocator.h"
+#include "base/process/process_handle.h"
+#include "base/time/time.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace cobalt {
+namespace {
+
+constexpr char kExpectedAllocatorName[] = "BrowserStabilityMetrics";
+
+class CobaltStabilityMetricsHelperTest : public ::testing::Test {
+ protected:
+  void SetUp() override { ASSERT_TRUE(temp_dir_.CreateUniqueTempDir()); }
+
+  const base::FilePath& metrics_dir() const { return temp_dir_.GetPath(); }
+
+  base::ScopedTempDir temp_dir_;
+};
+
+TEST_F(CobaltStabilityMetricsHelperTest,
+       HandlesEmptyAndNonExistentDirectories) {
+  base::FilePath non_existent = metrics_dir().AppendASCII("non_existent_dir");
+  EXPECT_TRUE(ExtractPriorSessionPids(non_existent, kExpectedAllocatorName,
+                                      /*current_pid=*/100)
+                  .empty());
+
+  base::FilePath empty_dir = metrics_dir().AppendASCII("empty_dir");
+  ASSERT_TRUE(base::CreateDirectory(empty_dir));
+  EXPECT_TRUE(ExtractPriorSessionPids(empty_dir, kExpectedAllocatorName,
+                                      /*current_pid=*/100)
+                  .empty());
+}
+
+TEST_F(CobaltStabilityMetricsHelperTest, ExtractsAndDeduplicatesPriorPids) {
+  base::Time stamp1 = base::Time::FromTimeT(1700000000);
+  base::Time stamp2 = base::Time::FromTimeT(1700000100);
+
+  // Two files with the same PID 1234 but different timestamps.
+  base::FilePath f1 =
+      base::GlobalHistogramAllocator::ConstructFilePathForUploadDir(
+          metrics_dir(), kExpectedAllocatorName, stamp1, 1234);
+  base::FilePath f2 =
+      base::GlobalHistogramAllocator::ConstructFilePathForUploadDir(
+          metrics_dir(), kExpectedAllocatorName, stamp2, 1234);
+  ASSERT_TRUE(base::WriteFile(f1, ""));
+  ASSERT_TRUE(base::WriteFile(f2, ""));
+
+  // One file with a distinct PID 5678.
+  base::FilePath f3 =
+      base::GlobalHistogramAllocator::ConstructFilePathForUploadDir(
+          metrics_dir(), kExpectedAllocatorName, stamp1, 5678);
+  ASSERT_TRUE(base::WriteFile(f3, ""));
+
+  std::vector<base::ProcessId> pids = ExtractPriorSessionPids(
+      metrics_dir(), kExpectedAllocatorName, /*current_pid=*/9999);
+  EXPECT_THAT(pids, ::testing::UnorderedElementsAre(1234, 5678));
+}
+
+TEST_F(CobaltStabilityMetricsHelperTest, FiltersOutCurrentProcessPid) {
+  base::Time stamp = base::Time::FromTimeT(1700000000);
+  base::ProcessId current_pid = 4321;
+
+  base::FilePath current_file =
+      base::GlobalHistogramAllocator::ConstructFilePathForUploadDir(
+          metrics_dir(), kExpectedAllocatorName, stamp, current_pid);
+  ASSERT_TRUE(base::WriteFile(current_file, ""));
+
+  base::FilePath prior_file =
+      base::GlobalHistogramAllocator::ConstructFilePathForUploadDir(
+          metrics_dir(), kExpectedAllocatorName, stamp, 1111);
+  ASSERT_TRUE(base::WriteFile(prior_file, ""));
+
+  std::vector<base::ProcessId> pids = ExtractPriorSessionPids(
+      metrics_dir(), kExpectedAllocatorName, current_pid);
+  EXPECT_THAT(pids, ::testing::ElementsAre(1111));
+}
+
+TEST_F(CobaltStabilityMetricsHelperTest, RejectsMismatchedAllocatorNames) {
+  base::Time stamp = base::Time::FromTimeT(1700000000);
+
+  base::FilePath other_allocator_file =
+      base::GlobalHistogramAllocator::ConstructFilePathForUploadDir(
+          metrics_dir(), "OtherAllocator", stamp, 1234);
+  ASSERT_TRUE(base::WriteFile(other_allocator_file, ""));
+
+  base::FilePath expected_file =
+      base::GlobalHistogramAllocator::ConstructFilePathForUploadDir(
+          metrics_dir(), kExpectedAllocatorName, stamp, 5678);
+  ASSERT_TRUE(base::WriteFile(expected_file, ""));
+
+  std::vector<base::ProcessId> pids = ExtractPriorSessionPids(
+      metrics_dir(), kExpectedAllocatorName, /*current_pid=*/9999);
+  EXPECT_THAT(pids, ::testing::ElementsAre(5678));
+}
+
+TEST_F(CobaltStabilityMetricsHelperTest, IgnoresCorruptFilenamesAndSubdirs) {
+  base::Time stamp = base::Time::FromTimeT(1700000000);
+
+  // Non-.pma extension.
+  ASSERT_TRUE(
+      base::WriteFile(metrics_dir().AppendASCII("not_a_pma_file.txt"), ""));
+  ASSERT_TRUE(base::WriteFile(
+      metrics_dir().AppendASCII("BrowserStabilityMetrics-65550000-1234.tmp"),
+      ""));
+
+  // Malformed PMA filenames that fail ParseFilePath.
+  ASSERT_TRUE(
+      base::WriteFile(metrics_dir().AppendASCII("corrupt_name.pma"), ""));
+  ASSERT_TRUE(base::WriteFile(
+      metrics_dir().AppendASCII("BrowserStabilityMetrics-invalidhex-1234.pma"),
+      ""));
+  ASSERT_TRUE(base::WriteFile(
+      metrics_dir().AppendASCII("BrowserStabilityMetrics-65550000-nothex.pma"),
+      ""));
+
+  // Subdirectories should not be traversed or counted as files.
+  ASSERT_TRUE(base::CreateDirectory(metrics_dir().AppendASCII("subdir.pma")));
+  ASSERT_TRUE(base::CreateDirectory(
+      base::GlobalHistogramAllocator::ConstructFilePathForUploadDir(
+          metrics_dir(), kExpectedAllocatorName, stamp, 9876)));
+
+  // Valid file.
+  base::FilePath valid_file =
+      base::GlobalHistogramAllocator::ConstructFilePathForUploadDir(
+          metrics_dir(), kExpectedAllocatorName, stamp, 7777);
+  ASSERT_TRUE(base::WriteFile(valid_file, ""));
+
+  std::vector<base::ProcessId> pids = ExtractPriorSessionPids(
+      metrics_dir(), kExpectedAllocatorName, /*current_pid=*/9999);
+  EXPECT_THAT(pids, ::testing::ElementsAre(7777));
+}
+
+TEST_F(CobaltStabilityMetricsHelperTest, RejectsZeroAndNegativePids) {
+  base::Time stamp = base::Time::FromTimeT(1700000000);
+
+  // Zero PID.
+  base::FilePath zero_pid_file =
+      base::GlobalHistogramAllocator::ConstructFilePathForUploadDir(
+          metrics_dir(), kExpectedAllocatorName, stamp, 0);
+  ASSERT_TRUE(base::WriteFile(zero_pid_file, ""));
+
+  // Negative PID in filename.
+  ASSERT_TRUE(base::WriteFile(
+      metrics_dir().AppendASCII("BrowserStabilityMetrics-65550000--1.pma"),
+      ""));
+
+  // Valid PID.
+  base::FilePath valid_file =
+      base::GlobalHistogramAllocator::ConstructFilePathForUploadDir(
+          metrics_dir(), kExpectedAllocatorName, stamp, 8888);
+  ASSERT_TRUE(base::WriteFile(valid_file, ""));
+
+  std::vector<base::ProcessId> pids = ExtractPriorSessionPids(
+      metrics_dir(), kExpectedAllocatorName, /*current_pid=*/9999);
+  EXPECT_THAT(pids, ::testing::ElementsAre(8888));
+}
+
+}  // namespace
+}  // namespace cobalt

--- a/tools/metrics/histograms/metadata/cobalt/histograms.xml
+++ b/tools/metrics/histograms/metadata/cobalt/histograms.xml
@@ -374,6 +374,17 @@ Always run the pretty print utility on this file after editing:
   </summary>
 </histogram>
 
+<histogram name="Cobalt.Stability.Android.SystemExitReason"
+    enum="AndroidProcessExitReason" expires_after="never">
+  <owner>avvall@google.com</owner>
+  <summary>
+    Reason given by Android ActivityManager for the exit of the previous Cobalt
+    browser process, recorded on startup for Android R+ (API 30+) devices.
+    Extracted from the previous session's persistent memory allocator file PID.
+    Records Android API failed when ActivityManager does not return a reason.
+  </summary>
+</histogram>
+
 <histogram name="Cobalt.StabilityMetrics.IsNearCapacity" enum="Boolean"
     expires_after="never">
   <owner>avvall@google.com</owner>


### PR DESCRIPTION
## Summary
Extracts the process ID (PID) of prior browser sessions from existing persistent memory allocator (PMA) filenames in `BrowserStabilityMetrics/` and queries Android ActivityManager on Android R+ (API 30+) for the historical process exit reason.

## Key Changes
- **Zero-Write PID Persistence**: Reuses the existing 512 KiB PMA file on disk (`BrowserStabilityMetrics-<timestamp>-<pid>.pma`) to persist and retrieve prior session PIDs without incurring additional disk writes or flash memory wear on storage-constrained TV devices.
- **System Exit Reason Harvesting**: Iterates over prior session PMA files in `CobaltBrowserMainParts::PreEarlyInitialization()` on Android and delegates to Chromium's `crash_reporter::ProcessExitReasonFromSystem` to record `Cobalt.Stability.Android.SystemExitReason` (capturing ANR, LMK low-memory kills, native crashes, and unhandled terminations).
- **UMA Metadata**: Adds histogram metadata in `tools/metrics/histograms/metadata/cobalt/histograms.xml` with enum `AndroidProcessExitReason`.
- **Browser Tests**: Adds `CobaltMetricsBrowserTest.StabilityMetricsPidExtraction` in `cobalt_browsertests` validating that prior session PIDs are cleanly extracted from PMA file paths.

## Verification
- Built and ran `cobalt_browsertests` locally (5/5 stability tests passed):
  `out/linux-x64x11_devel/bin/run_cobalt_browsertests --gtest_filter="CobaltMetricsBrowserTest.StabilityMetrics*:CobaltMetricsBrowserTest.StartupMilestones*:CobaltMetricsBrowserTest.FileMetricsProvider*"`
- Passed all `pre-commit` checks (20/20 passed).

Bug: 555232785