### PR TITLE
media: Remove background memory release for DecoderBuffer

### DIFF
--- a/content/renderer/media/renderer_web_media_player_delegate.cc
+++ b/content/renderer/media/renderer_web_media_player_delegate.cc
@@ -244,11 +244,6 @@ void RendererWebMediaPlayerDelegate::OnPageVisibilityChanged(
       // into a hidden state to free up system memory resources.
       LOG(INFO) << "Decommitting memory blocks on page hidden.";
       ::media::DecoderBufferAllocator::Get()->DecommitAllDecommitableBlocks();
-
-      // Release idle memory in decoder buffer allocator when the application
-      // transitions into a hidden state to shed unused system memory resources.
-      LOG(INFO) << "Releasing idle memory on page hidden.";
-      ::media::DecoderBufferAllocator::Get()->ReleaseIdleMemory();
     }
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
   }

--- a/media/starboard/decoder_buffer_allocator.cc
+++ b/media/starboard/decoder_buffer_allocator.cc
@@ -112,24 +112,6 @@ DecoderBufferAllocator* DecoderBufferAllocator::Get() {
   return static_cast<DecoderBufferAllocator*>(DecoderBuffer::Allocator::Get());
 }
 
-void DecoderBufferAllocator::ReleaseIdleMemory() {
-  if (is_memory_pool_allocated_on_demand_) {
-    return;
-  }
-  base::AutoLock scoped_lock(mutex_);
-  if (!should_release_idle_memory_) {
-    return;
-  }
-
-  if (strategy_ && strategy_->GetAllocated() == 0) {
-    LOG(INFO) << "Freeing " << strategy_->GetCapacity()
-              << " bytes of decoder buffer pool.";
-    strategy_.reset();
-  } else {
-    has_pending_release_ = true;
-  }
-}
-
 void DecoderBufferAllocator::DecommitAllDecommitableBlocks() {
   if (!decommit_on_suspend_enabled_.load(std::memory_order_acquire)) {
     return;
@@ -144,7 +126,6 @@ DecoderBuffer::Allocator::Handle DecoderBufferAllocator::Allocate(
     DemuxerStream::Type type,
     size_t size) {
   base::AutoLock scoped_lock(mutex_);
-  has_pending_release_ = false;
 
   EnsureStrategyIsCreated();
 
@@ -188,15 +169,13 @@ void DecoderBufferAllocator::Free(DemuxerStream::Type type,
 
   bool should_reset_strategy =
       is_strategy_switch_pending_ || is_memory_pool_allocated_on_demand_;
-  // Handle deferred memory release when suspended
-  should_reset_strategy |= has_pending_release_;
+
   if (should_reset_strategy && strategy_->GetAllocated() == 0) {
     // `strategy_->PrintAllocations()` will be called inside the dtor when
     // supported, so it shouldn't be called here.
     LOG(INFO) << "Freeing " << strategy_->GetCapacity()
               << " bytes of decoder buffer pool.";
     strategy_.reset();
-    has_pending_release_ = false;
   }
 }
 
@@ -346,10 +325,6 @@ base::expected<void, std::string> DecoderBufferAllocator::SetSetting(
     return ProcessEnableOnlySetting(name, value,
                                     [] { EnableMediaBufferPoolStrategy(); });
   }
-  if (name == "DecoderBuffer.ReleaseMemoryOnBackground") {
-    return ProcessEnableOnlySetting(name, value,
-                                    [] { EnableReleaseIdleMemory(); });
-  }
   return base::unexpected(name + " isn't a supported setting.");
 }
 
@@ -445,15 +420,6 @@ void DecoderBufferAllocator::EnableMediaBufferPoolStrategy() {
                   << " as MediaBufferPool::Acquire() returns nullptr.";
         return nullptr;
       }));
-}
-
-// static
-void DecoderBufferAllocator::EnableReleaseIdleMemory() {
-  auto* allocator = Get();
-  CHECK(allocator);
-  base::AutoLock scoped_lock(allocator->mutex_);
-  allocator->should_release_idle_memory_ = true;
-  LOG(INFO) << "DecoderBufferAllocator: ReleaseIdleMemory feature enabled.";
 }
 
 void DecoderBufferAllocator::EnsureStrategyIsCreated() {

--- a/media/starboard/decoder_buffer_allocator.h
+++ b/media/starboard/decoder_buffer_allocator.h
@@ -96,7 +96,6 @@ class DecoderBufferAllocator : public DecoderBuffer::Allocator,
 
   static DecoderBufferAllocator* Get();
 
-  void ReleaseIdleMemory();
   void DecommitAllDecommitableBlocks();
 
   // DecoderBuffer::Allocator methods.
@@ -165,7 +164,6 @@ class DecoderBufferAllocator : public DecoderBuffer::Allocator,
       bool enable_decommit_on_suspend,
       bool periodic_decommit);
   static void EnableMediaBufferPoolStrategy();
-  static void EnableReleaseIdleMemory();
 
   void EnsureStrategyIsCreated() EXCLUSIVE_LOCKS_REQUIRED(mutex_);
   void EnablePeriodicDecommitLoop();
@@ -183,11 +181,6 @@ class DecoderBufferAllocator : public DecoderBuffer::Allocator,
   mutable base::Lock mutex_;
   std::unique_ptr<Strategy> strategy_ GUARDED_BY(mutex_);
   bool is_strategy_switch_pending_ GUARDED_BY(mutex_) = false;
-  // ReleaseIdleMemory() can be called on the UI thread while buffers are still
-  // actively decoding on the media thread. We defer idle memory reclamation
-  // until buffers drain in Free().
-  bool has_pending_release_ GUARDED_BY(mutex_) = false;
-  bool should_release_idle_memory_ GUARDED_BY(mutex_) = false;
   StrategyCreateCB experimental_strategy_create_cb_ GUARDED_BY(mutex_);
   scoped_refptr<PeriodicDecommitState> periodic_decommit_state_
       GUARDED_BY(mutex_);


### PR DESCRIPTION
Revert changes from commit b0b2317d00c53741b8d7e8c38a5cdefaa4f0f4bb that shed decoder buffer memory when the application enters the background.

Results from experiment b/529454622 indicated significant regressions in YouTube Time (-1.90%), Watch Time (-1.85%), and active devices (-1.34%), along with an increase in cold home start latency (+165 ms) and a +12.76% increase in player reloads upon resume. The experiment was deprecated and the feature is now removed.

Bug: 529454622