### PR TITLE
android: Use WindowSurface for UI rendering by default

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -110,8 +110,10 @@ public class JavaSwitches {
   /** flag to aggressively flush v8 bytecode after a configurable old time. */
   public static final String V8_SET_BYTECODE_OLD_TIME = "V8SetBytecodeOldTime";
 
-  /** Flag for enable go/cobalt-direct-window-rendering */
-  public static final String DIRECT_WINDOW_RENDERING = "DirectWindowRendering";
+  /** Flag to force SurfaceView for UI rendering (legacy fallback). */
+  // We keep this fallback for emergency brake.
+  // TODO: b/542337082 - Remove this after 09/17 (2-weeks after full-launch).
+  public static final String SURFACE_VIEW_UI_RENDERING = "SurfaceViewUiRendering";
 
   public static final String V8_INITIAL_OLD_SPACE_SIZE = "V8InitialOldSpaceSize";
   public static final String V8_MAX_OLD_SPACE_SIZE = "V8MaxOldSpaceSize";
@@ -309,8 +311,8 @@ public class JavaSwitches {
       extraCommandLineArgs.add("--enable-features=CobaltMmapFontCache");
     }
 
-    if (javaSwitches.containsKey(JavaSwitches.DIRECT_WINDOW_RENDERING)) {
-      extraCommandLineArgs.add("--use-window-surface-for-ui");
+    if (javaSwitches.containsKey(JavaSwitches.SURFACE_VIEW_UI_RENDERING)) {
+      extraCommandLineArgs.add("--use-surface-view-for-ui");
     }
 
     if (javaSwitches.containsKey(JavaSwitches.AREA_BASED_VIDEO_BUFFER_BUDGET)) {

--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/util/JavaSwitchesTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/util/JavaSwitchesTest.java
@@ -75,7 +75,7 @@ public class JavaSwitchesTest {
     switches.put(JavaSwitches.COBALT_BYPASS_RESOURCE_LOAD_SCHEDULER, "1");
     switches.put(JavaSwitches.COBALT_BYPASS_HTML_PRELOAD_SCANNER, "1");
     switches.put(JavaSwitches.ENABLE_COBALT_MMAP_FONT_CACHE, "1");
-    switches.put(JavaSwitches.DIRECT_WINDOW_RENDERING, "1");
+    switches.put(JavaSwitches.SURFACE_VIEW_UI_RENDERING, "1");
     switches.put(JavaSwitches.AREA_BASED_VIDEO_BUFFER_BUDGET, "1");
     switches.put(JavaSwitches.ALLOW_CRITICAL_MEMORY_PRESSURE_HANDLING_IN_FOREGROUND, "1");
     switches.put(JavaSwitches.EVICT_MEMORY_CACHE_ON_CRITICAL_MEMORY_PRESSURE, "1");
@@ -107,7 +107,7 @@ public class JavaSwitchesTest {
     assertThat(args).contains("--enable-features=CobaltBypassResourceLoadScheduler");
     assertThat(args).contains("--enable-features=CobaltBypassHTMLPreloadScanner");
     assertThat(args).contains("--enable-features=CobaltMmapFontCache");
-    assertThat(args).contains("--use-window-surface-for-ui");
+    assertThat(args).contains("--use-surface-view-for-ui");
     assertThat(args).contains("--enable-features=AreaBasedVideoBufferBudget");
     assertThat(args).contains("--allow-critical-memory-pressure-handling-in-foreground");
     assertThat(args).contains("--enable-features=EvictMemoryCacheOnCriticalMemoryPressure");

--- a/cobalt/shell/android/java/src/dev/cobalt/shell/ContentViewRenderView.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/shell/ContentViewRenderView.java
@@ -60,12 +60,14 @@ public class ContentViewRenderView extends FrameLayout {
   }
 
   protected SurfaceBridge createSurfaceBridge() {
-    if (CommandLine.getInstance().hasSwitch("use-window-surface-for-ui")) {
-      Log.i(TAG, "ContentViewRenderView: created using WindowSurfaceBridge");
-      return new WindowSurfaceBridge();
+    // TODO: b/542337082 - Remove legacy SurfaceViewBridge and --use-surface-view-for-ui after
+    // 09/17.
+    if (CommandLine.getInstance().hasSwitch("use-surface-view-for-ui")) {
+      Log.i(TAG, "ContentViewRenderView: created with SurfaceView");
+      return new SurfaceViewBridge();
     }
-    Log.i(TAG, "ContentViewRenderView: created with SurfaceView");
-    return new SurfaceViewBridge();
+    Log.i(TAG, "ContentViewRenderView: created using WindowSurfaceBridge");
+    return new WindowSurfaceBridge();
   }
 
   /**


### PR DESCRIPTION
Enables WindowSurfaceBridge as the default UI rendering path on Android. The legacy SurfaceViewBridge is retained as an emergency fallback, controlled via the `--use-surface-view-for-ui` command-line switch and the `SurfaceViewUiRendering` Java switch.

Bug: 542337082