### PR TITLE
coat: Make CommandLineOverrideHelper flavor-agnostic

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -34,6 +34,7 @@ import android.widget.FrameLayout;
 import android.widget.Toast;
 import android.window.OnBackInvokedCallback;
 import android.window.OnBackInvokedDispatcher;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.annotation.VisibleForTesting;
@@ -53,6 +54,7 @@ import dev.cobalt.util.JavaSwitches;
 import dev.cobalt.util.Log;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -141,14 +143,9 @@ public abstract class CobaltActivity extends BaseCobaltActivity {
   private boolean mWasDisplayOn = true;
 
   @VisibleForTesting
-  static String[] appendArgsFromMetaData(Bundle metaData, String[] commandLineArgs) {
+  static void appendMetaDataArgs(@NonNull List<String> args, @Nullable Bundle metaData) {
     if (metaData == null) {
-      return commandLineArgs;
-    }
-
-    List<String> args = new ArrayList<>();
-    if (commandLineArgs != null) {
-      args.addAll(Arrays.asList(commandLineArgs));
+      return;
     }
 
     boolean enableSplashScreen = metaData.getBoolean(META_DATA_ENABLE_SPLASH_SCREEN, true);
@@ -158,14 +155,38 @@ public abstract class CobaltActivity extends BaseCobaltActivity {
 
     String enableFeatures = metaData.getString(META_DATA_ENABLE_FEATURES);
     if (TextUtils.isEmpty(enableFeatures)) {
-      return args.toArray(new String[0]);
+      return;
     }
 
     // CommandLineOverrideHelper will merge this with other --enable-features flags
     // It also accepts semi-colon-separated list of features.
     // https://github.com/youtube/cobalt/blob/6407cbdf6573f0b5fcae4a8fa6f46a3198b3d42b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java#L139-L167
     args.add("--enable-features=" + enableFeatures);
-    return args.toArray(new String[0]);
+  }
+
+  private void appendIntentArgs(@NonNull List<String> args) {
+    if (isReleaseBuild()) {
+      return;
+    }
+
+    String[] intentArgs = getCommandLineParamsFromIntent(getIntent(), COMMAND_LINE_ARGS_KEY);
+    if (intentArgs == null) {
+      return;
+    }
+    Collections.addAll(args, intentArgs);
+  }
+
+  @VisibleForTesting
+  @NonNull
+  List<String> getCommandLineArgs() {
+    List<String> args = new ArrayList<>();
+    if (isDevelopmentBuild()) {
+      args.add("--remote-allow-origins=https://chrome-devtools-frontend.appspot.com");
+    }
+    appendMetaDataArgs(args, getActivityMetaData());
+    args.addAll(JavaSwitches.getExtraCommandLineArgs(getJavaSwitches()));
+    appendIntentArgs(args);
+    return args;
   }
 
   // Initially copied from ContentShellActiviy.java
@@ -175,25 +196,7 @@ public abstract class CobaltActivity extends BaseCobaltActivity {
     // Initializing the command line must occur before loading the library.
     if (!CommandLine.isInitialized()) {
       CommandLine.init(null);
-
-      String[] commandLineArgs = null;
-      if (!isReleaseBuild()) {
-        commandLineArgs = getCommandLineParamsFromIntent(getIntent(), COMMAND_LINE_ARGS_KEY);
-      }
-      commandLineArgs = appendArgsFromMetaData(getActivityMetaData(), commandLineArgs);
-
-      List<String> extraCommandLineArgs = JavaSwitches.getExtraCommandLineArgs(getJavaSwitches());
-
-      if (!extraCommandLineArgs.isEmpty()) {
-        if (commandLineArgs != null) {
-          extraCommandLineArgs.addAll(0, Arrays.asList(commandLineArgs));
-        }
-        commandLineArgs = extraCommandLineArgs.toArray(new String[0]);
-      }
-
-      CommandLineOverrideHelper.getFlagOverrides(
-          new CommandLineOverrideHelper.CommandLineOverrideHelperParams(
-              !isDevelopmentBuild(), commandLineArgs));
+      CommandLineOverrideHelper.getFlagOverrides(getCommandLineArgs());
     }
     mIsCobaltUsingAndroidOverlay =
         CommandLine.getInstance().hasSwitch(COBALT_USING_ANDROID_OVERLAY);

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
@@ -14,6 +14,7 @@
 
 package dev.cobalt.coat;
 
+import androidx.annotation.NonNull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringJoiner;
@@ -30,17 +31,6 @@ import org.chromium.base.CommandLine;
 /** Helper class to provide commandLine Overrides. */
 public final class CommandLineOverrideHelper {
   private CommandLineOverrideHelper() {} // Prevent instantiation.
-
-  /** Param class to simplify #getFlagOverrides method signature */
-  public static class CommandLineOverrideHelperParams {
-    public CommandLineOverrideHelperParams(boolean isOfficialBuild, String[] commandLineArgs) {
-      mIsOfficialBuild = isOfficialBuild;
-      mCommandLineArgs = commandLineArgs;
-    }
-
-    private boolean mIsOfficialBuild;
-    private String[] mCommandLineArgs;
-  }
 
   // This can be returned as a list, since it does not need to be a single
   // string object. The others can be combined into a single String because
@@ -155,7 +145,7 @@ public final class CommandLineOverrideHelper {
     return paramOverrides;
   }
 
-  public static void getFlagOverrides(CommandLineOverrideHelperParams params) {
+  public static void getFlagOverrides(@NonNull List<String> commandLineArgs) {
     List<String> cliOverrides = getDefaultCommandLineOverridesList();
     StringJoiner jsFlagOverrides = getDefaultJsFlagOverridesList();
     StringJoiner enableFeatureOverrides = getDefaultEnableFeatureOverridesList();
@@ -164,67 +154,49 @@ public final class CommandLineOverrideHelper {
     StringJoiner traceStartupOverrides = new StringJoiner(",");
     StringJoiner enableH5vccSettings = new StringJoiner(";");
 
-    if (params != null) {
-      if (!params.mIsOfficialBuild) {
-        cliOverrides.add(
-            "--remote-allow-origins=" + "https://chrome-devtools-frontend.appspot.com");
+    for (String param : commandLineArgs) {
+      if (param == null || param.isEmpty()) {
+        continue;
+      }
+      String[] parts = param.split("=", 2);
+      if (parts.length != 2) {
+        cliOverrides.add(param);
+        continue;
       }
 
-      if (params.mCommandLineArgs != null) {
-        for (String param : params.mCommandLineArgs) {
-          if (param == null || param.isEmpty()) {
-            continue; // Skip null or empty params
-          }
-          String[] parts = param.split("=", 2);
-          if (parts.length == 2) {
-            String key = parts[0];
-            String value = parts[1];
-            String[] values = value.split(";");
-            for (String v : values) {
-              if (key.equals("--js-flags")) {
-                jsFlagOverrides.add(v);
-              } else if (key.equals("--enable-features")) {
-                enableFeatureOverrides.add(v);
-              } else if (key.equals("--disable-features")) {
-                disableFeatureOverrides.add(v);
-              } else if (key.equals("--enable-blink-features")) {
-                blinkEnableFeatureOverrides.add(v);
-              } else if (key.equals("--trace-startup")) {
-                traceStartupOverrides.add(v);
-              } else if (key.equals("--enable-h5vcc-settings")) {
-                enableH5vccSettings.add(v);
-              } else {
-                cliOverrides.add(param);
-                break; // Avoid adding the same param multiple times
-              }
-            }
-          } else {
-            cliOverrides.add(param);
-          }
+      String key = parts[0];
+      String value = parts[1];
+      for (String v : value.split(";")) {
+        if (key.equals("--js-flags")) {
+          jsFlagOverrides.add(v);
+        } else if (key.equals("--enable-features")) {
+          enableFeatureOverrides.add(v);
+        } else if (key.equals("--disable-features")) {
+          disableFeatureOverrides.add(v);
+        } else if (key.equals("--enable-blink-features")) {
+          blinkEnableFeatureOverrides.add(v);
+        } else if (key.equals("--trace-startup")) {
+          traceStartupOverrides.add(v);
+        } else if (key.equals("--enable-h5vcc-settings")) {
+          enableH5vccSettings.add(v);
+        } else {
+          cliOverrides.add(param);
+          break; // Avoid adding the same param multiple times
         }
       }
     }
-    CommandLine.getInstance().appendSwitchesAndArguments(cliOverrides.toArray(new String[0]));
-    CommandLine.getInstance()
-        .appendSwitchesAndArguments(new String[] {"--js-flags=" + jsFlagOverrides.toString()});
-    CommandLine.getInstance()
-        .appendSwitchesAndArguments(
-            new String[] {"--enable-features=" + enableFeatureOverrides.toString()});
-    CommandLine.getInstance()
-        .appendSwitchesAndArguments(
-            new String[] {"--disable-features=" + disableFeatureOverrides.toString()});
-    CommandLine.getInstance()
-        .appendSwitchesAndArguments(
-            new String[] {"--enable-blink-features=" + blinkEnableFeatureOverrides.toString()});
+
+    cliOverrides.add("--js-flags=" + jsFlagOverrides.toString());
+    cliOverrides.add("--enable-features=" + enableFeatureOverrides.toString());
+    cliOverrides.add("--disable-features=" + disableFeatureOverrides.toString());
+    cliOverrides.add("--enable-blink-features=" + blinkEnableFeatureOverrides.toString());
     if (traceStartupOverrides.length() > 0) {
-      CommandLine.getInstance()
-          .appendSwitchesAndArguments(
-              new String[] {"--trace-startup=" + traceStartupOverrides.toString()});
+      cliOverrides.add("--trace-startup=" + traceStartupOverrides.toString());
     }
     if (enableH5vccSettings.length() > 0) {
-      CommandLine.getInstance()
-          .appendSwitchesAndArguments(
-              new String[] {"--enable-h5vcc-settings=" + enableH5vccSettings.toString()});
+      cliOverrides.add("--enable-h5vcc-settings=" + enableH5vccSettings.toString());
     }
+
+    CommandLine.getInstance().appendSwitchesAndArguments(cliOverrides.toArray(new String[0]));
   }
 }

--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/CobaltActivityTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/CobaltActivityTest.java
@@ -15,6 +15,9 @@
 package dev.cobalt.coat;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
@@ -23,6 +26,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.view.KeyEvent;
 import dev.cobalt.shell.StartupGuard;
@@ -32,6 +36,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.chromium.base.CommandLine;
+import org.chromium.base.ContextUtils;
 import org.chromium.content.browser.input.ImeAdapterImpl;
 import org.junit.After;
 import org.junit.Before;
@@ -39,6 +45,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.shadows.ShadowLooper;
 
 /** CobaltActivityTest. */
@@ -66,70 +73,164 @@ public class CobaltActivityTest {
     return cobaltActivity;
   }
 
-  @Test
-  public void testAppendArgsFromMetaData_NullMetaData() {
-    String[] args = new String[] {"--arg1"};
-    String[] result = CobaltActivity.appendArgsFromMetaData(/* metaData= */ null, args);
-    assertArrayEquals(args, result);
+  public CobaltActivity createActivityForCommandLineTests(
+      final boolean isDevBuild, final Intent intent) {
+    final Intent actualIntent = intent != null ? intent : new Intent();
+    return new CobaltActivity() {
+      @Override
+      protected boolean isDevelopmentBuild() {
+        return isDevBuild;
+      }
+
+      @Override
+      protected boolean isReleaseBuild() {
+        return false;
+      }
+
+      @Override
+      public Intent getIntent() {
+        return actualIntent;
+      }
+
+      @Override
+      protected ImeAdapterImpl getImeAdapterImpl() {
+        return null;
+      }
+
+      @Override
+      protected StarboardBridge createStarboardBridge(String[] args, String startDeepLink) {
+        return null;
+      }
+    };
   }
 
   @Test
-  public void testAppendArgsFromMetaData_EmptyMetaData() {
+  public void testGetCommandLineArgs_DevelopmentBuild_AddsDefaultRemoteAllowOrigins() {
+    CobaltActivity activity =
+        createActivityForCommandLineTests(/* isDevBuild= */ true, /* intent= */ null);
+
+    List<String> args = activity.getCommandLineArgs();
+
+    assertTrue(
+        args.contains("--remote-allow-origins=https://chrome-devtools-frontend.appspot.com"));
+  }
+
+  @Test
+  public void testGetCommandLineArgs_NonDevelopmentBuild_DoesNotAddDefaultRemoteAllowOrigins() {
+    CobaltActivity activity =
+        createActivityForCommandLineTests(/* isDevBuild= */ false, /* intent= */ null);
+
+    List<String> args = activity.getCommandLineArgs();
+
+    assertFalse(
+        args.contains("--remote-allow-origins=https://chrome-devtools-frontend.appspot.com"));
+  }
+
+  @Test
+  public void testGetCommandLineArgs_UserRemoteAllowOriginsAppendedAfterDefault() {
+    Intent intent = new Intent();
+    intent.putExtra(
+        CobaltActivity.COMMAND_LINE_ARGS_KEY, new String[] {"--remote-allow-origins=*"});
+    CobaltActivity activity = createActivityForCommandLineTests(/* isDevBuild= */ true, intent);
+
+    List<String> args = activity.getCommandLineArgs();
+
+    int defaultIndex =
+        args.indexOf("--remote-allow-origins=https://chrome-devtools-frontend.appspot.com");
+    int userIndex = args.indexOf("--remote-allow-origins=*");
+    assertTrue(defaultIndex >= 0);
+    assertTrue(userIndex > defaultIndex);
+  }
+
+  @Test
+  public void testGetCommandLineArgs_UserRemoteAllowOriginsOverridesDefaultInCommandLine() {
+    Intent intent = new Intent();
+    intent.putExtra(
+        CobaltActivity.COMMAND_LINE_ARGS_KEY, new String[] {"--remote-allow-origins=*"});
+    CobaltActivity activity = createActivityForCommandLineTests(/* isDevBuild= */ true, intent);
+
+    CommandLine.resetForTesting(true);
+    CommandLineOverrideHelper.getFlagOverrides(activity.getCommandLineArgs());
+
+    assertEquals("*", CommandLine.getInstance().getSwitchValue("remote-allow-origins"));
+  }
+
+  @Test
+  public void testAppendMetaDataArgs_NullMetaData() {
+    List<String> args = new ArrayList<>();
+    args.add("--arg1");
+    CobaltActivity.appendMetaDataArgs(args, /* metaData= */ null);
+    assertArrayEquals(new String[] {"--arg1"}, args.toArray(new String[0]));
+  }
+
+  @Test
+  public void testAppendMetaDataArgs_EmptyMetaData() {
     Bundle metaData = mock(Bundle.class);
     when(metaData.getBoolean("cobalt.ENABLE_SPLASH_SCREEN", true)).thenReturn(true);
     when(metaData.getString("cobalt.ENABLE_FEATURES")).thenReturn(null);
-    String[] args = new String[] {"--arg1"};
-    String[] result = CobaltActivity.appendArgsFromMetaData(metaData, args);
-    assertArrayEquals(args, result);
+    List<String> args = new ArrayList<>();
+    args.add("--arg1");
+    CobaltActivity.appendMetaDataArgs(args, metaData);
+    assertArrayEquals(new String[] {"--arg1"}, args.toArray(new String[0]));
   }
 
   @Test
-  public void testAppendArgsFromMetaData_EmptyStringFeature() {
+  public void testAppendMetaDataArgs_EmptyStringFeature() {
     Bundle metaData = mock(Bundle.class);
     when(metaData.getBoolean("cobalt.ENABLE_SPLASH_SCREEN", true)).thenReturn(true);
     when(metaData.getString("cobalt.ENABLE_FEATURES")).thenReturn("");
-    String[] args = new String[] {"--arg1"};
-    String[] result = CobaltActivity.appendArgsFromMetaData(metaData, args);
-    assertArrayEquals(args, result);
+    List<String> args = new ArrayList<>();
+    args.add("--arg1");
+    CobaltActivity.appendMetaDataArgs(args, metaData);
+    assertArrayEquals(new String[] {"--arg1"}, args.toArray(new String[0]));
   }
 
   @Test
-  public void testAppendArgsFromMetaData_WithFeature() {
+  public void testAppendMetaDataArgs_WithFeature() {
     Bundle metaData = mock(Bundle.class);
     when(metaData.getBoolean("cobalt.ENABLE_SPLASH_SCREEN", true)).thenReturn(true);
     when(metaData.getString("cobalt.ENABLE_FEATURES")).thenReturn("FeatureA");
-    String[] args = new String[] {"--arg1"};
-    String[] result = CobaltActivity.appendArgsFromMetaData(metaData, args);
-    assertArrayEquals(new String[] {"--arg1", "--enable-features=FeatureA"}, result);
+    List<String> args = new ArrayList<>();
+    args.add("--arg1");
+    CobaltActivity.appendMetaDataArgs(args, metaData);
+    assertArrayEquals(
+        new String[] {"--arg1", "--enable-features=FeatureA"}, args.toArray(new String[0]));
   }
 
   @Test
-  public void testAppendArgsFromMetaData_WithMultipleFeatures() {
+  public void testAppendMetaDataArgs_WithMultipleFeatures() {
     Bundle metaData = mock(Bundle.class);
     when(metaData.getBoolean("cobalt.ENABLE_SPLASH_SCREEN", true)).thenReturn(true);
     when(metaData.getString("cobalt.ENABLE_FEATURES")).thenReturn("FeatureA;FeatureB");
-    String[] args = new String[] {"--arg1"};
-    String[] result = CobaltActivity.appendArgsFromMetaData(metaData, args);
-    assertArrayEquals(new String[] {"--arg1", "--enable-features=FeatureA;FeatureB"}, result);
+    List<String> args = new ArrayList<>();
+    args.add("--arg1");
+    CobaltActivity.appendMetaDataArgs(args, metaData);
+    assertArrayEquals(
+        new String[] {"--arg1", "--enable-features=FeatureA;FeatureB"},
+        args.toArray(new String[0]));
   }
 
   @Test
-  public void testAppendArgsFromMetaData_NullArgs() {
+  public void testAppendMetaDataArgs_EmptyArgs() {
     Bundle metaData = mock(Bundle.class);
     when(metaData.getBoolean("cobalt.ENABLE_SPLASH_SCREEN", true)).thenReturn(true);
     when(metaData.getString("cobalt.ENABLE_FEATURES")).thenReturn("FeatureA");
-    String[] result = CobaltActivity.appendArgsFromMetaData(metaData, /* commandLineArgs= */ null);
-    assertArrayEquals(new String[] {"--enable-features=FeatureA"}, result);
+    List<String> args = new ArrayList<>();
+    CobaltActivity.appendMetaDataArgs(args, metaData);
+    assertArrayEquals(new String[] {"--enable-features=FeatureA"}, args.toArray(new String[0]));
   }
 
   @Test
-  public void testAppendArgsFromMetaData_DisableSplashScreen() {
+  public void testAppendMetaDataArgs_DisableSplashScreen() {
     Bundle metaData = mock(Bundle.class);
     when(metaData.getBoolean("cobalt.ENABLE_SPLASH_SCREEN", true)).thenReturn(false);
     when(metaData.getString("cobalt.ENABLE_FEATURES")).thenReturn(null);
-    String[] args = new String[] {"--arg1"};
-    String[] result = CobaltActivity.appendArgsFromMetaData(metaData, args);
-    assertArrayEquals(new String[] {"--arg1", "--enable-features=DisableSplashScreen"}, result);
+    List<String> args = new ArrayList<>();
+    args.add("--arg1");
+    CobaltActivity.appendMetaDataArgs(args, metaData);
+    assertArrayEquals(
+        new String[] {"--arg1", "--enable-features=DisableSplashScreen"},
+        args.toArray(new String[0]));
   }
 
   @Test
@@ -281,6 +382,7 @@ public class CobaltActivityTest {
 
   @Before
   public void setUp() {
+    ContextUtils.initApplicationContextForTests(RuntimeEnvironment.getApplication());
     AppEventBridgeJni.setInstanceForTesting(mock(AppEventBridge.Natives.class));
     StartupGuard.getInstance().disarm();
   }

--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/CommandLineOverrideHelperTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/CommandLineOverrideHelperTest.java
@@ -16,6 +16,8 @@ package dev.cobalt.coat;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.chromium.base.CommandLine;
 import org.junit.Assert;
@@ -68,8 +70,8 @@ public class CommandLineOverrideHelperTest {
   }
 
   @Test
-  public void testFlagOverrides_NullParam() {
-    CommandLineOverrideHelper.getFlagOverrides(null);
+  public void testFlagOverrides_EmptyArgs() {
+    CommandLineOverrideHelper.getFlagOverrides(Collections.emptyList());
 
     Assert.assertTrue(CommandLine.getInstance().hasSwitch("single-process"));
     Assert.assertTrue(CommandLine.getInstance().hasSwitch("force-video-overlays"));
@@ -105,10 +107,8 @@ public class CommandLineOverrideHelperTest {
 
   @Test
   public void testFlagOverrides_SingleArg() {
-    String[] commandLineArgs = {"--enable-features=TestFeature1;TestFeature2"};
-    CommandLineOverrideHelper.CommandLineOverrideHelperParams params =
-        new CommandLineOverrideHelper.CommandLineOverrideHelperParams(true, commandLineArgs);
-    CommandLineOverrideHelper.getFlagOverrides(params);
+    List<String> commandLineArgs = Arrays.asList("--enable-features=TestFeature1;TestFeature2");
+    CommandLineOverrideHelper.getFlagOverrides(commandLineArgs);
 
     String actual = CommandLine.getInstance().getSwitchValue("enable-features");
     String expected =
@@ -119,15 +119,13 @@ public class CommandLineOverrideHelperTest {
 
   @Test
   public void testFlagOverrides_MultipleArgs() {
-    String[] commandLineArgs = {
-      "--enable-features=TestFeature1;TestFeature2",
-      "--disable-features=TestFeature3",
-      "--js-flags=--test-flag;--another-flag",
-      "--enable-h5vcc-settings=TestSetting1;TestSetting2"
-    };
-    CommandLineOverrideHelper.CommandLineOverrideHelperParams params =
-        new CommandLineOverrideHelper.CommandLineOverrideHelperParams(true, commandLineArgs);
-    CommandLineOverrideHelper.getFlagOverrides(params);
+    List<String> commandLineArgs =
+        Arrays.asList(
+            "--enable-features=TestFeature1;TestFeature2",
+            "--disable-features=TestFeature3",
+            "--js-flags=--test-flag;--another-flag",
+            "--enable-h5vcc-settings=TestSetting1;TestSetting2");
+    CommandLineOverrideHelper.getFlagOverrides(commandLineArgs);
 
     String enableFeatures = CommandLine.getInstance().getSwitchValue("enable-features");
     String expectedEnable =
@@ -154,10 +152,8 @@ public class CommandLineOverrideHelperTest {
 
   @Test
   public void testFlagOverrides_WithRegularSwitch() {
-    String[] commandLineArgs = {"--some-other-switch=value"};
-    CommandLineOverrideHelper.CommandLineOverrideHelperParams params =
-        new CommandLineOverrideHelper.CommandLineOverrideHelperParams(true, commandLineArgs);
-    CommandLineOverrideHelper.getFlagOverrides(params);
+    List<String> commandLineArgs = Arrays.asList("--some-other-switch=value");
+    CommandLineOverrideHelper.getFlagOverrides(commandLineArgs);
 
     Assert.assertTrue(CommandLine.getInstance().hasSwitch("some-other-switch"));
     String actual = CommandLine.getInstance().getSwitchValue("some-other-switch");
@@ -165,13 +161,21 @@ public class CommandLineOverrideHelperTest {
   }
 
   @Test
+  public void testFlagOverrides_UserOverrideTakesPrecedence() {
+    List<String> commandLineArgs =
+        Arrays.asList(
+            "--remote-allow-origins=https://chrome-devtools-frontend.appspot.com",
+            "--remote-allow-origins=*");
+    CommandLineOverrideHelper.getFlagOverrides(commandLineArgs);
+
+    Assert.assertEquals("*", CommandLine.getInstance().getSwitchValue("remote-allow-origins"));
+  }
+
+  @Test
   public void testFlagOverrides_EmptyAndNullArgs() {
-    String[] commandLineArgs = {
-      "--enable-features=TestFeature1;", null, "--disable-features=TestFeature2"
-    };
-    CommandLineOverrideHelper.CommandLineOverrideHelperParams params =
-        new CommandLineOverrideHelper.CommandLineOverrideHelperParams(true, commandLineArgs);
-    CommandLineOverrideHelper.getFlagOverrides(params);
+    List<String> commandLineArgs =
+        Arrays.asList("--enable-features=TestFeature1;", null, "--disable-features=TestFeature2");
+    CommandLineOverrideHelper.getFlagOverrides(commandLineArgs);
 
     String enableFeatures = CommandLine.getInstance().getSwitchValue("enable-features");
     String expectedEnable =
@@ -188,10 +192,9 @@ public class CommandLineOverrideHelperTest {
 
   @Test
   public void testFlagOverrides_FeaturesWithValues() {
-    String[] commandLineArgs = {"--enable-features=TestFeature1=value1;TestFeature2=value2"};
-    CommandLineOverrideHelper.CommandLineOverrideHelperParams params =
-        new CommandLineOverrideHelper.CommandLineOverrideHelperParams(true, commandLineArgs);
-    CommandLineOverrideHelper.getFlagOverrides(params);
+    List<String> commandLineArgs =
+        Arrays.asList("--enable-features=TestFeature1=value1;TestFeature2=value2");
+    CommandLineOverrideHelper.getFlagOverrides(commandLineArgs);
 
     String enableFeatures = CommandLine.getInstance().getSwitchValue("enable-features");
     String expectedEnable =
@@ -202,10 +205,9 @@ public class CommandLineOverrideHelperTest {
 
   @Test
   public void testFlagOverrides_EnableH5vccSettings() {
-    String[] commandLineArgs = {"--enable-h5vcc-settings=Setting1=val1;Setting2=val2"};
-    CommandLineOverrideHelper.CommandLineOverrideHelperParams params =
-        new CommandLineOverrideHelper.CommandLineOverrideHelperParams(true, commandLineArgs);
-    CommandLineOverrideHelper.getFlagOverrides(params);
+    List<String> commandLineArgs =
+        Arrays.asList("--enable-h5vcc-settings=Setting1=val1;Setting2=val2");
+    CommandLineOverrideHelper.getFlagOverrides(commandLineArgs);
 
     String h5vccSettings = CommandLine.getInstance().getSwitchValue("enable-h5vcc-settings");
     Assert.assertEquals("Setting1=val1;Setting2=val2", h5vccSettings);
@@ -213,10 +215,9 @@ public class CommandLineOverrideHelperTest {
 
   @Test
   public void testFlagOverrides_TraceStartup() {
-    String[] commandLineArgs = {"--trace-startup=-*;disabled-by-default-memory-infra"};
-    CommandLineOverrideHelper.CommandLineOverrideHelperParams params =
-        new CommandLineOverrideHelper.CommandLineOverrideHelperParams(true, commandLineArgs);
-    CommandLineOverrideHelper.getFlagOverrides(params);
+    List<String> commandLineArgs =
+        Arrays.asList("--trace-startup=-*;disabled-by-default-memory-infra");
+    CommandLineOverrideHelper.getFlagOverrides(commandLineArgs);
 
     String traceStartup = CommandLine.getInstance().getSwitchValue("trace-startup");
     Assert.assertEquals("-*,disabled-by-default-memory-infra", traceStartup);
@@ -224,27 +225,23 @@ public class CommandLineOverrideHelperTest {
 
   @Test
   public void testFlagOverrides_TraceStartupEmpty() {
-    String[] commandLineArgs = {"--trace-startup"};
-    CommandLineOverrideHelper.CommandLineOverrideHelperParams params =
-        new CommandLineOverrideHelper.CommandLineOverrideHelperParams(true, commandLineArgs);
-    CommandLineOverrideHelper.getFlagOverrides(params);
+    List<String> commandLineArgs = Arrays.asList("--trace-startup");
+    CommandLineOverrideHelper.getFlagOverrides(commandLineArgs);
 
     Assert.assertTrue(CommandLine.getInstance().hasSwitch("trace-startup"));
   }
 
   @Test
   public void testFlagOverrides_HeapProfilingAdbArgs() {
-    String[] commandLineArgs = {
-      "--enable-heap-profiling",
-      "--memlog=all",
-      "--memlog-stack-mode=native-with-thread-names",
-      "--trace-startup=-*;disabled-by-default-memory-infra",
-      "--trace-startup-duration=60",
-      "--trace-startup-file=/sdcard/Download/trace_atv.pftrace"
-    };
-    CommandLineOverrideHelper.CommandLineOverrideHelperParams params =
-        new CommandLineOverrideHelper.CommandLineOverrideHelperParams(true, commandLineArgs);
-    CommandLineOverrideHelper.getFlagOverrides(params);
+    List<String> commandLineArgs =
+        Arrays.asList(
+            "--enable-heap-profiling",
+            "--memlog=all",
+            "--memlog-stack-mode=native-with-thread-names",
+            "--trace-startup=-*;disabled-by-default-memory-infra",
+            "--trace-startup-duration=60",
+            "--trace-startup-file=/sdcard/Download/trace_atv.pftrace");
+    CommandLineOverrideHelper.getFlagOverrides(commandLineArgs);
 
     Assert.assertTrue(CommandLine.getInstance().hasSwitch("enable-heap-profiling"));
     Assert.assertEquals("all", CommandLine.getInstance().getSwitchValue("memlog"));


### PR DESCRIPTION
Refactor CommandLineOverrideHelper to be build-flavor agnostic by
removing the CommandLineOverrideHelperParams class and accepting a
list of strings directly. This simplifies the interface and moves
environment-specific logic, such as the official build check for
remote-allow-origins, into CobaltActivity.

The change also consolidates command-line switch applications into a
single batch call and flattens nested loops for better readability.
CobaltActivity now linearly accumulates arguments from intents and
metadata. Updated unit tests to reflect the API changes.

Bug: 414009070