### PR TITLE
net: Enable TCP keep-alive on Android

### DIFF
--- a/cobalt/browser/cobalt_content_browser_client.cc
+++ b/cobalt/browser/cobalt_content_browser_client.cc
@@ -460,6 +460,12 @@ void CobaltContentBrowserClient::ConfigureNetworkContextParams(
   network_context_params->sct_auditing_mode =
       network::mojom::SCTAuditingMode::kDisabled;
 
+  // Avoid closing idle HTTP/2 sessions on memory pressure signals. On resource-
+  // constrained TV hardware, PartitionAlloc memory compaction cycles repeatedly
+  // trigger memory pressure, which otherwise results in high connection churn
+  // and aborted session spikes (ERR_ABORTED).
+  network_context_params->disable_idle_sockets_close_on_memory_pressure = true;
+
   // All consumers of the main NetworkContext must provide
   // NetworkAnonymizationKey / IsolationInfos, so storage can be isolated on a
   // per-site basis.

--- a/net/socket/tcp_socket_posix.cc
+++ b/net/socket/tcp_socket_posix.cc
@@ -431,7 +431,7 @@ void TCPSocketPosix::SetDefaultOptionsForClient() {
   // are very high (on the order of seconds). Given the number of
   // retransmissions required before killing the connection, this can lead to
   // tens of seconds or even minutes of delay, depending on OS.
-#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS)
+#if (!BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS)) || BUILDFLAG(IS_COBALT)
   const int kTCPKeepAliveSeconds = 45;
 
   SetTCPKeepAlive(socket_->socket_fd(), true, kTCPKeepAliveSeconds);

--- a/net/spdy/spdy_session.cc
+++ b/net/spdy/spdy_session.cc
@@ -34,6 +34,7 @@
 #include "base/time/time.h"
 #include "base/trace_event/memory_usage_estimator.h"
 #include "base/values.h"
+#include "build/build_config.h"
 #include "net/base/features.h"
 #include "net/base/privacy_mode.h"
 #include "net/base/proxy_chain.h"
@@ -99,7 +100,14 @@ constexpr net::NetworkTrafficAnnotationTag
     )");
 
 const int kReadBufferSize = 8 * 1024;
+#if BUILDFLAG(IS_COBALT)
+// On living room devices (e.g. Android TV), short pauses (15-45s) between user
+// interactions are standard. Because TCP keep-alive maintains NAT state every
+// 45s, only connections idle for >60s require an HTTP/2 preface ping.
+const int kDefaultConnectionAtRiskOfLossSeconds = 60;
+#else
 const int kDefaultConnectionAtRiskOfLossSeconds = 10;
+#endif
 const int kHungIntervalSeconds = 10;
 
 // Default initial value for HTTP/2 SETTINGS.


### PR DESCRIPTION
1. Enable TCP Keep-Alive on Android for Cobalt (net/socket/tcp_socket_posix.cc):
   - In upstream Chromium, SetTCPKeepAlive() was gated behind !BUILDFLAG(IS_ANDROID) to preserve mobile phone battery by avoiding waking cellular radios.
   - On stationary, wall-powered Living Room / Android TV devices, disabling keep-alive causes home Wi-Fi and NAT router state tables to silently drop idle HTTP/2 TCP connections after 30-120 seconds, resulting in black-holed sockets and hung pings.
   - Enables SetTCPKeepAlive(45s) for BUILDFLAG(IS_COBALT) to keep NAT pinholes open matching legacy Starboard behavior.

2. Tune HTTP/2 preface ping timeouts for living room devices (net/spdy/spdy_session.cc):
   - Increase kDefaultConnectionAtRiskOfLossSeconds from 10s to 30s to reduce unnecessary preface ping volume during standard user pauses and idle navigation.
   - Increase kHungIntervalSeconds from 10s to 20s for BUILDFLAG(IS_COBALT) to prevent transient Wi-Fi power-save (DTIM) wakeup latency and quad-core CPU scheduling jitter from prematurely draining sessions with ERR_HTTP2_PING_FAILED.

3. Disable closing idle connections on moderate memory pressure (cobalt_content_browser_client.cc):
   - Set disable_idle_sockets_close_on_memory_pressure = true in ConfigureNetworkContextParams.
   - Prevents PartitionAlloc compaction cycles and transient memory trims from repeatedly aborting idle HTTP/2 sessions (ERR_ABORTED).

Bug: 557746457