### PR TITLE
android: Eliminate runtime JNI build type queries using java_cpp_template

### DIFF
--- a/cobalt/android/BUILD.gn
+++ b/cobalt/android/BUILD.gn
@@ -1,8 +1,20 @@
 import("//build/config/android/config.gni")
 import("//build/config/android/rules.gni")
 import("//cobalt/android/manifest.gni")
+import("//cobalt/build/configs/cobalt.gni")
 import("//third_party/icu/config.gni")
 import("//third_party/jni_zero/jni_zero.gni")
+
+java_cpp_template("cobalt_build_info_srcjar") {
+  sources = [ "apk/app/src/main/java/dev/cobalt/coat/CobaltBuildInfo.tmpl" ]
+  defines = []
+  if (is_official_build) {
+    defines += [ "OFFICIAL_BUILD" ]
+  }
+  if (cobalt_is_release_build) {
+    defines += [ "COBALT_IS_RELEASE_BUILD" ]
+  }
+}
 
 jinja_template("cobalt_manifest") {
   input = "//cobalt/shell/android/shell_apk/AndroidManifest.xml.jinja2"
@@ -125,6 +137,7 @@ android_library("cobalt_main_java") {
   }
 
   srcjar_deps = [
+    ":cobalt_build_info_srcjar",
     ":cobalt_crash_streak_thresholds_java",
     ":cobalt_experiment_names_java",
     ":cobalt_pref_names_java",

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/BaseCobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/BaseCobaltActivity.java
@@ -198,12 +198,20 @@ public abstract class BaseCobaltActivity extends Activity {
     }
   }
 
+  /**
+   * Returns true if compiled for release (i.e. 'gold' build; false for 'qa'). Subclasses may
+   * override this (e.g. to allow dev args on dogfood builds).
+   */
   protected boolean isReleaseBuild() {
-    return BaseStarboardBridge.isReleaseBuild();
+    return CobaltBuildInfo.IS_RELEASE_BUILD;
   }
 
+  /**
+   * Returns true if compiled for development (i.e. 'devel' or 'debug' build; false for 'qa' and
+   * 'gold'). Subclasses may override this.
+   */
   protected boolean isDevelopmentBuild() {
-    return BaseStarboardBridge.isDevelopmentBuild();
+    return !CobaltBuildInfo.IS_OFFICIAL_BUILD;
   }
 
   @Override

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/BaseStarboardBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/BaseStarboardBridge.java
@@ -188,10 +188,6 @@ public class BaseStarboardBridge {
     void setAndroidPlayServicesVersion(long version);
 
     void setYoutubeCertificationScope(String certScope);
-
-    boolean isReleaseBuild();
-
-    boolean isDevelopmentBuild();
   }
 
   protected void onActivityStart(Activity activity) {
@@ -326,16 +322,6 @@ public class BaseStarboardBridge {
   @CalledByNative
   public boolean isPlatformErrorShowing() {
     return false;
-  }
-
-  /** Returns true if the native code is compiled for release (i.e. 'gold' build). */
-  public static boolean isReleaseBuild() {
-    return BaseStarboardBridgeJni.get().isReleaseBuild();
-  }
-
-  /** Returns true if the native code is compiled for development (i.e. 'devel' build). */
-  public static boolean isDevelopmentBuild() {
-    return BaseStarboardBridgeJni.get().isDevelopmentBuild();
   }
 
   protected Holder<Activity> getActivityHolder() {

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -64,7 +64,6 @@ import org.chromium.base.library_loader.LibraryProcessType;
 import org.chromium.base.memory.MemoryPressureMonitor;
 import org.chromium.base.memory.MemoryPressureUma;
 import org.chromium.base.metrics.RecordHistogram;
-import org.chromium.base.version_info.VersionInfo;
 import org.chromium.content.browser.input.ImeAdapterImpl;
 import org.chromium.content_public.browser.BrowserStartupController;
 import org.chromium.content_public.browser.DeviceUtils;
@@ -176,7 +175,7 @@ public abstract class CobaltActivity extends BaseCobaltActivity {
     // Initializing the command line must occur before loading the library.
     if (!CommandLine.isInitialized()) {
       String[] commandLineArgs = null;
-      if (!VersionInfo.isReleaseBuild()) {
+      if (!isReleaseBuild()) {
         commandLineArgs = getCommandLineParamsFromIntent(getIntent(), COMMAND_LINE_ARGS_KEY);
         // Initializes command line from content-shell-command-line for telemetry tests.
         CommandLineOverrideHelper.initializeContentShellCommandLine();
@@ -196,7 +195,7 @@ public abstract class CobaltActivity extends BaseCobaltActivity {
 
       CommandLineOverrideHelper.getFlagOverrides(
           new CommandLineOverrideHelper.CommandLineOverrideHelperParams(
-              VersionInfo.isOfficialBuild(), commandLineArgs));
+              !isDevelopmentBuild(), commandLineArgs));
     }
     mIsCobaltUsingAndroidOverlay =
         CommandLine.getInstance().hasSwitch(COBALT_USING_ANDROID_OVERLAY);

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltBuildInfo.tmpl
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltBuildInfo.tmpl
@@ -1,0 +1,35 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dev.cobalt.coat;
+
+/**
+ * Build configuration flags for Cobalt.
+ * Generated at build time from CobaltBuildInfo.tmpl via java_cpp_template.
+ */
+public final class CobaltBuildInfo {
+#if defined(COBALT_IS_RELEASE_BUILD)
+    public static final boolean IS_RELEASE_BUILD = true;
+#else
+    public static final boolean IS_RELEASE_BUILD = false;
+#endif
+
+#if defined(OFFICIAL_BUILD)
+    public static final boolean IS_OFFICIAL_BUILD = true;
+#else
+    public static final boolean IS_OFFICIAL_BUILD = false;
+#endif
+
+    private CobaltBuildInfo() {}
+}

--- a/starboard/android/shared/base_starboard_bridge.cc
+++ b/starboard/android/shared/base_starboard_bridge.cc
@@ -189,23 +189,6 @@ void JNI_BaseStarboardBridge_SetYoutubeCertificationScope(
 #endif  // !BUILDFLAG(IS_PARTNER_TOOLCHAIN)
 }
 
-jboolean JNI_BaseStarboardBridge_IsReleaseBuild(JNIEnv* env) {
-#if BUILDFLAG(COBALT_IS_RELEASE_BUILD)
-  return true;
-#else
-  return false;
-#endif
-}
-
-jboolean JNI_BaseStarboardBridge_IsDevelopmentBuild(JNIEnv* env) {
-// OFFICIAL_BUILD is set for Cobalt QA and Gold releases
-#if defined(OFFICIAL_BUILD)
-  return false;
-#else
-  return true;
-#endif
-}
-
 // StarboardBridge::GetInstance() should not be inlined in the
 // header. This makes sure that when source files from multiple targets include
 // this header they don't end up with different copies of the inlined code


### PR DESCRIPTION
Replace runtime JNI calls to BaseStarboardBridge.isReleaseBuild() and
isDevelopmentBuild() with compile-time constants generated via
java_cpp_template.

Bug: 557444130