### PR TITLE
starboard: Fix type in SbFeatureParamExt

### DIFF
--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -465,6 +465,7 @@ test("starboard_platform_tests") {
     ":test_support",
     "//base",
     "//starboard:starboard_group",
+    "//starboard/shared/starboard:starboard_test",
     "//starboard/shared/starboard/drm:drm_test_helpers",
     "//starboard/shared/starboard/player/filter/testing:test_util",
     "//starboard/testing:scoped_feature_list",

--- a/starboard/shared/starboard/feature_list.h
+++ b/starboard/shared/starboard/feature_list.h
@@ -145,12 +145,30 @@ struct SbFeatureParamExt : public SbFeatureParam {
                 "Unsupported Starboard FeatureParam<> type");
 
   constexpr SbFeatureParamExt(const SbFeature& feature, const char* name)
-      : SbFeatureParam{feature.name, name} {}
+      : SbFeatureParam{feature.name, name, GetParamType()} {}
 
   // Function used to retrieve the parameter value for a given param. Outside
   // code will call this function, which will then call the corresponding
   // FeatureList::GetParam function.
   T Get() const { return FeatureList::GetParam(*this); }
+
+ private:
+  static constexpr SbFeatureParamType GetParamType() {
+    if constexpr (std::is_same_v<bool, T>) {
+      return SbFeatureParamTypeBool;
+    } else if constexpr (std::is_same_v<int, T>) {
+      return SbFeatureParamTypeInt;
+    } else if constexpr (std::is_same_v<double, T>) {
+      return SbFeatureParamTypeDouble;
+    } else if constexpr (std::is_same_v<std::string, T>) {
+      return SbFeatureParamTypeString;
+    } else if constexpr (std::is_same_v<int64_t, T>) {
+      return SbFeatureParamTypeTime;
+    } else {
+      static_assert(!std::is_same_v<T, T>,
+                    "Unsupported Starboard FeatureParam<> type");
+    }
+  }
 };
 
 template <>

--- a/starboard/shared/starboard/feature_list_test.cc
+++ b/starboard/shared/starboard/feature_list_test.cc
@@ -146,4 +146,25 @@ TEST_F(StarboardFeatureListTest, CanAccessParams) {
     }
   }
 }
+
+TEST_F(StarboardFeatureListTest, FeatureParamExtHasCorrectType) {
+  SbFeatureParamExt<bool> bool_param(kStarboardFeatureTestEnabled, "ParamBool");
+  EXPECT_EQ(SbFeatureParamTypeBool, bool_param.type);
+
+  SbFeatureParamExt<int> int_param(kStarboardFeatureTestEnabled, "ParamInt");
+  EXPECT_EQ(SbFeatureParamTypeInt, int_param.type);
+
+  SbFeatureParamExt<double> double_param(kStarboardFeatureTestEnabled,
+                                         "ParamDouble");
+  EXPECT_EQ(SbFeatureParamTypeDouble, double_param.type);
+
+  SbFeatureParamExt<std::string> string_param(kStarboardFeatureTestEnabled,
+                                              "ParamString");
+  EXPECT_EQ(SbFeatureParamTypeString, string_param.type);
+
+  SbFeatureParamExt<int64_t> time_param(kStarboardFeatureTestEnabled,
+                                        "ParamTime");
+  EXPECT_EQ(SbFeatureParamTypeTime, time_param.type);
+}
+
 }  // namespace starboard


### PR DESCRIPTION
SbFeatureParamExt omitted the type field during aggregate initialization of the SbFeatureParam base struct, causing type to default to SbFeatureParamTypeBool (0) for all parameter types.

Initialize SbFeatureParam::type based on the template argument T. Also add a unit test in feature_list_test.cc to verify the type field and include starboard_test in starboard_platform_tests.

Bug: 435467391
Bug: 541298090