### PR TITLE
build: Remove no-op modular test GN changes

### DIFF
--- a/cobalt/aosp/modular_apk.gni
+++ b/cobalt/aosp/modular_apk.gni
@@ -68,12 +68,11 @@ template("modular_apk") {
       deps += [ "//cobalt/shell:pak($default_toolchain)" ]
     }
 
-    if (_name == "nplb" || _name == "player_filter_tests") {
-      deps += [ "//starboard/shared/starboard/player:player_test_data_assets" ]
-    }
     if (_name == "nplb") {
-      deps +=
-          [ "//starboard/nplb/testdata/file_tests:nplb_file_tests_data_assets" ]
+      deps += [
+        "//starboard/nplb/testdata/file_tests:nplb_file_tests_data_assets",
+        "//starboard/shared/starboard/player:player_test_data_assets",
+      ]
     }
   }
 

--- a/cobalt/build/modular_executable.gni
+++ b/cobalt/build/modular_executable.gni
@@ -72,7 +72,6 @@ template("loader_final_target") {
 
     shared_library(original_target_name) {
       forward_variables_from(invoker, "*")
-      not_needed("*")
     }
 
     # TODO: b/421951995 - Use original loader target instead of copy target.
@@ -244,10 +243,7 @@ template("modular_executable") {
   }
 
   if (is_android) {
-    target("executable", _name) {
-      forward_variables_from(invoker, "*")
-      not_needed("*")
-    }
+    not_needed(invoker, "*", [ "testonly" ])
     modular_apk("${_name}_apk") {
       forward_variables_from(invoker, [ "testonly" ])
       module_name = _name


### PR DESCRIPTION
The player_filter_tests hunks that https://github.com/youtube/cobalt/pull/12068 added to modular_executable.gni and modular_apk.gni have no effect. Remove them.

Issue: 535995457