### PR TITLE
cobalt: Provide a dedicated path for Punch-out GPU Posting

### DIFF
--- a/media/gpu/starboard/starboard_gpu_factory.h
+++ b/media/gpu/starboard/starboard_gpu_factory.h
@@ -52,6 +52,10 @@ class StarboardGpuFactory : public gpu::CommandBufferStub::DestructionObserver {
       SbDecodeTargetGlesContextRunnerTarget target_function,
       void* target_function_context,
       base::WaitableEvent* done_event) = 0;
+  virtual void RunStandaloneFunctionOnGpu(
+      SbDecodeTargetGlesContextRunnerTarget target_function,
+      void* target_function_context,
+      base::WaitableEvent* done_event) = 0;
   virtual void RunCallbackOnGpu(base::OnceCallback<void()> callback,
                                 base::WaitableEvent* done_event) = 0;
   virtual void PostCallbackToGpu(base::OnceCallback<void()> callback) = 0;

--- a/media/gpu/starboard/starboard_gpu_factory_impl.cc
+++ b/media/gpu/starboard/starboard_gpu_factory_impl.cc
@@ -67,6 +67,15 @@ void StarboardGpuFactoryImpl::RunSbDecodeTargetFunctionOnGpu(
   done_event->Signal();
 }
 
+void StarboardGpuFactoryImpl::RunStandaloneFunctionOnGpu(
+    SbDecodeTargetGlesContextRunnerTarget target_function,
+    void* target_function_context,
+    base::WaitableEvent* done_event) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  target_function(target_function_context);
+  done_event->Signal();
+}
+
 void StarboardGpuFactoryImpl::RunCallbackOnGpu(
     base::OnceCallback<void()> callback,
     base::WaitableEvent* done_event) {

--- a/media/gpu/starboard/starboard_gpu_factory_impl.h
+++ b/media/gpu/starboard/starboard_gpu_factory_impl.h
@@ -37,6 +37,10 @@ class StarboardGpuFactoryImpl : public StarboardGpuFactory {
       SbDecodeTargetGlesContextRunnerTarget target_function,
       void* target_function_context,
       base::WaitableEvent* done_event) override;
+  void RunStandaloneFunctionOnGpu(
+      SbDecodeTargetGlesContextRunnerTarget target_function,
+      void* target_function_context,
+      base::WaitableEvent* done_event) override;
   void RunCallbackOnGpu(base::OnceCallback<void()> callback,
                         base::WaitableEvent* done_event) override;
   void PostCallbackToGpu(base::OnceCallback<void()> callback) override;

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.cc
@@ -721,9 +721,18 @@ void StarboardRendererWrapper::GraphicsContextRunner(
     base::WaitableEvent done_event(
         base::WaitableEvent::ResetPolicy::MANUAL,
         base::WaitableEvent::InitialState::NOT_SIGNALED);
-    provider->gpu_factory_
-        .AsyncCall(&StarboardGpuFactory::RunSbDecodeTargetFunctionOnGpu)
-        .WithArgs(target_function, target_function_context, &done_event);
+    // In non decode-to-texture playbacks, post standalone functions
+    // (which manage their own EGL context) via RunStandaloneFunctionOnGpu to
+    // avoid dependency on CommandBufferStub.
+    if (!provider->overlay_plane_id_.is_empty()) {
+      provider->gpu_factory_
+          .AsyncCall(&StarboardGpuFactory::RunStandaloneFunctionOnGpu)
+          .WithArgs(target_function, target_function_context, &done_event);
+    } else {
+      provider->gpu_factory_
+          .AsyncCall(&StarboardGpuFactory::RunSbDecodeTargetFunctionOnGpu)
+          .WithArgs(target_function, target_function_context, &done_event);
+    }
     // Blocking is okay here to allow SbPlayer to post |target_function|
     // on gpu thread, and StarboardRenderer waits for the execution.
     base::ScopedAllowBaseSyncPrimitives allow_wait;

--- a/media/mojo/services/starboard/starboard_renderer_wrapper_unittest.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper_unittest.cc
@@ -147,6 +147,13 @@ class MockStarboardGpuFactory : public StarboardGpuFactory {
     done_event->Signal();
   }
 
+  void RunStandaloneFunctionOnGpu(
+      SbDecodeTargetGlesContextRunnerTarget target_function,
+      void* target_function_context,
+      base::WaitableEvent* done_event) override {
+    done_event->Signal();
+  }
+
   void RunCallbackOnGpu(base::OnceCallback<void()> callback,
                         base::WaitableEvent* done_event) override {
     done_event->Signal();


### PR DESCRIPTION
Introduce RunStandaloneFunctionOnGpu to StarboardGpuFactory to
support Punch-out mode GPU task calls.  Using a dedicated path avoids a
dependency on CommandBufferStub, which is required by the standard
decode target execution path. When not using decode-to-texture,
it's possible that CommandBufferStub will not be set, causing issues
when clearing the surface view.

This ensures that when an overlay plane is active, the renderer
wrapper correctly routes tasks that do not rely on the internal
command buffer state.

Bug: 555127326