### PR TITLE
ci: trigger AI rebase agent from autoroll_chromium when conflicted PR created

### DIFF
--- a/.github/workflows/autoroll_chromium.yaml
+++ b/.github/workflows/autoroll_chromium.yaml
@@ -1,0 +1,200 @@
+name: Autoroll Chromium
+
+on:
+  schedule:
+    - cron: '0 */4 * * *' # Every 4th hour.
+  workflow_dispatch:
+    inputs:
+      max_commits:
+        description: 'Max number of commits to include on a single PR'
+        type: number
+        default: 1
+
+permissions:
+  contents: read
+
+jobs:
+  autoroll:
+    runs-on: ubuntu-latest
+    env:
+      DEPOT_TOOLS_METRICS: 0
+      GIT_AUTHOR_NAME: "cobalt-github-releaser-bot"
+      GIT_AUTHOR_EMAIL: "cobalt-github-releaser-bot@google.com"
+      GIT_COMMITTER_NAME: "cobalt-github-releaser-bot"
+      GIT_COMMITTER_EMAIL: "cobalt-github-releaser-bot@google.com"
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: write
+    defaults:
+      run:
+        working-directory: src
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: [
+          {source: chromium/main, target: staging, autoroll: .github/AUTOROLL_CHROMIUM},
+        ]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: src
+          fetch-depth: 1000
+          token: ${{ secrets.CHERRY_PICK_TOKEN }}
+
+      - name: Prepare Cherry Pick Branch
+        env:
+          SOURCE_BRANCH: ${{ matrix.branch.source }}
+          TARGET_BRANCH: ${{ matrix.branch.target }}
+          FETCH_DEPTH: 1000
+        run: |
+          set -x
+
+          git config --global submodule.recurse false
+
+          # Copy script from repository.
+          git show HEAD:.github/scripts/autoroll_chromium.py > "${RUNNER_TEMP}/autoroll_chromium.py"
+          git show HEAD:.github/scripts/autoroll_lib.py > "${RUNNER_TEMP}/autoroll_lib.py"
+
+          git fetch --depth="${FETCH_DEPTH}" --no-recurse-submodules origin "${TARGET_BRANCH}:${TARGET_BRANCH}"
+
+          # Use existing branch from remote if it exists, otherwise start from target branch.
+          if git fetch --depth="${FETCH_DEPTH}" --no-recurse-submodules origin "autoroll-${SOURCE_BRANCH}-to-${TARGET_BRANCH}"; then
+            git checkout --no-recurse-submodules -B "autoroll-${SOURCE_BRANCH}-to-${TARGET_BRANCH}" FETCH_HEAD
+          else
+            git checkout --no-recurse-submodules -B "autoroll-${SOURCE_BRANCH}-to-${TARGET_BRANCH}" "${TARGET_BRANCH}" --no-track
+          fi
+
+          # Fetch enough history for source branch.
+          git fetch --depth="${FETCH_DEPTH}" --no-recurse-submodules origin "${SOURCE_BRANCH}:${SOURCE_BRANCH}"
+
+      - name: Get Existing PR Info
+        id: pr_info
+        env:
+          GITHUB_TOKEN: ${{ secrets.CHERRY_PICK_TOKEN }}
+          SOURCE_BRANCH: ${{ matrix.branch.source }}
+          TARGET_BRANCH: ${{ matrix.branch.target }}
+        run: |
+          # Get the first commit SHA of the existing PR.
+          # If the PR doesn't exist, it returns an empty string.
+          FIRST_SHA=$(gh pr list --head "autoroll-${SOURCE_BRANCH}-to-${TARGET_BRANCH}" --state open --json commits --jq '.[0].commits[0].oid // ""')
+          echo "first_sha=${FIRST_SHA}" >> "${GITHUB_OUTPUT}"
+
+      - name: Set Up Depot Tools
+        run: |
+          DEPOT_TOOLS_TEMP="${RUNNER_TEMP}/depot_tools"
+          git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git "${DEPOT_TOOLS_TEMP}"
+          echo "${DEPOT_TOOLS_TEMP}" >> "${GITHUB_PATH}"
+          source "${DEPOT_TOOLS_TEMP}/bootstrap_python3" && bootstrap_python3
+
+      - name: Cherry Pick Merged PRs
+        id: autoroll
+        env:
+          MAX_COMMITS: ${{ inputs.max_commits || 1 }}
+          SOURCE_BRANCH: ${{ matrix.branch.source }}
+          AUTOROLL_FILE: ${{ matrix.branch.autoroll }}
+          FIRST_SHA: ${{ steps.pr_info.outputs.first_sha }}
+        run: |
+          set -x
+
+          # Run the Python script to perform cherry-picks and get all PR links.
+          PR_LINKS=$(python3 "${RUNNER_TEMP}/autoroll_chromium.py" \
+            --source-branch "${SOURCE_BRANCH}" \
+            --autoroll-file "${AUTOROLL_FILE}" \
+            --max-commits "${MAX_COMMITS}" \
+            --existing-pr-sha "${FIRST_SHA}")
+
+          if [[ -n "${PR_LINKS}" ]]; then
+            echo "cherry_picked=true" >> "${GITHUB_OUTPUT}"
+            {
+              echo "pr_links<<EOF"
+              echo "${PR_LINKS}"
+              echo "EOF"
+            } >> "${GITHUB_OUTPUT}"
+          else
+            echo "::warning::No commits to roll found."
+          fi
+
+      - name: Push and Create PR
+        id: create_pr
+        if: steps.autoroll.outputs.pr_links != ''
+        env:
+          SOURCE_BRANCH: ${{ matrix.branch.source }}
+          TARGET_BRANCH: ${{ matrix.branch.target }}
+          GITHUB_TOKEN: ${{ secrets.CHERRY_PICK_TOKEN }}
+          PR_LINKS: ${{ steps.autoroll.outputs.pr_links }}
+          AUTOROLL_FILE: ${{ matrix.branch.autoroll }}
+        run: |
+          set -x
+
+          git push origin "autoroll-${SOURCE_BRANCH}-to-${TARGET_BRANCH}"
+
+          PR_TITLE="Autoroll from ${SOURCE_BRANCH} to ${TARGET_BRANCH}"
+
+          PR_BODY_FILE=$(mktemp)
+          {
+            echo "Automated cherry-pick roll to ${TARGET_BRANCH}."
+            echo ""
+            echo "Original pull requests:"
+            echo "${PR_LINKS}"
+            echo ""
+            echo "To merge these changes, run the autoroll script:"
+            echo ""
+            echo '```bash'
+            echo "GITHUB_REPOSITORY=${GITHUB_REPOSITORY} python3 cobalt/devinfra/github/autoroll/merge_autoroll.py \\"
+            echo "  --source-branch ${SOURCE_BRANCH} \\"
+            echo "  --target-branch ${TARGET_BRANCH}"
+            echo '```'
+          } > "${PR_BODY_FILE}"
+
+          IS_CONFLICTED=false
+          if [[ -f "${AUTOROLL_FILE}" ]] && grep -q "^CONFLICTED:" "${AUTOROLL_FILE}"; then
+            IS_CONFLICTED=true
+            PR_TITLE="$(git log -1 --pretty=%s)"
+            {
+              echo ""
+              echo "This PR has conflicts that must be resolved manually (don't forget to update the \`${AUTOROLL_FILE}\` file). Use the following commands to checkout the branch locally and resolve the conflicts in a separate commit:"
+              echo ""
+              echo '```bash'
+              echo "gh pr checkout <pull_request_number> -R ${GITHUB_REPOSITORY}"
+              echo ""
+              echo "# Resolve conflicts and update ${AUTOROLL_FILE} then"
+              echo "git add <resolved_files>"
+              echo ""
+              echo "# Copy CONFLICTED commit's message and metadata"
+              echo "# Replace CONFLICTED in title with RESOLVED"
+              echo "git commit -c <conflicted_sha>"
+              echo ""
+              echo "git push origin autoroll-${SOURCE_BRANCH}-to-${TARGET_BRANCH}"
+              echo '```'
+            } >> "${PR_BODY_FILE}"
+          fi
+
+          PR_STATE=$(gh pr view "autoroll-${SOURCE_BRANCH}-to-${TARGET_BRANCH}" --json state --template '{{.state}}' 2>/dev/null || echo "NOT_FOUND")
+
+          if [[ "${PR_STATE}" == "OPEN" ]]; then
+            PR_NUMBER=$(gh pr view "autoroll-${SOURCE_BRANCH}-to-${TARGET_BRANCH}" --json number --jq .number)
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" -f title="${PR_TITLE}" -f body="$(cat "${PR_BODY_FILE}")" --jq .html_url
+          else
+            gh pr create --base "${TARGET_BRANCH}" --head "autoroll-${SOURCE_BRANCH}-to-${TARGET_BRANCH}" --title "${PR_TITLE}" --body-file "${PR_BODY_FILE}" --reviewer linxinan-yt,oxve,briantting
+            PR_NUMBER=$(gh pr view "autoroll-${SOURCE_BRANCH}-to-${TARGET_BRANCH}" --json number --jq .number)
+            echo "created=true" >> "${GITHUB_OUTPUT}"
+          fi
+          echo "pr_number=${PR_NUMBER}" >> "${GITHUB_OUTPUT}"
+          echo "is_conflicted=${IS_CONFLICTED}" >> "${GITHUB_OUTPUT}"
+
+      - name: Trigger AI Rebase Agent
+        if: steps.create_pr.outputs.created == 'true' && steps.create_pr.outputs.is_conflicted == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.CHERRY_PICK_TOKEN }}
+          PR_NUMBER: ${{ steps.create_pr.outputs.pr_number }}
+          TARGET_BRANCH: ${{ matrix.branch.target }}
+        run: |
+          set -x
+          echo "Dispatching AI Rebase Agent workflow for conflicted PR #${PR_NUMBER} on branch ${TARGET_BRANCH}..."
+          gh workflow run ai_rebase_resolver.yaml \
+            --repo "${GITHUB_REPOSITORY}" \
+            --ref "${TARGET_BRANCH}" \
+            -f pr_number="${PR_NUMBER}" \
+            -f dry_run=false || echo "::warning::Failed to trigger AI Rebase Agent workflow for PR #${PR_NUMBER}"


### PR DESCRIPTION
### Summary
Adds `.github/workflows/autoroll_chromium.yaml` to the `staging` branch and configures it to automatically dispatch the `ai_rebase_resolver.yaml` workflow whenever a newly created Chromium autoroll PR contains merge or cherry-pick conflicts (`CONFLICTED`).

### Changes
- Configures `actions: write` permission on the autoroll job to allow workflow dispatch.
- Detects whether the newly created PR contains conflicts (`is_conflicted`).
- Adds the `Trigger AI Rebase Agent` step which triggers `ai_rebase_resolver.yaml` with `-f pr_number="${PR_NUMBER}"` and `-f dry_run=false` on `staging`.

Bug: 552561778