### PR TITLE
tvos: Build test targets on non-release configs

### DIFF
--- a/cobalt/devinfra/kokoro/bin/common.sh
+++ b/cobalt/devinfra/kokoro/bin/common.sh
@@ -124,11 +124,6 @@ is_release_build () {
 }
 
 
-is_nightly_build () {
-  is_release_build || [[ "${KOKORO_JOB_NAME:-}" == *nightly* ]] || [[ "${KOKORO_ROOT_JOB_NAME:-}" == *nightly* ]]
-}
-
-
 is_release_config () {
   [[ "${RELEASE_CONFIGS}" =~ "${CONFIG}" ]]
 }

--- a/cobalt/devinfra/kokoro/bin/presubmit_build_mac.sh
+++ b/cobalt/devinfra/kokoro/bin/presubmit_build_mac.sh
@@ -113,9 +113,9 @@ EOF
   # Build Cobalt.
   local out_dir="${WORKSPACE_COBALT}/out/${TARGET_PLATFORM}_${CONFIG}"
 
-  # Extract test targets from JSON for non-nightly (e.g. presubmit) builds.
+  # Extract test targets from JSON for non-release configs (e.g. devel).
   local json_targets=""
-  if ! is_nightly_build; then
+  if ! is_release_config; then
     local test_targets_json="${WORKSPACE_COBALT}/cobalt/build/testing/targets/${TARGET_PLATFORM}/test_targets.json"
     if [[ -f "${test_targets_json}" ]]; then
       # Extract test targets from the JSON file (list of dicts schema)


### PR DESCRIPTION
Ensure test targets are compiled for devel configurations across all
pipelines (presubmit, postsubmit, and nightly), skipping test targets
only on release configurations (qa and gold).

Tag: agy
Conv: 42c4eb1d-1654-400b-9199-fc68db892954
Bug: 555298615

---

<sub>Stack created with [GitHub Stacks CLI](https://github.com/github/gh-stack) • [Give Feedback 💬](https://gh.io/stacks-feedback)</sub>