### PR TITLE
Cherry pick PR #12453: gpu: Fix EGL context restore and teardown crashes on Android suspend/resume

### DIFF
--- a/gpu/command_buffer/service/raster_decoder.cc
+++ b/gpu/command_buffer/service/raster_decoder.cc
@@ -1160,7 +1160,38 @@ void RasterDecoderImpl::Destroy(bool have_context) {
   // Note: `have_context` is always false for Vulkan, so we don't gate this code
   // on it.
   if (sk_surface_ || scoped_shared_image_raster_write_) {
+#if BUILDFLAG(IS_COBALT)
+    // If the GL context is still valid (or using a non-GL backend) and has not
+    // been marked lost, complete pending rasterization commands normally.
+    if (shared_context_state_ &&
+        (have_context || !shared_context_state_->GrContextIsGL()) &&
+        !shared_context_state_->context_lost()) {
+      DoEndRasterCHROMIUM();
+    } else {
+      // When tearing down without a valid GL context, calling
+      // DoEndRasterCHROMIUM() would flush Skia commands and issue GL calls
+      // (e.g., glDrawElements) with no current context, crashing the driver.
+      // Safely unlock font handles and release pending write/surface state
+      // without submitting GPU commands.
+      if (scoped_shared_image_raster_write_) {
+        scoped_shared_image_raster_write_->set_callback(base::BindOnce(
+            [](scoped_refptr<ServiceFontManager> font_manager,
+               std::vector<SkDiscardableHandleId> handles) {
+              font_manager->Unlock(handles);
+            },
+            font_manager_, std::move(locked_handles_)));
+        scoped_shared_image_raster_write_.reset();
+        shared_image_raster_.reset();
+        locked_handles_.clear();
+      }
+      raster_canvas_ = nullptr;
+      scoped_shared_image_write_.reset();
+      sk_surface_ = nullptr;
+      end_semaphores_.clear();
+    }
+#else
     DoEndRasterCHROMIUM();
+#endif
   }
 
   if (have_context && use_gpu_raster_ && transfer_cache()) {

--- a/gpu/ipc/service/gpu_channel_manager.cc
+++ b/gpu/ipc/service/gpu_channel_manager.cc
@@ -770,7 +770,9 @@ void GpuChannelManager::DoWakeUpGpu() {
   glFinish();
   DidAccessGpu();
 }
+#endif  // BUILDFLAG(IS_ANDROID)
 
+#if BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
 void GpuChannelManager::OnBackgroundCleanup() {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
 
@@ -831,7 +833,7 @@ void GpuChannelManager::OnBackgroundCleanup() {
   // 5. Clear CPU-side font and 2D raster caches.
   SkGraphics::PurgeAllCaches();
 }
-#endif  // BUILDFLAG(IS_ANDROID)
+#endif
 
 void GpuChannelManager::OnApplicationBackgrounded() {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);

--- a/ui/gl/gl_context_egl.cc
+++ b/ui/gl/gl_context_egl.cc
@@ -416,14 +416,24 @@ void GLContextEGL::Destroy() {
     // the driver or ANGLE immediately releases the thread context binding.
     if (IsCurrent(nullptr) || eglGetCurrentContext() == context_) {
       SetCurrent(nullptr);
-      eglMakeCurrent(gl_display_->GetDisplay(), EGL_NO_SURFACE, EGL_NO_SURFACE,
-                     EGL_NO_CONTEXT);
+      if (gl_display_ && gl_display_->IsInitialized() &&
+          gl_display_->IsEGLSurfacelessContextSupported()) {
+        eglMakeCurrent(gl_display_->GetDisplay(), EGL_NO_SURFACE, EGL_NO_SURFACE,
+                       EGL_NO_CONTEXT);
+      }
     }
-#endif
+    if (gl_display_ && gl_display_->IsInitialized()) {
+      if (!eglDestroyContext(gl_display_->GetDisplay(), context_)) {
+        LOG(ERROR) << "eglDestroyContext failed with error "
+                   << GetLastEGLErrorString();
+      }
+    }
+#else
     if (!eglDestroyContext(gl_display_->GetDisplay(), context_)) {
       LOG(ERROR) << "eglDestroyContext failed with error "
                  << GetLastEGLErrorString();
     }
+#endif
 
     context_ = nullptr;
   }
@@ -543,6 +553,13 @@ bool GLContextEGL::MakeCurrentImpl(GLSurface* surface) {
     glBindFramebufferEXT(GL_FRAMEBUFFER, 0);
   }
 
+#if BUILDFLAG(IS_COBALT)
+  if (!gl_display_ || !gl_display_->IsInitialized()) {
+    LOG(WARNING) << "Failed to make context current: display is not initialized";
+    return false;
+  }
+#endif
+
   if (!eglMakeCurrent(gl_display_->GetDisplay(), surface->GetHandle(),
                       surface->GetHandle(), context_)) {
     LOG(ERROR) << "eglMakeCurrent failed with error "
@@ -577,12 +594,23 @@ void GLContextEGL::ReleaseCurrent(GLSurface* surface) {
     glBindFramebufferEXT(GL_FRAMEBUFFER, 0);
 
   SetCurrent(nullptr);
+#if BUILDFLAG(IS_COBALT)
+  if (gl_display_ && gl_display_->IsInitialized()) {
+    if (!eglMakeCurrent(gl_display_->GetDisplay(), EGL_NO_SURFACE, EGL_NO_SURFACE,
+                        EGL_NO_CONTEXT)) {
+      LOG(ERROR) << "eglMakeCurrent failed to release current with error "
+                 << GetLastEGLErrorString();
+      lost_ = true;
+    }
+  }
+#else
   if (!eglMakeCurrent(gl_display_->GetDisplay(), EGL_NO_SURFACE, EGL_NO_SURFACE,
                       EGL_NO_CONTEXT)) {
     LOG(ERROR) << "eglMakeCurrent failed to release current with error "
                << GetLastEGLErrorString();
     lost_ = true;
   }
+#endif
 
   DCHECK(!IsCurrent(nullptr));
 }


### PR DESCRIPTION
Refer to original PR: #12453

Fix forward for b/556622752 following PR #11796.

### Problem
On Android devices with native EGL/GLES drivers (e.g. Mali on Android
10), suspending the app caused a crash (SIGSEGV) in the GPU thread or
left the application in an infinite context restore failure loop on
resume (resulting in a persistent pitch-black screen):
1. In `GpuChannelManager::OnBackgroundCleanup()`, `#if
BUILDFLAG(IS_ANDROID)` preceded `#elif BUILDFLAG(IS_COBALT)`. In Android
Cobalt, both flags are defined, which caused Cobalt's synchronous
channel teardown and `default_offscreen_surface_` destruction to be
bypassed.
2. When the display shut down, `GLContextEGL::Destroy()` invoked
`eglDestroyContext(nullptr, context_)`, triggering a null-pointer
dereference (`display->getContext(ctx)`) at offset 0x28.
3. In `RasterDecoderImpl::Destroy(bool have_context)`,
`DoEndRasterCHROMIUM()` ran even when `have_context == false`, flushing
Skia commands and issuing `glDrawElements` without a current GL context,
crashing in `libGLES_mali.so`.
4. On resume, `default_offscreen_surface_` remained pointing to the
stale pbuffer surface from before `eglTerminate()`. Reusing it with a
new EGLDisplay and context produced repeated `EGL_BAD_MATCH` (3009) in
`eglMakeCurrent`.
5. Calling `eglMakeCurrent` with `EGL_NO_SURFACE` in
`GLContextEGL::Destroy()` failed with `EGL_BAD_MATCH` on drivers lacking
`EGL_KHR_surfaceless_context`.

### Solution
- `gpu/ipc/service/gpu_channel_manager.cc` & `.h`: Prioritize
`BUILDFLAG(IS_COBALT)` over `BUILDFLAG(IS_ANDROID)` in
`GpuChannelManager::OnBackgroundCleanup()` so Android Cobalt
synchronously destroys GPU channels, shared contexts, and the default
offscreen surface.
- `ui/gl/gl_context_egl.cc`: Guard `eglDestroyContext`,
`ReleaseCurrent`, and `MakeCurrentImpl` with display initialization
checks. Check `gl_display_->IsEGLSurfacelessContextSupported()` before
unbinding with `EGL_NO_SURFACE`.
- `gpu/command_buffer/service/raster_decoder.cc`: Guard
`DoEndRasterCHROMIUM()` in `RasterDecoderImpl::Destroy()` to prevent
flushing GL commands when the GL context is lost or unavailable.
Directly release locked font handles and surfaces.
- `components/viz/service/gl/gpu_service_impl.cc`: Ensure
`default_offscreen_surface` is cleanly recreated whenever the EGL
display is re-initialized on foreground.

### Testing
- Reproduced on Xiaomi MiTV Stick (aquaman, Android 10) with Cobalt QA
build: black screen on resume with repeating `EGL_BAD_MATCH` (3009).
- Verified fix on device across multiple consecutive suspend/resume
cycles: confirmed clean startup, zero crashes or SIGSEGV on suspend, and
instant, complete UI restoration on resume.

(cherry picked from commit 658e912e2f78d2d107735c7f4711285efb690488)

Bug: 556622752