### PR TITLE
staging: Fix build after recent cherry-picks

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -291,6 +291,8 @@ public abstract class CobaltActivity extends BaseCobaltActivity {
               false, // Do not start a separate GPU process
               // TODO(b/377025565): Figure out what this means
               false, // Do not start in "minimal" or paused mode
+              /* singleProcess= */ true, // Cobalt always runs in single-process mode
+              /* scheduleFlushStartupTasks= */ false,
               new BrowserStartupController.StartupCallback() {
                 @Override
                 public void onSuccess() {

--- a/cobalt/browser/experiments/experiment_config_manager_unittest.cc
+++ b/cobalt/browser/experiments/experiment_config_manager_unittest.cc
@@ -14,6 +14,7 @@
 
 #include "cobalt/browser/experiments/experiment_config_manager.h"
 
+#include "base/files/file_path.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_split.h"
 #include "base/strings/stringprintf.h"

--- a/skia/ext/font_utils.cc
+++ b/skia/ext/font_utils.cc
@@ -88,11 +88,7 @@ static sk_sp<SkFontMgr> fontmgr_factory() {
     custom_fonts.fFontsXml = xml_path.c_str();
     custom_fonts.fFallbackFontsXml = nullptr;
     custom_fonts.fIsolated = true;
-    if (base::FeatureList::IsEnabled(skia::kFontationsAndroidSystemFonts)) {
-      return SkFontMgr_New_Android(&custom_fonts, SkFontScanner_Make_Fontations());
-    } else {
-      return SkFontMgr_New_Android(&custom_fonts);
-    }
+    return SkFontMgr_New_Android(&custom_fonts, SkFontScanner_Make_Fontations());
   }
 #endif  // BUILDFLAG(IS_COBALT)
   return SkFontMgr_New_Android(nullptr, SkFontScanner_Make_Fontations());


### PR DESCRIPTION
* experimental_config_manager_unittest.cc (broken by #12417): IWYU for base::FilePath and FILE_PATH_LITERAL
* font_utils.cc (broken by #12431): Finish adapting the code to https://crrev.com/c/6650671
* CobaltActivity.java (broken by #12429): Restore missing arguments to startBrowserProcessesAsync() that were removed in the cherry-pick.

Bug: 552583161
Bug: 517249177
Bug: 448156280