### PR TITLE
media: Remove GetMediaAudioStorageTypeName()

### DIFF
--- a/starboard/common/media.cc
+++ b/starboard/common/media.cc
@@ -809,18 +809,6 @@ const char* GetMediaAudioSampleTypeName(SbMediaAudioSampleType sample_type) {
   return "Invalid";
 }
 
-const char* GetMediaAudioStorageTypeName(
-    SbMediaAudioFrameStorageType storage_type) {
-  switch (storage_type) {
-    case kSbMediaAudioFrameStorageTypeInterleaved:
-      return "interleaved";
-    case kSbMediaAudioFrameStorageTypePlanar:
-      return "planar";
-  }
-  SB_NOTREACHED();
-  return "Invalid";
-}
-
 bool ParseVideoCodec(const char* codec_string,
                      SbMediaVideoCodec* codec,
                      int* profile,

--- a/starboard/common/media.h
+++ b/starboard/common/media.h
@@ -30,8 +30,6 @@ const char* GetMediaMatrixIdName(SbMediaMatrixId matrix_id);
 const char* GetMediaRangeIdName(SbMediaRangeId range_id);
 
 const char* GetMediaAudioSampleTypeName(SbMediaAudioSampleType sample_type);
-const char* GetMediaAudioStorageTypeName(
-    SbMediaAudioFrameStorageType storage_type);
 
 // This function parses the video codec string and returns a codec.  All fields
 // will be filled with information parsed from the codec string when possible,


### PR DESCRIPTION
This is part of the effort to remove kSbMediaAudioFrameStorageTypePlanar from 1P implementation.

Remove GetMediaAudioStorageTypeName() from starboard/common/media.*. Due to previous changes eliminating storage type tracking and parameters from DecodedAudio, AudioResampler, and player components, this helper method is no longer needed.

Bug: 272837615