### PR TITLE
android: Delay V8 Write Using PostDelayedIdleTask

### DIFF
--- a/third_party/blink/renderer/bindings/core/v8/v8_script_runner.cc
+++ b/third_party/blink/renderer/bindings/core/v8/v8_script_runner.cc
@@ -666,18 +666,22 @@ ScriptEvaluationResult V8ScriptRunner::CompileAndRunScript(
         auto code_cache_task = WTF::BindOnce(&DelayedProduceCodeCacheTask,
                                              WrapPersistent(script_state),
                                              v8::Global<v8::Script>(isolate, script),
-                                             WrapPersistent(cache_handler),
+                                             std::move(cache_handler),
                                              classic_script->SourceText().length(),
                                              classic_script->SourceUrl(),
                                              classic_script->StartPosition());
 
-        ThreadScheduler::Current()->PostDelayedIdleTask(
-            FROM_HERE, base::Milliseconds(1),
-            WTF::BindOnce(
-                [](base::OnceClosure task, base::TimeTicks /* deadline */) {
-                  std::move(task).Run();
-                },
-                std::move(code_cache_task)));
+        if (auto* scheduler = ThreadScheduler::Current()) {
+          scheduler->PostDelayedIdleTask(
+              FROM_HERE, base::Milliseconds(1),
+              WTF::BindOnce(
+                  [](base::OnceClosure task, base::TimeTicks /* deadline */) {
+                    std::move(task).Run();
+                  },
+                  std::move(code_cache_task)));
+        } else {
+          std::move(code_cache_task).Run();
+        }
       } else
 #endif
       if (produce_cache_options ==

--- a/third_party/blink/renderer/bindings/core/v8/v8_script_runner.cc
+++ b/third_party/blink/renderer/bindings/core/v8/v8_script_runner.cc
@@ -32,6 +32,7 @@
 #include "base/feature_list.h"
 #include "base/metrics/histogram_functions.h"
 #include "build/build_config.h"
+#include "third_party/blink/renderer/platform/scheduler/public/thread_scheduler.h"
 #include "third_party/blink/public/common/features.h"
 #include "third_party/blink/public/common/page/v8_compile_hints_histograms.h"
 #include "third_party/blink/public/mojom/v8_cache_options.mojom-blink.h"
@@ -653,19 +654,35 @@ ScriptEvaluationResult V8ScriptRunner::CompileAndRunScript(
           cache_handler) {
         cache_handler->WillProduceCodeCache();
       }
-#if BUILDFLAG(IS_COBALT)
+#if BUILDFLAG(IS_COBALT) && BUILDFLAG(IS_ANDROID)
       static const bool defer_v8_code_cache_write =
           base::CommandLine::ForCurrentProcess()->HasSwitch(
               "defer-v8-code-cache-write");
       if (produce_cache_options ==
               V8CodeCache::ProduceCacheOptions::kProduceCodeCache &&
-          (execution_context->IsServiceWorkerGlobalScope() ||
-           defer_v8_code_cache_write)) {
-#else
+          defer_v8_code_cache_write) {
+        // Route V8 cache write through ThreadScheduler's Idle queue to free up thread
+        // space for more critical work on startup.
+        auto code_cache_task = WTF::BindOnce(&DelayedProduceCodeCacheTask,
+                                             WrapPersistent(script_state),
+                                             v8::Global<v8::Script>(isolate, script),
+                                             WrapPersistent(cache_handler),
+                                             classic_script->SourceText().length(),
+                                             classic_script->SourceUrl(),
+                                             classic_script->StartPosition());
+
+        ThreadScheduler::Current()->PostDelayedIdleTask(
+            FROM_HERE, base::Milliseconds(1),
+            WTF::BindOnce(
+                [](base::OnceClosure task, base::TimeTicks /* deadline */) {
+                  std::move(task).Run();
+                },
+                std::move(code_cache_task)));
+      } else
+#endif
       if (produce_cache_options ==
               V8CodeCache::ProduceCacheOptions::kProduceCodeCache &&
           execution_context->IsServiceWorkerGlobalScope()) {
-#endif
         static constexpr base::TimeDelta kCacheCodeOnIdleDelay =
             base::Milliseconds(1);
         // TODO(crbug.com/40202028): Consider scheduling idle tasks via

--- a/third_party/blink/renderer/bindings/core/v8/v8_script_runner.cc
+++ b/third_party/blink/renderer/bindings/core/v8/v8_script_runner.cc
@@ -666,7 +666,7 @@ ScriptEvaluationResult V8ScriptRunner::CompileAndRunScript(
         auto code_cache_task = WTF::BindOnce(&DelayedProduceCodeCacheTask,
                                              WrapPersistent(script_state),
                                              v8::Global<v8::Script>(isolate, script),
-                                             std::move(cache_handler),
+                                             WrapPersistent(cache_handler),
                                              classic_script->SourceText().length(),
                                              classic_script->SourceUrl(),
                                              classic_script->StartPosition());

--- a/third_party/blink/renderer/bindings/core/v8/v8_script_runner.cc
+++ b/third_party/blink/renderer/bindings/core/v8/v8_script_runner.cc
@@ -654,7 +654,7 @@ ScriptEvaluationResult V8ScriptRunner::CompileAndRunScript(
           cache_handler) {
         cache_handler->WillProduceCodeCache();
       }
-#if BUILDFLAG(IS_COBALT) && BUILDFLAG(IS_ANDROID)
+#if BUILDFLAG(IS_COBALT)
       static const bool defer_v8_code_cache_write =
           base::CommandLine::ForCurrentProcess()->HasSwitch(
               "defer-v8-code-cache-write");


### PR DESCRIPTION
This PR updates the `defer-v8-code-cache-write` feature flag for Cobalt on Android to leverage Blink's `ThreadScheduler` Idle Task loop.     
                   
#11790 deferred cache tasks through ExecutionContext queues like `TaskType::kInternalDefault` or `TaskType::kIdleTask`. However, this caused some regressions to Active Devices, amongst other metrics although we saw improvements in PMF from 0-4 min. 

By migrating to `ThreadScheduler::Current()->PostDelayedIdleTask()`, we push the cache generation strictly to the back of the priority line, preventing competition with the UI load on launch. 
The task now acts as transparent filler work, processing only when the 60fps rendering lifecycle has genuine leftover frame budget before the next vsync.

Bug: 544849876