### PR TITLE
ci: Fix CI Shepherd PR resolution for fork pull requests

### DIFF
--- a/.github/workflows/ci_shepherd.yml
+++ b/.github/workflows/ci_shepherd.yml
@@ -135,7 +135,7 @@ jobs:
             -f description="${desc}" \
             -f context="CI / ${WORKFLOW_NAME}"
 
-          pr_number=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" --jq '.[0].number // ""')
+          pr_number=$(gh pr list --repo "${REPO}" --search "${HEAD_SHA}" --json number --jq '.[0].number // ""')
           echo "pr_number=${pr_number}" >> "${GITHUB_OUTPUT}"
 
       - name: Generate Shepherd Report


### PR DESCRIPTION
Use `gh pr list` with commit SHA search to fetch the PR number associated with triggering workflow runs.

### Problem
Previously, `ci_shepherd` queried `repos/${REPO}/commits/${HEAD_SHA}/pulls`, which returns an empty list for pull requests opened from forks because GitHub's commits API on the upstream repository does not associate unmerged fork commits with the upstream PR. As a result, the sticky comment report was skipped on all fork PRs (such as #11871).

### Solution
Use `gh pr list --repo "${REPO}" --search "${HEAD_SHA}" --json number --jq '.[0].number // ""'`.
- Works seamlessly across both fork PRs and internal branch PRs using GitHub's GraphQL API.
- Scoped to open PRs in the repository, naturally returning empty for non-PR pushes to `main`.
- Replaces the REST commit-pulls query with zero fallback logic.

Bug: 551996294