### PR TITLE
cobalt: Restore launch=preload query on startup

### DIFF
--- a/cobalt/shell/browser/shell_browser_main_parts.cc
+++ b/cobalt/shell/browser/shell_browser_main_parts.cc
@@ -100,7 +100,7 @@ class NetworkChangeNotifierFactoryStarboard
 };
 #endif  // BUILDFLAG(IS_STARBOARD) && !BUILDFLAG(IS_ANDROID)
 
-GURL GetStartupURL() {
+GURL GetStartupURL(bool should_preload) {
   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
   if (command_line->HasSwitch(switches::kBrowserTest)) {
     return GURL();
@@ -123,6 +123,10 @@ GURL GetStartupURL() {
       return net::FilePathToFileURL(
           base::MakeAbsoluteFilePath(base::FilePath(url_string)));
     }
+  }
+
+  if (should_preload) {
+    initial_url = net::AppendQueryParameter(initial_url, "launch", "preload");
   }
 
 #if BUILDFLAG(IS_STARBOARD)
@@ -177,8 +181,9 @@ void ShellBrowserMainParts::InitializeBrowserContexts() {
 }
 
 void ShellBrowserMainParts::InitializeMessageLoopContext() {
-  Shell::CreateNewWindow(browser_context_.get(), GetStartupURL(), nullptr,
-                         gfx::Size(),
+  Shell::CreateNewWindow(browser_context_.get(),
+                         GetStartupURL(/*should_preload=*/!is_visible_),
+                         nullptr, gfx::Size(),
 #if BUILDFLAG(IS_ANDROID)
                          false /* create_splash_screen_web_contents */
 #else

--- a/cobalt/tools/test_preload.sh
+++ b/cobalt/tools/test_preload.sh
@@ -46,6 +46,7 @@ log "Verifying initial preloaded state (Hidden & Not Focused)..."
 # In preload mode, the app should be hidden and not have focus.
 bash cobalt/tools/wait_for_state.sh "document.visibilityState" "hidden" $PORT 120 || exit 1
 bash cobalt/tools/wait_for_state.sh "document.hasFocus()" "False" $PORT 120 || exit 1
+bash cobalt/tools/wait_for_state.sh "window.location.search.includes('launch=preload')" "True" $PORT 120 || exit 1
 
 log "Sending SIGCONT to reveal application..."
 kill -SIGCONT $COBALT_PID


### PR DESCRIPTION
Restore behavior from Cobalt 25. Append "launch=preload" to the document URL when the application is launched in preload mode.

As a result, this notifies Kabuki to start in background mode. This prevents potential wastage of TV resources, and allows instantaneous launching of the YouTube TV app.

Bug: 503025265