### PR TITLE
cobalt: Skip PartitionRoot re-creation when options match

### DIFF
--- a/base/allocator/partition_alloc_support.cc
+++ b/base/allocator/partition_alloc_support.cc
@@ -26,6 +26,7 @@
 #include "base/functional/callback.h"
 #include "base/immediate_crash.h"
 #include "base/location.h"
+#include "base/logging.h"
 #include "base/memory/post_delayed_memory_reduction_task.h"
 #include "base/memory/raw_ptr_asan_service.h"
 #include "base/metrics/histogram_functions.h"
@@ -1206,6 +1207,14 @@ void PartitionAllocSupport::ReconfigureAfterFeatureListInit(
       allocator_shim::EventuallyZeroFreedMemory(eventually_zero_freed_memory),
       allocator_shim::FewerMemoryRegions(fewer_memory_regions),
       use_small_single_slot_spans);
+
+#if BUILDFLAG(IS_COBALT)
+  LOG(INFO) << "PartitionAlloc: main root re-creation "
+            << (allocator_shim::internal::PartitionAllocMalloc::
+                        OriginalAllocator() == nullptr
+                    ? "skipped (reused initial root)"
+                    : "executed (new root created)");
+#endif  // BUILDFLAG(IS_COBALT)
 
   const uint32_t extras_size = allocator_shim::GetMainPartitionRootExtrasSize();
   // As per description, extras are optional and are expected not to

--- a/base/allocator/partition_allocator/src/partition_alloc/partition_root.cc
+++ b/base/allocator/partition_allocator/src/partition_alloc/partition_root.cc
@@ -1156,6 +1156,10 @@ void PartitionRoot::Init(PartitionOptions opts) {
     scheduler_loop_quarantine.Configure(
         scheduler_loop_quarantine_root,
         opts.scheduler_loop_quarantine_global_config);
+#if BUILDFLAG(IS_COBALT)
+    settings.scheduler_loop_quarantine_global_config =
+        opts.scheduler_loop_quarantine_global_config;
+#endif  // BUILDFLAG(IS_COBALT)
     settings.scheduler_loop_quarantine_thread_local_config =
         opts.scheduler_loop_quarantine_thread_local_config;
 
@@ -1234,6 +1238,9 @@ void PartitionRoot::Init(PartitionOptions opts) {
 
     const bool use_small_single_slot_spans =
         opts.use_small_single_slot_spans == PartitionOptions::kEnabled;
+#if BUILDFLAG(IS_COBALT)
+    settings.use_small_single_slot_spans = use_small_single_slot_spans;
+#endif  // BUILDFLAG(IS_COBALT)
 
     // Set up the actual usable buckets first.
     for (size_t bucket_index = 0; bucket_index < BucketIndexLookup::kNumBuckets;

--- a/base/allocator/partition_allocator/src/partition_alloc/partition_root.h
+++ b/base/allocator/partition_allocator/src/partition_alloc/partition_root.h
@@ -272,9 +272,16 @@ struct alignas(64) PA_COMPONENT_EXPORT(PARTITION_ALLOC) PartitionRoot {
 #endif  // PA_BUILDFLAG(HAS_64_BIT_POINTERS)
 
     bool eventually_zero_freed_memory = false;
+#if BUILDFLAG(IS_COBALT)
+    internal::SchedulerLoopQuarantineConfig
+        scheduler_loop_quarantine_global_config;
+#endif  // BUILDFLAG(IS_COBALT)
     internal::SchedulerLoopQuarantineConfig
         scheduler_loop_quarantine_thread_local_config;
     bool fewer_memory_regions = false;
+#if BUILDFLAG(IS_COBALT)
+    bool use_small_single_slot_spans = false;
+#endif  // BUILDFLAG(IS_COBALT)
 #if PA_BUILDFLAG(HAS_MEMORY_TAGGING)
     bool memory_tagging_enabled_ = false;
     bool use_random_memory_tagging_ = false;

--- a/base/allocator/partition_allocator/src/partition_alloc/shim/allocator_shim_default_dispatch_to_partition_alloc.cc
+++ b/base/allocator/partition_allocator/src/partition_alloc/shim/allocator_shim_default_dispatch_to_partition_alloc.cc
@@ -149,6 +149,19 @@ class MainPartitionConstructor {
     // the decision to turn the thread cache on until then.
     // Also tests, such as the ThreadCache tests create a thread cache.
     opts.thread_cache = partition_alloc::PartitionOptions::kDisabled;
+#if BUILDFLAG(IS_COBALT)
+    // Cobalt initializes PartitionAlloc with known fixed options:
+    // - use_cookie_if_supported: standard cookie support when enabled by build.
+    // - backup_ref_ptr: disabled for the main malloc partition.
+    // - fewer_memory_regions: enabled to minimize address space reservations.
+    // - use_small_single_slot_spans: enabled to reduce single-slot span overhead.
+    // Initializing the root with these options up front allows ConfigurePartitions()
+    // to match settings and avoid re-creating a duplicate PartitionRoot.
+    opts.use_cookie_if_supported = partition_alloc::PartitionOptions::kEnabled;
+    opts.fewer_memory_regions = partition_alloc::PartitionOptions::kEnabled;
+    opts.use_small_single_slot_spans =
+        partition_alloc::PartitionOptions::kEnabled;
+#endif  // BUILDFLAG(IS_COBALT)
     opts.backup_ref_ptr = partition_alloc::PartitionOptions::kDisabled;
     auto* new_root = new (buffer) partition_alloc::PartitionRoot(opts);
 
@@ -630,6 +643,77 @@ void EnablePartitionAllocMemoryReclaimer() {
   PA_DCHECK(OriginalAllocator() == nullptr);
 }
 
+#if BUILDFLAG(IS_COBALT)
+bool QuarantineConfigMatches(
+    const partition_alloc::internal::SchedulerLoopQuarantineConfig& a,
+    const partition_alloc::internal::SchedulerLoopQuarantineConfig& b) {
+  if (a.enable_quarantine != b.enable_quarantine) {
+    return false;
+  }
+  if (!a.enable_quarantine) {
+    return true;  // Both disabled; capacity and other settings are inactive.
+  }
+  return a.enable_zapping == b.enable_zapping &&
+         a.quarantine_config.branch_capacity_in_bytes ==
+             b.quarantine_config.branch_capacity_in_bytes &&
+         a.quarantine_config.lock_required ==
+             b.quarantine_config.lock_required;
+}
+
+bool SettingsMatch(
+    const partition_alloc::PartitionRoot* current_root,
+    EnableBrp enable_brp,
+    size_t brp_extra_extras_size,
+    EnableMemoryTagging enable_memory_tagging,
+    partition_alloc::TagViolationReportingMode memory_tagging_reporting_mode,
+    const partition_alloc::internal::SchedulerLoopQuarantineConfig&
+        scheduler_loop_quarantine_global_config,
+    const partition_alloc::internal::SchedulerLoopQuarantineConfig&
+        scheduler_loop_quarantine_thread_local_config,
+    EventuallyZeroFreedMemory eventually_zero_freed_memory,
+    FewerMemoryRegions fewer_memory_regions,
+    UseSmallSingleSlotSpans use_small_single_slot_spans) {
+  // BRP is not supported on Cobalt.
+  if (enable_brp.value()) {
+    return false;
+  }
+
+  // Memory tagging is not supported on Cobalt.
+  if (enable_memory_tagging.value()) {
+    return false;
+  }
+
+  if (!QuarantineConfigMatches(
+          current_root->settings.scheduler_loop_quarantine_global_config,
+          scheduler_loop_quarantine_global_config)) {
+    return false;
+  }
+
+  if (!QuarantineConfigMatches(
+          current_root->settings.scheduler_loop_quarantine_thread_local_config,
+          scheduler_loop_quarantine_thread_local_config)) {
+    return false;
+  }
+
+  if (current_root->settings.eventually_zero_freed_memory !=
+      eventually_zero_freed_memory.value()) {
+    return false;
+  }
+
+  if (current_root->settings.fewer_memory_regions !=
+      fewer_memory_regions.value()) {
+    return false;
+  }
+
+  if (current_root->settings.use_small_single_slot_spans !=
+      use_small_single_slot_spans.value()) {
+    return false;
+  }
+
+  return true;
+}
+#endif  // BUILDFLAG(IS_COBALT)
+
 void ConfigurePartitions(
     EnableBrp enable_brp,
     size_t brp_extra_extras_size,
@@ -647,6 +731,25 @@ void ConfigurePartitions(
   // used, because it has a side effect of initializing the variable, if it
   // wasn't already.
   auto* current_root = g_root.Get();
+
+#if BUILDFLAG(IS_COBALT)
+  // If the initial PartitionRoot already matches the required options, skip
+  // re-creating the root allocator to avoid duplicate PartitionRoot overhead.
+  if (SettingsMatch(
+          current_root, enable_brp, brp_extra_extras_size,
+          enable_memory_tagging, memory_tagging_reporting_mode,
+          scheduler_loop_quarantine_global_config,
+          scheduler_loop_quarantine_thread_local_config,
+          eventually_zero_freed_memory, fewer_memory_regions,
+          use_small_single_slot_spans)) {
+    if (distribution == BucketDistribution::kDenser) {
+      current_root->SwitchToDenserBucketDistribution();
+    }
+
+    PA_CHECK(!g_roots_finalized.exchange(true));  // Ensure configured once.
+    return;
+  }
+#endif  // BUILDFLAG(IS_COBALT)
 
   // We've been bitten before by using a static local when initializing a
   // partition. For synchronization, static local variables call into the


### PR DESCRIPTION
Avoid re-creating the main PartitionRoot in ConfigurePartitions when the
existing root settings are identical to the requested configuration.
This prevents unnecessary overhead of about 1MB memory.

Bug: 555848602