### PR TITLE
gpu: Fix EGL context restore and teardown crashes on Android suspend/resume

### DIFF
--- a/components/viz/service/gl/gpu_service_impl.cc
+++ b/components/viz/service/gl/gpu_service_impl.cc
@@ -1317,15 +1317,21 @@ void GpuServiceImpl::OnForegroundedOnMainThread() {
   // accessor simple and avoids lazy-initialization races across client threads.
   gl::GLDisplayEGL* display = gl::GetDefaultDisplayEGL();
   if (display) {
+    bool reinitialized_display = false;
     if (!display->IsInitialized()) {
       gl::init::GetOrInitializeGLOneOffPlatformImplementation(
           /*fallback_to_software_gl=*/false,
           /*disable_gl_drawing=*/false,
           /*init_extensions=*/true,
           gl::GpuPreference::kDefault);
+      reinitialized_display = true;
     }
     if (display->IsInitialized() &&
-        !gpu_channel_manager_->default_offscreen_surface()) {
+        (!gpu_channel_manager_->default_offscreen_surface() ||
+         reinitialized_display)) {
+      if (gpu_channel_manager_->default_offscreen_surface()) {
+        gpu_channel_manager_->default_offscreen_surface()->Destroy();
+      }
       scoped_refptr<gl::GLSurface> surface =
           gl::init::CreateOffscreenGLSurface(display, gfx::Size());
       gpu_channel_manager_->SetDefaultOffscreenSurface(std::move(surface));

--- a/components/viz/service/gl/gpu_service_impl.cc
+++ b/components/viz/service/gl/gpu_service_impl.cc
@@ -1317,21 +1317,15 @@ void GpuServiceImpl::OnForegroundedOnMainThread() {
   // accessor simple and avoids lazy-initialization races across client threads.
   gl::GLDisplayEGL* display = gl::GetDefaultDisplayEGL();
   if (display) {
-    bool reinitialized_display = false;
     if (!display->IsInitialized()) {
       gl::init::GetOrInitializeGLOneOffPlatformImplementation(
           /*fallback_to_software_gl=*/false,
           /*disable_gl_drawing=*/false,
           /*init_extensions=*/true,
           gl::GpuPreference::kDefault);
-      reinitialized_display = true;
     }
     if (display->IsInitialized() &&
-        (!gpu_channel_manager_->default_offscreen_surface() ||
-         reinitialized_display)) {
-      if (gpu_channel_manager_->default_offscreen_surface()) {
-        gpu_channel_manager_->default_offscreen_surface()->Destroy();
-      }
+        !gpu_channel_manager_->default_offscreen_surface()) {
       scoped_refptr<gl::GLSurface> surface =
           gl::init::CreateOffscreenGLSurface(display, gfx::Size());
       gpu_channel_manager_->SetDefaultOffscreenSurface(std::move(surface));

--- a/gpu/command_buffer/service/raster_decoder.cc
+++ b/gpu/command_buffer/service/raster_decoder.cc
@@ -1163,7 +1163,8 @@ void RasterDecoderImpl::Destroy(bool have_context) {
 #if BUILDFLAG(IS_COBALT)
     // If the GL context is still valid (or using a non-GL backend) and has not
     // been marked lost, complete pending rasterization commands normally.
-    if ((have_context || !shared_context_state_->GrContextIsGL()) &&
+    if (shared_context_state_ &&
+        (have_context || !shared_context_state_->GrContextIsGL()) &&
         !shared_context_state_->context_lost()) {
       DoEndRasterCHROMIUM();
     } else {

--- a/gpu/command_buffer/service/raster_decoder.cc
+++ b/gpu/command_buffer/service/raster_decoder.cc
@@ -1161,10 +1161,17 @@ void RasterDecoderImpl::Destroy(bool have_context) {
   // on it.
   if (sk_surface_ || scoped_shared_image_raster_write_) {
 #if BUILDFLAG(IS_COBALT)
+    // If the GL context is still valid (or using a non-GL backend) and has not
+    // been marked lost, complete pending rasterization commands normally.
     if ((have_context || !shared_context_state_->GrContextIsGL()) &&
         !shared_context_state_->context_lost()) {
       DoEndRasterCHROMIUM();
     } else {
+      // When tearing down without a valid GL context, calling
+      // DoEndRasterCHROMIUM() would flush Skia commands and issue GL calls
+      // (e.g., glDrawElements) with no current context, crashing the driver.
+      // Safely unlock font handles and release pending write/surface state
+      // without submitting GPU commands.
       if (scoped_shared_image_raster_write_) {
         scoped_shared_image_raster_write_->set_callback(base::BindOnce(
             [](scoped_refptr<ServiceFontManager> font_manager,

--- a/gpu/command_buffer/service/raster_decoder.cc
+++ b/gpu/command_buffer/service/raster_decoder.cc
@@ -1160,7 +1160,30 @@ void RasterDecoderImpl::Destroy(bool have_context) {
   // Note: `have_context` is always false for Vulkan, so we don't gate this code
   // on it.
   if (sk_surface_ || scoped_shared_image_raster_write_) {
+#if BUILDFLAG(IS_COBALT)
+    if ((have_context || !shared_context_state_->GrContextIsGL()) &&
+        !shared_context_state_->context_lost()) {
+      DoEndRasterCHROMIUM();
+    } else {
+      if (scoped_shared_image_raster_write_) {
+        scoped_shared_image_raster_write_->set_callback(base::BindOnce(
+            [](scoped_refptr<ServiceFontManager> font_manager,
+               std::vector<SkDiscardableHandleId> handles) {
+              font_manager->Unlock(handles);
+            },
+            font_manager_, std::move(locked_handles_)));
+        scoped_shared_image_raster_write_.reset();
+        shared_image_raster_.reset();
+        locked_handles_.clear();
+      }
+      raster_canvas_ = nullptr;
+      scoped_shared_image_write_.reset();
+      sk_surface_ = nullptr;
+      end_semaphores_.clear();
+    }
+#else
     DoEndRasterCHROMIUM();
+#endif
   }
 
   if (have_context && use_gpu_raster_ && transfer_cache()) {

--- a/gpu/ipc/service/gpu_channel_manager.cc
+++ b/gpu/ipc/service/gpu_channel_manager.cc
@@ -770,36 +770,9 @@ void GpuChannelManager::DoWakeUpGpu() {
   glFinish();
   DidAccessGpu();
 }
+#endif  // BUILDFLAG(IS_ANDROID)
 
-void GpuChannelManager::OnBackgroundCleanup() {
-  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-
-  // Delete all the GL contexts when the channel does not use WebGL and Chrome
-  // goes to background on low-end devices.
-  std::vector<int> channels_to_clear;
-  for (auto& kv : gpu_channels_) {
-    // Stateful contexts (e.g. WebGL and WebGPU) support context lost
-    // notifications, but for now, skip those.
-    if (kv.second->HasActiveStatefulContext()) {
-      continue;
-    }
-    channels_to_clear.push_back(kv.first);
-    kv.second->MarkAllContextsLost();
-  }
-  for (int channel : channels_to_clear)
-    RemoveChannel(channel);
-
-  if (program_cache_)
-    program_cache_->Trim(0u);
-
-  if (shared_context_state_) {
-    shared_context_state_->MarkContextLost();
-    shared_context_state_.reset();
-  }
-
-  SkGraphics::PurgeAllCaches();
-}
-#elif BUILDFLAG(IS_COBALT)
+#if BUILDFLAG(IS_COBALT)
 void GpuChannelManager::OnBackgroundCleanup() {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
 
@@ -831,7 +804,36 @@ void GpuChannelManager::OnBackgroundCleanup() {
   // 5. Clear CPU-side font and 2D raster caches.
   SkGraphics::PurgeAllCaches();
 }
-#endif  // BUILDFLAG(IS_ANDROID)
+#elif BUILDFLAG(IS_ANDROID)
+void GpuChannelManager::OnBackgroundCleanup() {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+
+  // Delete all the GL contexts when the channel does not use WebGL and Chrome
+  // goes to background on low-end devices.
+  std::vector<int> channels_to_clear;
+  for (auto& kv : gpu_channels_) {
+    // Stateful contexts (e.g. WebGL and WebGPU) support context lost
+    // notifications, but for now, skip those.
+    if (kv.second->HasActiveStatefulContext()) {
+      continue;
+    }
+    channels_to_clear.push_back(kv.first);
+    kv.second->MarkAllContextsLost();
+  }
+  for (int channel : channels_to_clear)
+    RemoveChannel(channel);
+
+  if (program_cache_)
+    program_cache_->Trim(0u);
+
+  if (shared_context_state_) {
+    shared_context_state_->MarkContextLost();
+    shared_context_state_.reset();
+  }
+
+  SkGraphics::PurgeAllCaches();
+}
+#endif
 
 void GpuChannelManager::OnApplicationBackgrounded() {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);

--- a/gpu/ipc/service/gpu_channel_manager.cc
+++ b/gpu/ipc/service/gpu_channel_manager.cc
@@ -772,7 +772,36 @@ void GpuChannelManager::DoWakeUpGpu() {
 }
 #endif  // BUILDFLAG(IS_ANDROID)
 
-#if BUILDFLAG(IS_COBALT)
+#if BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
+void GpuChannelManager::OnBackgroundCleanup() {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+
+  // Delete all the GL contexts when the channel does not use WebGL and Chrome
+  // goes to background on low-end devices.
+  std::vector<int> channels_to_clear;
+  for (auto& kv : gpu_channels_) {
+    // Stateful contexts (e.g. WebGL and WebGPU) support context lost
+    // notifications, but for now, skip those.
+    if (kv.second->HasActiveStatefulContext()) {
+      continue;
+    }
+    channels_to_clear.push_back(kv.first);
+    kv.second->MarkAllContextsLost();
+  }
+  for (int channel : channels_to_clear)
+    RemoveChannel(channel);
+
+  if (program_cache_)
+    program_cache_->Trim(0u);
+
+  if (shared_context_state_) {
+    shared_context_state_->MarkContextLost();
+    shared_context_state_.reset();
+  }
+
+  SkGraphics::PurgeAllCaches();
+}
+#elif BUILDFLAG(IS_COBALT)
 void GpuChannelManager::OnBackgroundCleanup() {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
 
@@ -802,35 +831,6 @@ void GpuChannelManager::OnBackgroundCleanup() {
   }
 
   // 5. Clear CPU-side font and 2D raster caches.
-  SkGraphics::PurgeAllCaches();
-}
-#elif BUILDFLAG(IS_ANDROID)
-void GpuChannelManager::OnBackgroundCleanup() {
-  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-
-  // Delete all the GL contexts when the channel does not use WebGL and Chrome
-  // goes to background on low-end devices.
-  std::vector<int> channels_to_clear;
-  for (auto& kv : gpu_channels_) {
-    // Stateful contexts (e.g. WebGL and WebGPU) support context lost
-    // notifications, but for now, skip those.
-    if (kv.second->HasActiveStatefulContext()) {
-      continue;
-    }
-    channels_to_clear.push_back(kv.first);
-    kv.second->MarkAllContextsLost();
-  }
-  for (int channel : channels_to_clear)
-    RemoveChannel(channel);
-
-  if (program_cache_)
-    program_cache_->Trim(0u);
-
-  if (shared_context_state_) {
-    shared_context_state_->MarkContextLost();
-    shared_context_state_.reset();
-  }
-
   SkGraphics::PurgeAllCaches();
 }
 #endif

--- a/ui/gl/gl_context_egl.cc
+++ b/ui/gl/gl_context_egl.cc
@@ -414,16 +414,24 @@ void GLContextEGL::Destroy() {
 #if BUILDFLAG(IS_COBALT)
     // Unbind the context from the calling thread before destroying it so that
     // the driver or ANGLE immediately releases the thread context binding.
-    if (IsCurrent(nullptr) || eglGetCurrentContext() == context_) {
-      SetCurrent(nullptr);
-      eglMakeCurrent(gl_display_->GetDisplay(), EGL_NO_SURFACE, EGL_NO_SURFACE,
-                     EGL_NO_CONTEXT);
+    if (gl_display_ && gl_display_->IsInitialized()) {
+      if (gl_display_->IsEGLSurfacelessContextSupported() &&
+          (IsCurrent(nullptr) || eglGetCurrentContext() == context_)) {
+        SetCurrent(nullptr);
+        eglMakeCurrent(gl_display_->GetDisplay(), EGL_NO_SURFACE, EGL_NO_SURFACE,
+                       EGL_NO_CONTEXT);
+      }
+      if (!eglDestroyContext(gl_display_->GetDisplay(), context_)) {
+        LOG(ERROR) << "eglDestroyContext failed with error "
+                   << GetLastEGLErrorString();
+      }
     }
-#endif
+#else
     if (!eglDestroyContext(gl_display_->GetDisplay(), context_)) {
       LOG(ERROR) << "eglDestroyContext failed with error "
                  << GetLastEGLErrorString();
     }
+#endif
 
     context_ = nullptr;
   }
@@ -543,6 +551,13 @@ bool GLContextEGL::MakeCurrentImpl(GLSurface* surface) {
     glBindFramebufferEXT(GL_FRAMEBUFFER, 0);
   }
 
+#if BUILDFLAG(IS_COBALT)
+  if (!gl_display_ || !gl_display_->IsInitialized()) {
+    LOG(WARNING) << "Failed to make context current: display is not initialized";
+    return false;
+  }
+#endif
+
   if (!eglMakeCurrent(gl_display_->GetDisplay(), surface->GetHandle(),
                       surface->GetHandle(), context_)) {
     LOG(ERROR) << "eglMakeCurrent failed with error "
@@ -577,12 +592,23 @@ void GLContextEGL::ReleaseCurrent(GLSurface* surface) {
     glBindFramebufferEXT(GL_FRAMEBUFFER, 0);
 
   SetCurrent(nullptr);
+#if BUILDFLAG(IS_COBALT)
+  if (gl_display_ && gl_display_->IsInitialized()) {
+    if (!eglMakeCurrent(gl_display_->GetDisplay(), EGL_NO_SURFACE, EGL_NO_SURFACE,
+                        EGL_NO_CONTEXT)) {
+      LOG(ERROR) << "eglMakeCurrent failed to release current with error "
+                 << GetLastEGLErrorString();
+      lost_ = true;
+    }
+  }
+#else
   if (!eglMakeCurrent(gl_display_->GetDisplay(), EGL_NO_SURFACE, EGL_NO_SURFACE,
                       EGL_NO_CONTEXT)) {
     LOG(ERROR) << "eglMakeCurrent failed to release current with error "
                << GetLastEGLErrorString();
     lost_ = true;
   }
+#endif
 
   DCHECK(!IsCurrent(nullptr));
 }

--- a/ui/gl/gl_context_egl.cc
+++ b/ui/gl/gl_context_egl.cc
@@ -414,13 +414,15 @@ void GLContextEGL::Destroy() {
 #if BUILDFLAG(IS_COBALT)
     // Unbind the context from the calling thread before destroying it so that
     // the driver or ANGLE immediately releases the thread context binding.
-    if (gl_display_ && gl_display_->IsInitialized()) {
-      if (gl_display_->IsEGLSurfacelessContextSupported() &&
-          (IsCurrent(nullptr) || eglGetCurrentContext() == context_)) {
-        SetCurrent(nullptr);
+    if (IsCurrent(nullptr) || eglGetCurrentContext() == context_) {
+      SetCurrent(nullptr);
+      if (gl_display_ && gl_display_->IsInitialized() &&
+          gl_display_->IsEGLSurfacelessContextSupported()) {
         eglMakeCurrent(gl_display_->GetDisplay(), EGL_NO_SURFACE, EGL_NO_SURFACE,
                        EGL_NO_CONTEXT);
       }
+    }
+    if (gl_display_ && gl_display_->IsInitialized()) {
       if (!eglDestroyContext(gl_display_->GetDisplay(), context_)) {
         LOG(ERROR) << "eglDestroyContext failed with error "
                    << GetLastEGLErrorString();


### PR DESCRIPTION
Fix forward following PR #11796.

Prioritize Cobalt's synchronous GPU channel teardown over standard
Android background cleanup. This ensures that GPU channels and
the shared context are destroyed before the EGL display is
terminated during suspension.

Update GL context logic to verify EGL display initialization before
destruction and state changes. Guard against flushing raster
commands when the GL context is unavailable to prevent driver
segfaults. Additionally, ensure the default offscreen surface is
recreated when the EGL display is re-initialized on resume.

Bug: 556622752