### PR TITLE
cobalt: Disable Media Remoting

### DIFF
--- a/cobalt/build/configs/common.gn
+++ b/cobalt/build/configs/common.gn
@@ -98,3 +98,7 @@ enable_backup_ref_ptr_feature_flag = false
 # Disable vectorized HTML scanning (SIMD speedups for HTML parsing
 # are not needed).
 enable_vectorized_html_scanning = false
+
+# Disable Media Remoting (Casting / Remoter Mojo endpoints) for Cobalt.
+enable_media_remoting = false
+enable_media_remoting_rpc = false


### PR DESCRIPTION
Disable the media remoting and media remoting RPC build flags in the
common configuration. Cobalt does not use these features, which
include Casting and Remoter Mojo endpoints. Disabling them can
reduce runtime memory overhead of ~12KB.

Bug: 557781504