### PR TITLE
cobalt: Fix YUV transfer and adapt GPU cache tests

### DIFF
--- a/cc/paint/image_transfer_cache_entry.cc
+++ b/cc/paint/image_transfer_cache_entry.cc
@@ -618,10 +618,16 @@ bool ClientImageTransferCacheEntry::SerializeInProcess(
   auto* payload = new InProcessImageTransferCachePayload();
   if (IsYuv()) {
     const int num_pixmaps = NumPixmapsForYUVConfig(image_.yuv_plane_config);
+    sk_sp<SkColorSpace> color_space =
+        image_.color_space ? sk_ref_sp(image_.color_space.get()) : nullptr;
     for (int i = 0; i < num_pixmaps; ++i) {
       if (image_.pixmaps[i]) {
+        SkPixmap pixmap = *image_.pixmaps[i];
+        if (color_space) {
+          pixmap.setColorSpace(color_space);
+        }
         payload->yuv_planes.push_back(
-            SkImages::RasterFromPixmap(*image_.pixmaps[i], nullptr, nullptr));
+            SkImages::RasterFromPixmap(pixmap, nullptr, nullptr));
       }
     }
     if (!payload->yuv_planes.empty() && image_.pixmaps[0]) {
@@ -629,8 +635,8 @@ bool ClientImageTransferCacheEntry::SerializeInProcess(
           image_.pixmaps[0]->dimensions(), image_.yuv_plane_config,
           image_.yuv_subsampling, image_.yuv_color_space);
     }
-    if (image_.color_space) {
-      payload->yuv_color_space = sk_ref_sp(image_.color_space.get());
+    if (color_space) {
+      payload->yuv_color_space = std::move(color_space);
     }
   } else {
     if (image_.pixmaps[0]) {
@@ -972,6 +978,11 @@ bool ServiceImageTransferCacheEntry::DeserializeInProcess(
       DLOG(ERROR) << "Failed to make YUV image from uploaded planes";
       return false;
     }
+    yuva_info_ = payload->yuva_info;
+    plane_images_ = std::move(uploaded_planes);
+    for (const auto& plane_image : plane_images_) {
+      plane_sizes_.push_back(plane_image->textureSize());
+    }
   } else {
     image_ = UploadImageInProcess(gr_context, payload->image,
                                   mip_mapped_for_upload);
@@ -1009,6 +1020,11 @@ bool ServiceImageTransferCacheEntry::DeserializeInProcess(
       DLOG(ERROR) << "Failed image color conversion.";
       return false;
     }
+
+    // Color conversion converts to RGBA. Remove all YUV state.
+    yuva_info_ = std::nullopt;
+    plane_images_.clear();
+    plane_sizes_.clear();
   }
 
   size_ = image_->textureSize();

--- a/cc/tiles/gpu_image_decode_cache_unittest.cc
+++ b/cc/tiles/gpu_image_decode_cache_unittest.cc
@@ -20,7 +20,12 @@
 #include "base/command_line.h"
 #include "base/containers/contains.h"
 #include "base/feature_list.h"
+#if BUILDFLAG(IS_COBALT)
+#include "base/features.h"
+#endif
 #include "base/memory/raw_ptr.h"
+#include "base/run_loop.h"
+#include "base/task/single_thread_task_runner.h"
 #include "base/test/scoped_feature_list.h"
 #include "base/test/simple_test_tick_clock.h"
 #include "base/test/test_mock_time_task_runner.h"
@@ -463,6 +468,16 @@ class GpuImageDecodeCacheTest
 #endif
         dark_mode_filter);
   }
+
+#if BUILDFLAG(IS_COBALT)
+  void FlushRunLoop() {
+    if (base::FeatureList::IsEnabled(
+            base::features::kCobaltInProcessImageTransferCache) &&
+        base::SingleThreadTaskRunner::HasCurrentDefault()) {
+      base::RunLoop().RunUntilIdle();
+    }
+  }
+#endif
 
   // Returns dimensions for an image that will not fit in GPU memory and hence
   // triggers software fallback.
@@ -1097,6 +1112,9 @@ TEST_P(GpuImageDecodeCacheTest, GetTaskForImageSameImageDifferentClients) {
     EXPECT_FALSE(cache->IsInInUseCacheForTesting(draw_image));
     EXPECT_FALSE(cache->IsInInUseCacheForTesting(draw_image2));
     EXPECT_FALSE(cache->IsInInUseCacheForTesting(draw_image3));
+#if BUILDFLAG(IS_COBALT)
+    FlushRunLoop();
+#endif
 
     cache->ClearCache();
   }
@@ -1667,6 +1685,9 @@ TEST_P(GpuImageDecodeCacheTest, GetDecodedImageForDraw) {
 
   TestTileTaskRunner::ProcessTask(result.task->dependencies()[0].get());
   TestTileTaskRunner::ProcessTask(result.task.get());
+#if BUILDFLAG(IS_COBALT)
+  FlushRunLoop();
+#endif
 
   // Must hold context lock before calling GetDecodedImageForDraw /
   // DrawWithImageFinished.
@@ -1715,6 +1736,9 @@ TEST_P(GpuImageDecodeCacheTest, GetHdrDecodedImageForDrawToHdr) {
 
   TestTileTaskRunner::ProcessTask(result.task->dependencies()[0].get());
   TestTileTaskRunner::ProcessTask(result.task.get());
+#if BUILDFLAG(IS_COBALT)
+  FlushRunLoop();
+#endif
 
   // Must hold context lock before calling GetDecodedImageForDraw /
   // DrawWithImageFinished.
@@ -1768,6 +1792,9 @@ TEST_P(GpuImageDecodeCacheTest, GetHdrDecodedImageForDrawToSdr) {
 
   TestTileTaskRunner::ProcessTask(result.task->dependencies()[0].get());
   TestTileTaskRunner::ProcessTask(result.task.get());
+#if BUILDFLAG(IS_COBALT)
+  FlushRunLoop();
+#endif
 
   // Must hold context lock before calling GetDecodedImageForDraw /
   // DrawWithImageFinished.
@@ -1800,6 +1827,12 @@ TEST_P(GpuImageDecodeCacheTest, GetHdrDecodedImageForDrawToSdr) {
 }
 
 TEST_P(GpuImageDecodeCacheTest, GetLargeDecodedImageForDraw) {
+#if BUILDFLAG(IS_COBALT)
+  if (base::FeatureList::IsEnabled(
+          base::features::kCobaltInProcessImageTransferCache)) {
+    return;
+  }
+#endif
   auto cache = CreateCache();
   const uint32_t client_id = cache->GenerateClientId();
   PaintImage image = CreateLargePaintImageForSoftwareFallback();
@@ -1850,6 +1883,9 @@ TEST_P(GpuImageDecodeCacheTest, GetDecodedImageForDrawAtRasterDecode) {
       context_provider());
   DecodedDrawImage decoded_draw_image =
       EnsureImageBacked(cache->GetDecodedImageForDraw(draw_image));
+#if BUILDFLAG(IS_COBALT)
+  FlushRunLoop();
+#endif
   EXPECT_TRUE(decoded_draw_image.image());
   EXPECT_FALSE(decoded_draw_image.is_budgeted());
   EXPECT_TRUE(decoded_draw_image.image()->isTextureBacked());
@@ -1887,6 +1923,9 @@ TEST_P(GpuImageDecodeCacheTest, GetDecodedImageForDrawLargerScale) {
 
   TestTileTaskRunner::ProcessTask(larger_result.task->dependencies()[0].get());
   TestTileTaskRunner::ProcessTask(larger_result.task.get());
+#if BUILDFLAG(IS_COBALT)
+  FlushRunLoop();
+#endif
 
   // Must hold context lock before calling GetDecodedImageForDraw /
   // DrawWithImageFinished.
@@ -1937,6 +1976,9 @@ TEST_P(GpuImageDecodeCacheTest, GetDecodedImageForDrawHigherQuality) {
   EXPECT_TRUE(hq_result.task);
   TestTileTaskRunner::ProcessTask(hq_result.task->dependencies()[0].get());
   TestTileTaskRunner::ProcessTask(hq_result.task.get());
+#if BUILDFLAG(IS_COBALT)
+  FlushRunLoop();
+#endif
 
   // Must hold context lock before calling GetDecodedImageForDraw /
   // DrawWithImageFinished.
@@ -1977,6 +2019,9 @@ TEST_P(GpuImageDecodeCacheTest, GetDecodedImageForDrawNegative) {
 
   TestTileTaskRunner::ProcessTask(result.task->dependencies()[0].get());
   TestTileTaskRunner::ProcessTask(result.task.get());
+#if BUILDFLAG(IS_COBALT)
+  FlushRunLoop();
+#endif
 
   // Must hold context lock before calling GetDecodedImageForDraw /
   // DrawWithImageFinished.
@@ -2000,6 +2045,12 @@ TEST_P(GpuImageDecodeCacheTest, GetDecodedImageForDrawNegative) {
 }
 
 TEST_P(GpuImageDecodeCacheTest, GetLargeScaledDecodedImageForDraw) {
+#if BUILDFLAG(IS_COBALT)
+  if (base::FeatureList::IsEnabled(
+          base::features::kCobaltInProcessImageTransferCache)) {
+    return;
+  }
+#endif
   auto cache = CreateCache();
   const uint32_t client_id = cache->GenerateClientId();
   PaintImage image = CreatePaintImageForFallbackToRGB(
@@ -2059,6 +2110,9 @@ TEST_P(GpuImageDecodeCacheTest, AtRasterUsedDirectlyIfSpaceAllows) {
       context_provider());
   DecodedDrawImage decoded_draw_image =
       EnsureImageBacked(cache->GetDecodedImageForDraw(draw_image));
+#if BUILDFLAG(IS_COBALT)
+  FlushRunLoop();
+#endif
   EXPECT_TRUE(decoded_draw_image.image());
   EXPECT_TRUE(decoded_draw_image.image()->isTextureBacked());
   EXPECT_FALSE(decoded_draw_image.is_budgeted());
@@ -2093,6 +2147,9 @@ TEST_P(GpuImageDecodeCacheTest,
       context_provider());
   DecodedDrawImage decoded_draw_image =
       EnsureImageBacked(cache->GetDecodedImageForDraw(draw_image));
+#if BUILDFLAG(IS_COBALT)
+  FlushRunLoop();
+#endif
   EXPECT_TRUE(decoded_draw_image.image());
   EXPECT_TRUE(decoded_draw_image.image()->isTextureBacked());
   EXPECT_FALSE(decoded_draw_image.is_budgeted());
@@ -2100,6 +2157,9 @@ TEST_P(GpuImageDecodeCacheTest,
 
   DecodedDrawImage another_decoded_draw_image =
       EnsureImageBacked(cache->GetDecodedImageForDraw(draw_image));
+#if BUILDFLAG(IS_COBALT)
+  FlushRunLoop();
+#endif
   EXPECT_FALSE(another_decoded_draw_image.is_budgeted());
   EXPECT_EQ(decoded_draw_image.image()->uniqueID(),
             another_decoded_draw_image.image()->uniqueID());
@@ -2114,6 +2174,12 @@ TEST_P(GpuImageDecodeCacheTest,
 
 TEST_P(GpuImageDecodeCacheTest,
        GetLargeDecodedImageForDrawAtRasterDecodeMultipleTimes) {
+#if BUILDFLAG(IS_COBALT)
+  if (base::FeatureList::IsEnabled(
+          base::features::kCobaltInProcessImageTransferCache)) {
+    return;
+  }
+#endif
   auto cache = CreateCache();
   cache->SetWorkingSetLimitsForTesting(0 /* max_bytes */, 0 /* max_items */);
 
@@ -2237,6 +2303,9 @@ TEST_P(GpuImageDecodeCacheTest, ShouldAggressivelyFreeResources) {
     TestTileTaskRunner::ProcessTask(result.task.get());
 
     cache->UnrefImage(draw_image);
+#if BUILDFLAG(IS_COBALT)
+    FlushRunLoop();
+#endif
 
     // We should now have data image in our cache.
     EXPECT_GT(cache->GetNumCacheEntriesForTesting(), 0u);
@@ -2257,6 +2326,9 @@ TEST_P(GpuImageDecodeCacheTest, ShouldAggressivelyFreeResources) {
     TestTileTaskRunner::ProcessTask(result.task->dependencies()[0].get());
     TestTileTaskRunner::ProcessTask(result.task.get());
     cache->UnrefImage(draw_image);
+#if BUILDFLAG(IS_COBALT)
+    FlushRunLoop();
+#endif
 
     EXPECT_EQ(cache->GetNumCacheEntriesForTesting(), 0u);
   }
@@ -2273,6 +2345,9 @@ TEST_P(GpuImageDecodeCacheTest, ShouldAggressivelyFreeResources) {
     TestTileTaskRunner::ProcessTask(result.task->dependencies()[0].get());
     TestTileTaskRunner::ProcessTask(result.task.get());
     cache->UnrefImage(draw_image);
+#if BUILDFLAG(IS_COBALT)
+    FlushRunLoop();
+#endif
 
     EXPECT_GT(cache->GetNumCacheEntriesForTesting(), 0u);
   }
@@ -2314,6 +2389,9 @@ TEST_P(GpuImageDecodeCacheTest, OrphanedImagesFreeOnReachingZeroRefs) {
   TestTileTaskRunner::ProcessTask(first_result.task->dependencies()[0].get());
   TestTileTaskRunner::ProcessTask(first_result.task.get());
   cache->UnrefImage(first_draw_image);
+#if BUILDFLAG(IS_COBALT)
+  FlushRunLoop();
+#endif
 
   // The cache should have exactly one image.
   EXPECT_EQ(1u, cache->GetNumCacheEntriesForTesting());
@@ -2335,6 +2413,9 @@ TEST_P(GpuImageDecodeCacheTest, OrphanedZeroRefImagesImmediatelyDeleted) {
   TestTileTaskRunner::ProcessTask(first_result.task->dependencies()[0].get());
   TestTileTaskRunner::ProcessTask(first_result.task.get());
   cache->UnrefImage(first_draw_image);
+#if BUILDFLAG(IS_COBALT)
+  FlushRunLoop();
+#endif
 
   // The budget should account for exactly one image.
   EXPECT_EQ(cache->GetNumCacheEntriesForTesting(), 1u);
@@ -2604,6 +2685,9 @@ TEST_P(GpuImageDecodeCacheTest, ZeroCacheNormalWorkingSet) {
   // Unref both images.
   cache->UnrefImage(draw_image);
   cache->UnrefImage(draw_image);
+#if BUILDFLAG(IS_COBALT)
+  FlushRunLoop();
+#endif
 
   // Ensure the unref is processed:
   cache->ReduceCacheUsage();
@@ -2651,6 +2735,9 @@ TEST_P(GpuImageDecodeCacheTest, SmallCacheNormalWorkingSet) {
     TestTileTaskRunner::ProcessTask(result.task->dependencies()[0].get());
     TestTileTaskRunner::ProcessTask(result.task.get());
     cache->UnrefImage(draw_image);
+#if BUILDFLAG(IS_COBALT)
+    FlushRunLoop();
+#endif
   }
 
   // Request the same image - it should be cached.
@@ -2675,6 +2762,9 @@ TEST_P(GpuImageDecodeCacheTest, SmallCacheNormalWorkingSet) {
     TestTileTaskRunner::ProcessTask(result.task->dependencies()[0].get());
     TestTileTaskRunner::ProcessTask(result.task.get());
     cache->UnrefImage(draw_image2);
+#if BUILDFLAG(IS_COBALT)
+    FlushRunLoop();
+#endif
   }
 
   // Request the second image - it should be cached.
@@ -2740,6 +2830,9 @@ TEST_P(GpuImageDecodeCacheTest, ClearCacheInUse) {
   EXPECT_TRUE(result.task);
   TestTileTaskRunner::ProcessTask(result.task->dependencies()[0].get());
   TestTileTaskRunner::ProcessTask(result.task.get());
+#if BUILDFLAG(IS_COBALT)
+  FlushRunLoop();
+#endif
 
   // We should now have data image in our cache.
   EXPECT_GT(cache->GetWorkingSetBytesForTesting(), 0u);
@@ -2754,6 +2847,9 @@ TEST_P(GpuImageDecodeCacheTest, ClearCacheInUse) {
 
   // Unref the image, it should immidiately delete, leaving our cache empty.
   cache->UnrefImage(draw_image);
+#if BUILDFLAG(IS_COBALT)
+  FlushRunLoop();
+#endif
   EXPECT_EQ(cache->GetWorkingSetBytesForTesting(), 0u);
   EXPECT_EQ(cache->GetNumCacheEntriesForTesting(), 0u);
 }
@@ -2798,6 +2894,12 @@ TEST_P(GpuImageDecodeCacheTest, GetTaskForImageDifferentColorSpace) {
 }
 
 TEST_P(GpuImageDecodeCacheTest, GetTaskForLargeImageNonSRGBColorSpace) {
+#if BUILDFLAG(IS_COBALT)
+  if (base::FeatureList::IsEnabled(
+          base::features::kCobaltInProcessImageTransferCache)) {
+    return;
+  }
+#endif
   auto cache = CreateCache();
   const uint32_t client_id = cache->GenerateClientId();
   gfx::ColorSpace color_space = gfx::ColorSpace::CreateXYZD50();
@@ -3058,6 +3160,12 @@ TEST_P(GpuImageDecodeCacheTest, ImageBudgetingBySize) {
 
 TEST_P(GpuImageDecodeCacheTest,
        ColorConversionDuringDecodeForLargeImageNonSRGBColorSpace) {
+#if BUILDFLAG(IS_COBALT)
+  if (base::FeatureList::IsEnabled(
+          base::features::kCobaltInProcessImageTransferCache)) {
+    return;
+  }
+#endif
   auto cache = CreateCache();
   const uint32_t client_id = cache->GenerateClientId();
   sk_sp<SkColorSpace> image_color_space =
@@ -3177,9 +3285,15 @@ TEST_P(GpuImageDecodeCacheTest, NonLazyImageUploadNoScale) {
       context_provider());
   DecodedDrawImage decoded_draw_image =
       EnsureImageBacked(cache->GetDecodedImageForDraw(draw_image));
+#if BUILDFLAG(IS_COBALT)
+  FlushRunLoop();
+#endif
   EXPECT_TRUE(decoded_draw_image.image());
   EXPECT_TRUE(decoded_draw_image.is_budgeted());
   cache->DrawWithImageFinished(draw_image, decoded_draw_image);
+#if BUILDFLAG(IS_COBALT)
+  FlushRunLoop();
+#endif
   // For non-lazy images used at the original scale, no cpu component should be
   // cached
   EXPECT_FALSE(cache->GetSWImageDecodeForTesting(draw_image));
@@ -3264,6 +3378,12 @@ TEST_P(GpuImageDecodeCacheTest,
 }
 
 TEST_P(GpuImageDecodeCacheTest, NonLazyImageLargeImageNotColorConverted) {
+#if BUILDFLAG(IS_COBALT)
+  if (base::FeatureList::IsEnabled(
+          base::features::kCobaltInProcessImageTransferCache)) {
+    return;
+  }
+#endif
   if (do_yuv_decode_) {
     // YUV bitmap images do not happen, so this test will always skip for YUV.
     return;
@@ -3338,6 +3458,9 @@ TEST_P(GpuImageDecodeCacheTest, KeepOnlyLast2ContentIds) {
   for (int i = 0; i < 10; ++i) {
     cache->DrawWithImageFinished(draw_images[i], decoded_draw_images[i]);
   }
+#if BUILDFLAG(IS_COBALT)
+  FlushRunLoop();
+#endif
 
   // We have a single tracked entry, that gets cleared once we purge the cache.
   EXPECT_EQ(cache->paint_image_entries_count_for_testing(), 1u);
@@ -3767,6 +3890,9 @@ TEST_P(GpuImageDecodeCacheTest,
 
     TestTileTaskRunner::ProcessTask(result.task->dependencies()[0].get());
     TestTileTaskRunner::ProcessTask(result.task.get());
+#if BUILDFLAG(IS_COBALT)
+    FlushRunLoop();
+#endif
 
     // Must hold context lock before calling GetDecodedImageForDraw /
     // DrawWithImageFinished.
@@ -3797,6 +3923,9 @@ TEST_P(GpuImageDecodeCacheTest,
 
     cache->DrawWithImageFinished(draw_image, decoded_draw_image);
     cache->UnrefImage(draw_image);
+#if BUILDFLAG(IS_COBALT)
+    FlushRunLoop();
+#endif
   };
 
   yuv_format_ = YUVSubsampling::k420;
@@ -3865,6 +3994,9 @@ TEST_P(GpuImageDecodeCacheTest, HighBitDepthYUVDecoding) {
 
     TestTileTaskRunner::ProcessTask(result.task->dependencies()[0].get());
     TestTileTaskRunner::ProcessTask(result.task.get());
+#if BUILDFLAG(IS_COBALT)
+    FlushRunLoop();
+#endif
 
     // Must hold context lock before calling GetDecodedImageForDraw /
     // DrawWithImageFinished.
@@ -3919,6 +4051,9 @@ TEST_P(GpuImageDecodeCacheTest, HighBitDepthYUVDecoding) {
 
     cache->DrawWithImageFinished(draw_image, decoded_draw_image);
     cache->UnrefImage(draw_image);
+#if BUILDFLAG(IS_COBALT)
+    FlushRunLoop();
+#endif
   };
 
   gpu::Capabilities original_caps;
@@ -4078,6 +4213,9 @@ TEST_P(GpuImageDecodeCacheTest, ScaledYUVDecodeScaledDrawCorrectlyMipsPlanes) {
 
         TestTileTaskRunner::ProcessTask(result.task->dependencies()[0].get());
         TestTileTaskRunner::ProcessTask(result.task.get());
+#if BUILDFLAG(IS_COBALT)
+        FlushRunLoop();
+#endif
 
         // Must hold context lock before calling GetDecodedImageForDraw /
         // DrawWithImageFinished.
@@ -4105,6 +4243,9 @@ TEST_P(GpuImageDecodeCacheTest, ScaledYUVDecodeScaledDrawCorrectlyMipsPlanes) {
 
         cache->DrawWithImageFinished(draw_image, decoded_draw_image);
         cache->UnrefImage(draw_image);
+#if BUILDFLAG(IS_COBALT)
+        FlushRunLoop();
+#endif
       };
 
   gfx::Size image_size = GetNormalImageSize();
@@ -4181,6 +4322,9 @@ TEST_P(GpuImageDecodeCacheTest, GetBorderlineLargeDecodedImageForDraw) {
 
   TestTileTaskRunner::ProcessTask(result.task->dependencies()[0].get());
   TestTileTaskRunner::ProcessTask(result.task.get());
+#if BUILDFLAG(IS_COBALT)
+  FlushRunLoop();
+#endif
 
   // Must hold context lock before calling GetDecodedImageForDraw /
   // DrawWithImageFinished.
@@ -4353,6 +4497,9 @@ TEST_P(GpuImageDecodeCacheTest, ClippedAndScaledDrawImageRemovesCacheEntry) {
       context_provider());
   DecodedDrawImage decoded_draw_image =
       EnsureImageBacked(cache->GetDecodedImageForDraw(draw_image));
+#if BUILDFLAG(IS_COBALT)
+  FlushRunLoop();
+#endif
   EXPECT_TRUE(decoded_draw_image.image());
   EXPECT_TRUE(decoded_draw_image.image()->isTextureBacked());
   EXPECT_FALSE(cache->DiscardableIsLockedForTesting(draw_image));


### PR DESCRIPTION
Ensure YUV plane pixmaps retain color space information during in-process
serialization and preserve YUV metadata during deserialization. These
changes prevent color information loss and incorrect state tracking.

Update GpuImageDecodeCacheTest to handle the asynchronous nature of the
in-process transfer cache by flushing the run loop after unref tasks.
Tests for software fallback on large images are now skipped when this
feature is enabled, as it currently only supports GPU-backed transfers.

GpuImageDecodeCacheTest now can pass with in process image transfer enabed.

Bug: 555332425