### PR TITLE
Cobalt override for GetCacheQuotaSettings

### DIFF
--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -444,6 +444,7 @@ test("cobalt_unittests") {
     "//mojo/core/test:run_all_unittests",
     "//net/traffic_annotation:test_support",
     "//services/network/public/cpp",
+    "//storage/browser:test_support",
     "//testing/gmock",
     "//testing/gtest",
     "//third_party/metrics_proto",

--- a/cobalt/browser/BUILD.gn
+++ b/cobalt/browser/BUILD.gn
@@ -109,6 +109,7 @@ source_set("browser") {
     "//components/viz/common",
     "//services/resource_coordinator/public/cpp/memory_instrumentation",
     "//starboard:starboard_group",
+    "//storage/browser",
   ]
 
   if (!cobalt_is_release_build) {

--- a/cobalt/browser/cobalt_content_browser_client.cc
+++ b/cobalt/browser/cobalt_content_browser_client.cc
@@ -14,6 +14,7 @@
 
 #include "cobalt/browser/cobalt_content_browser_client.h"
 
+#include <algorithm>
 #include <string>
 
 #include "base/base_switches.h"
@@ -33,6 +34,8 @@
 #include "base/strings/string_split.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
+#include "base/task/thread_pool.h"
+#include "base/threading/scoped_blocking_call.h"
 #include "base/time/time.h"
 #include "base/timer/elapsed_timer.h"
 #include "cobalt/browser/cobalt_browser_interface_binders.h"
@@ -78,6 +81,10 @@
 #include "services/network/public/cpp/features.h"
 #include "services/network/public/mojom/network_context.mojom.h"
 #include "services/service_manager/public/cpp/binder_registry.h"
+#include "starboard/configuration_constants.h"
+#include "storage/browser/quota/quota_device_info_helper.h"
+#include "storage/browser/quota/quota_features.h"
+#include "storage/browser/quota/quota_settings.h"
 #include "third_party/blink/public/common/associated_interfaces/associated_interface_registry.h"
 #include "third_party/blink/public/common/web_preferences/web_preferences.h"
 
@@ -223,6 +230,52 @@ blink::UserAgentMetadata GetCobaltUserAgentMetadata() {
   metadata.wow64 = embedder_support::IsWoW64();
 
   return metadata;
+}
+
+std::optional<storage::QuotaSettings> CalculateCobaltCacheQuotaSettings(
+    const base::FilePath& cache_path,
+    storage::QuotaDeviceInfoHelper* device_info_helper) {
+  base::ScopedBlockingCall scoped_blocking_call(FROM_HERE,
+                                                base::BlockingType::MAY_BLOCK);
+
+  int64_t total = device_info_helper->AmountOfTotalDiskSpace(cache_path);
+  if (total <= 0) {
+    LOG(ERROR) << "Unable to compute QuotaSettings for cache path: "
+               << cache_path;
+    return std::nullopt;
+  }
+
+  int64_t pool_size = total;
+  if (kSbMaxSystemPathCacheDirectorySize > 0) {
+    pool_size = std::min(
+        pool_size, static_cast<int64_t>(kSbMaxSystemPathCacheDirectorySize));
+  }
+
+  const int64_t kMustRemainAvailableFixed =
+      static_cast<int64_t>(storage::features::kMustRemainAvailableBytes.Get());
+  const double kMustRemainAvailableRatio =
+      storage::features::kMustRemainAvailableRatio.Get();
+
+  const int64_t kShouldRemainAvailableFixed = static_cast<int64_t>(
+      storage::features::kShouldRemainAvailableBytes.Get());
+  const double kShouldRemainAvailableRatio =
+      storage::features::kShouldRemainAvailableRatio.Get();
+
+  storage::QuotaSettings settings;
+  settings.pool_size = pool_size;
+  // Cobalt only needs to cache data from a single origin (youtube.com),
+  // so allocate 100% of the pool to the storage key.
+  settings.per_storage_key_quota = pool_size;
+  settings.session_only_per_storage_key_quota = pool_size;
+  settings.should_remain_available =
+      std::min(kShouldRemainAvailableFixed,
+               static_cast<int64_t>(total * kShouldRemainAvailableRatio));
+  settings.must_remain_available =
+      std::min(kMustRemainAvailableFixed,
+               static_cast<int64_t>(total * kMustRemainAvailableRatio));
+  settings.refresh_interval = base::Seconds(60);
+
+  return settings;
 }
 
 CobaltContentBrowserClient::CobaltContentBrowserClient(
@@ -464,6 +517,34 @@ void CobaltContentBrowserClient::ConfigureNetworkContextParams(
   // NetworkAnonymizationKey / IsolationInfos, so storage can be isolated on a
   // per-site basis.
   network_context_params->require_network_anonymization_key = true;
+}
+
+void CobaltContentBrowserClient::GetCacheQuotaSettings(
+    content::BrowserContext* browser_context,
+    const base::FilePath& cache_path,
+    storage::OptionalQuotaSettingsCallback callback) {
+  if (browser_context && browser_context->IsOffTheRecord()) {
+    storage::GetNominalDynamicSettings(cache_path, /*is_incognito=*/true,
+                                       storage::GetDefaultDeviceInfoHelper(),
+                                       std::move(callback));
+    return;
+  }
+
+  base::ThreadPool::PostTaskAndReplyWithResult(
+      FROM_HERE,
+      {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
+       base::TaskShutdownBehavior::CONTINUE_ON_SHUTDOWN},
+      base::BindOnce(&CalculateCobaltCacheQuotaSettings, cache_path,
+                     storage::GetDefaultDeviceInfoHelper()),
+      std::move(callback));
+}
+
+// static
+std::optional<storage::QuotaSettings>
+CobaltContentBrowserClient::CalculateCacheQuotaSettingsForTesting(
+    const base::FilePath& cache_path,
+    storage::QuotaDeviceInfoHelper* device_info_helper) {
+  return CalculateCobaltCacheQuotaSettings(cache_path, device_info_helper);
 }
 
 void CobaltContentBrowserClient::OnWebContentsCreated(

--- a/cobalt/browser/cobalt_content_browser_client.h
+++ b/cobalt/browser/cobalt_content_browser_client.h
@@ -26,6 +26,7 @@
 #include "content/public/browser/generated_code_cache_settings.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
 #include "starboard/window.h"
+#include "storage/browser/quota/quota_settings.h"
 
 #if BUILDFLAG(IS_STARBOARD)
 #include "ui/ozone/platform/starboard/platform_window_starboard.h"
@@ -43,6 +44,10 @@ class WebContents;
 namespace metrics_services_manager {
 class MetricsServicesManager;
 }  // namespace metrics_services_manager
+
+namespace storage {
+class QuotaDeviceInfoHelper;
+}  // namespace storage
 
 namespace mojo {
 template <typename>
@@ -107,6 +112,15 @@ class CobaltContentBrowserClient : public content::ShellContentBrowserClient {
       network::mojom::NetworkContextParams* network_context_params,
       cert_verifier::mojom::CertVerifierCreationParams*
           cert_verifier_creation_params) override;
+  void GetCacheQuotaSettings(
+      content::BrowserContext* browser_context,
+      const base::FilePath& cache_path,
+      ::storage::OptionalQuotaSettingsCallback callback) override;
+
+  static std::optional<::storage::QuotaSettings>
+  CalculateCacheQuotaSettingsForTesting(
+      const base::FilePath& cache_path,
+      ::storage::QuotaDeviceInfoHelper* device_info_helper);
   void OverrideWebPreferences(content::WebContents* web_contents,
                               content::SiteInstance& main_frame_site,
                               blink::web_pref::WebPreferences* prefs) override;

--- a/cobalt/browser/cobalt_content_browser_client_unittest.cc
+++ b/cobalt/browser/cobalt_content_browser_client_unittest.cc
@@ -17,15 +17,31 @@
 #include <string>
 #include <variant>
 
+#include "base/files/file_path.h"
 #include "base/test/task_environment.h"
+#include "base/test/test_future.h"
 #include "build/build_config.h"
 #include "cobalt/browser/global_features.h"
 #include "content/public/browser/overlay_window.h"
+#include "starboard/configuration_constants.h"
+#include "storage/browser/quota/quota_device_info_helper.h"
+#include "storage/browser/quota/quota_settings.h"
+#include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 
 namespace cobalt {
 namespace {
+
+class MockQuotaDeviceInfoHelper : public storage::QuotaDeviceInfoHelper {
+ public:
+  MockQuotaDeviceInfoHelper() = default;
+  MOCK_METHOD(int64_t,
+              AmountOfTotalDiskSpace,
+              (const base::FilePath&),
+              (const, override));
+  MOCK_METHOD(uint64_t, AmountOfPhysicalMemory, (), (const, override));
+};
 
 class CobaltContentBrowserClientTest : public testing::Test {
  protected:
@@ -63,6 +79,82 @@ TEST_F(CobaltContentBrowserClientTest,
 #else
   EXPECT_EQ(window, nullptr);
 #endif
+}
+
+TEST_F(CobaltContentBrowserClientTest, GetCacheQuotaSettings_LargeDiskSpace) {
+  MockQuotaDeviceInfoHelper device_info_helper;
+  const int64_t kTotalDiskSpace = 500LL * 1024 * 1024 * 1024;  // 500 GB
+  EXPECT_CALL(device_info_helper, AmountOfTotalDiskSpace(testing::_))
+      .WillRepeatedly(testing::Return(kTotalDiskSpace));
+
+  auto settings =
+      CobaltContentBrowserClient::CalculateCacheQuotaSettingsForTesting(
+          base::FilePath(FILE_PATH_LITERAL("/dummy/cache")),
+          &device_info_helper);
+
+  ASSERT_TRUE(settings.has_value());
+  const int64_t expected_pool_size =
+      static_cast<int64_t>(kSbMaxSystemPathCacheDirectorySize);
+  EXPECT_EQ(settings->pool_size, expected_pool_size);
+  EXPECT_EQ(settings->per_storage_key_quota, expected_pool_size);
+  EXPECT_EQ(settings->session_only_per_storage_key_quota, expected_pool_size);
+  // Must remain available should be min(1GB, 500GB * 0.01 = 5GB) = 1GB.
+  EXPECT_EQ(settings->must_remain_available, 1024LL * 1024 * 1024);
+  // Should remain available should be min(2GB, 500GB * 0.10 = 50GB) = 2GB.
+  EXPECT_EQ(settings->should_remain_available, 2048LL * 1024 * 1024);
+}
+
+TEST_F(CobaltContentBrowserClientTest, GetCacheQuotaSettings_SmallDiskSpace) {
+  MockQuotaDeviceInfoHelper device_info_helper;
+  const int64_t kTotalDiskSpace = 10LL * 1024 * 1024;  // 10 MB (< 24 MiB)
+  EXPECT_CALL(device_info_helper, AmountOfTotalDiskSpace(testing::_))
+      .WillRepeatedly(testing::Return(kTotalDiskSpace));
+
+  auto settings =
+      CobaltContentBrowserClient::CalculateCacheQuotaSettingsForTesting(
+          base::FilePath(FILE_PATH_LITERAL("/dummy/cache")),
+          &device_info_helper);
+
+  ASSERT_TRUE(settings.has_value());
+  EXPECT_EQ(settings->pool_size, kTotalDiskSpace);
+  EXPECT_EQ(settings->per_storage_key_quota, kTotalDiskSpace);
+  EXPECT_EQ(settings->session_only_per_storage_key_quota, kTotalDiskSpace);
+  // Must remain available should be min(1GB, 10MB * 0.01) = 104857 bytes (~100
+  // KB).
+  EXPECT_EQ(settings->must_remain_available,
+            static_cast<int64_t>(kTotalDiskSpace * 0.01));
+  // Should remain available should be min(2GB, 10MB * 0.10) = 1048576 bytes (1
+  // MB).
+  EXPECT_EQ(settings->should_remain_available,
+            static_cast<int64_t>(kTotalDiskSpace * 0.10));
+}
+
+TEST_F(CobaltContentBrowserClientTest, GetCacheQuotaSettings_DiskSpaceError) {
+  MockQuotaDeviceInfoHelper device_info_helper;
+  EXPECT_CALL(device_info_helper, AmountOfTotalDiskSpace(testing::_))
+      .WillRepeatedly(testing::Return(-1));
+
+  auto settings =
+      CobaltContentBrowserClient::CalculateCacheQuotaSettingsForTesting(
+          base::FilePath(FILE_PATH_LITERAL("/dummy/cache")),
+          &device_info_helper);
+
+  EXPECT_FALSE(settings.has_value());
+}
+
+TEST_F(CobaltContentBrowserClientTest, GetCacheQuotaSettings_AsyncDispatch) {
+  CobaltContentBrowserClient client(/*startup_timestamp=*/absl::nullopt,
+                                    /*deep_link=*/"",
+                                    /*is_visible=*/true);
+  base::test::TestFuture<std::optional<storage::QuotaSettings>> future;
+  client.GetCacheQuotaSettings(/*browser_context=*/nullptr,
+                               base::FilePath(FILE_PATH_LITERAL("/tmp")),
+                               future.GetCallback());
+  task_environment_.RunUntilIdle();
+  auto settings = future.Take();
+  ASSERT_TRUE(settings.has_value());
+  EXPECT_GT(settings->pool_size, 0);
+  EXPECT_EQ(settings->per_storage_key_quota, settings->pool_size);
 }
 
 }  // namespace


### PR DESCRIPTION
This allows wires kSbMaxSystemPathCacheDirectorySize to the StoragePartitionImpl quota calculation and expands the per-origin cache pool ratio from 60% to 100% of available cache space since Cobalt should only need to cache from youtube.com.

Bug: 555871214