### PR TITLE
media: Remove unused audio storage type parameters

### DIFF
--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -242,7 +242,6 @@ class AudioRendererSinkAndroid : public AudioRendererSinkImpl {
              int channels,
              int sampling_frequency_hz,
              SbMediaAudioSampleType audio_sample_type,
-             SbMediaAudioFrameStorageType audio_frame_storage_type,
              SbAudioSinkFrameBuffers frame_buffers,
              int frames_per_channel,
              RenderCallback* render_callback) override {
@@ -254,8 +253,7 @@ class AudioRendererSinkAndroid : public AudioRendererSinkImpl {
         audio_sink_->IsType(SbAudioSinkImpl::GetPreferredType()) &&
         channels == channels_ &&
         sampling_frequency_hz == sampling_frequency_hz_ &&
-        audio_sample_type == audio_sample_type_ &&
-        audio_frame_storage_type == audio_frame_storage_type_) {
+        audio_sample_type == audio_sample_type_) {
       SB_LOG(INFO) << "Audio track is already started with the same config, "
                    << "skipping Start().";
       auto* track_sink = static_cast<AudioTrackAudioSink*>(audio_sink_);
@@ -272,12 +270,10 @@ class AudioRendererSinkAndroid : public AudioRendererSinkImpl {
     channels_ = channels;
     sampling_frequency_hz_ = sampling_frequency_hz;
     audio_sample_type_ = audio_sample_type;
-    audio_frame_storage_type_ = audio_frame_storage_type;
 
-    AudioRendererSinkImpl::Start(media_start_time, channels,
-                                 sampling_frequency_hz, audio_sample_type,
-                                 audio_frame_storage_type, frame_buffers,
-                                 frames_per_channel, render_callback);
+    AudioRendererSinkImpl::Start(
+        media_start_time, channels, sampling_frequency_hz, audio_sample_type,
+        frame_buffers, frames_per_channel, render_callback);
   }
 
  private:
@@ -322,8 +318,6 @@ class AudioRendererSinkAndroid : public AudioRendererSinkImpl {
   int sampling_frequency_hz_ = -1;
   SbMediaAudioSampleType audio_sample_type_ =
       kSbMediaAudioSampleTypeInt16Deprecated;
-  SbMediaAudioFrameStorageType audio_frame_storage_type_ =
-      kSbMediaAudioFrameStorageTypeInterleaved;
 };
 
 class PlayerComponentsPassthrough : public PlayerComponents {

--- a/starboard/shared/starboard/player/filter/audio_renderer_pcm_internal.cc
+++ b/starboard/shared/starboard/player/filter/audio_renderer_pcm_internal.cc
@@ -581,9 +581,8 @@ void AudioRendererPcm::OnFirstOutput(
   buffered_frames_to_start_ = std::min(
       destination_sample_rate / 5, max_cached_frames_ - min_frames_per_append_);
 
-  // |time_stretcher_| only supports kSbMediaAudioSampleTypeFloat32 and
-  // kSbMediaAudioFrameStorageTypeInterleaved, so we resample the audio to that
-  // format to avoid unnecessary extra conversion.
+  // |time_stretcher_| only supports kSbMediaAudioSampleTypeFloat32, so we
+  // resample the audio to that format to avoid unnecessary extra conversion.
   if (decoded_sample_rate != destination_sample_rate ||
       decoded_sample_type != kSbMediaAudioSampleTypeFloat32) {
     resampler_ = AudioResampler::Create(
@@ -594,10 +593,8 @@ void AudioRendererPcm::OnFirstOutput(
     resampler_.reset(new IdentityAudioResampler);
   }
 
-  // TODO: Support planar only audio sink.
   audio_renderer_sink_->Start(
       seeking_to_time_, channels_, destination_sample_rate, sink_sample_type_,
-      kSbMediaAudioFrameStorageTypeInterleaved,
       reinterpret_cast<SbAudioSinkFrameBuffers>(frame_buffers_),
       max_cached_frames_, this);
   if (!audio_renderer_sink_->HasStarted()) {

--- a/starboard/shared/starboard/player/filter/audio_renderer_sink.h
+++ b/starboard/shared/starboard/player/filter/audio_renderer_sink.h
@@ -56,8 +56,6 @@ class AudioRendererSink {
 
   virtual bool IsAudioSampleTypeSupported(
       SbMediaAudioSampleType audio_sample_type) const = 0;
-  virtual bool IsAudioFrameStorageTypeSupported(
-      SbMediaAudioFrameStorageType audio_frame_storage_type) const = 0;
   virtual int GetNearestSupportedSampleFrequency(
       int sampling_frequency_hz) const = 0;
 
@@ -66,7 +64,6 @@ class AudioRendererSink {
                      int channels,
                      int sampling_frequency_hz,
                      SbMediaAudioSampleType audio_sample_type,
-                     SbMediaAudioFrameStorageType audio_frame_storage_type,
                      SbAudioSinkFrameBuffers frame_buffers,
                      int frames_per_channel,
                      RenderCallback* render_callback) = 0;

--- a/starboard/shared/starboard/player/filter/audio_renderer_sink_impl.cc
+++ b/starboard/shared/starboard/player/filter/audio_renderer_sink_impl.cc
@@ -88,23 +88,19 @@ bool AudioRendererSinkImpl::HasStarted() const {
   return SbAudioSinkIsValid(audio_sink_);
 }
 
-void AudioRendererSinkImpl::Start(
-    int64_t media_start_time,
-    int channels,
-    int sampling_frequency_hz,
-    SbMediaAudioSampleType audio_sample_type,
-    SbMediaAudioFrameStorageType audio_frame_storage_type,
-    SbAudioSinkFrameBuffers frame_buffers,
-    int frames_per_channel,
-    RenderCallback* render_callback) {
+void AudioRendererSinkImpl::Start(int64_t media_start_time,
+                                  int channels,
+                                  int sampling_frequency_hz,
+                                  SbMediaAudioSampleType audio_sample_type,
+                                  SbAudioSinkFrameBuffers frame_buffers,
+                                  int frames_per_channel,
+                                  RenderCallback* render_callback) {
   SB_CHECK(thread_checker_.CalledOnValidThread());
   SB_DCHECK(!HasStarted());
   SB_DCHECK_GT(channels, 0);
   SB_DCHECK_LE(channels, SbAudioSinkGetMaxChannels());
   SB_DCHECK_GT(sampling_frequency_hz, 0);
   SB_DCHECK(SbAudioSinkIsAudioSampleTypeSupported(audio_sample_type));
-  SB_DCHECK(
-      SbAudioSinkIsAudioFrameStorageTypeSupported(audio_frame_storage_type));
   SB_DCHECK(frame_buffers);
   SB_DCHECK_GT(frames_per_channel, 0);
 
@@ -112,8 +108,8 @@ void AudioRendererSinkImpl::Start(
   render_callback_ = render_callback;
   audio_sink_ = create_audio_sink_func_(
       media_start_time, channels, sampling_frequency_hz, audio_sample_type,
-      audio_frame_storage_type, frame_buffers, frames_per_channel,
-      &AudioRendererSinkImpl::UpdateSourceStatusFunc,
+      kSbMediaAudioFrameStorageTypeInterleaved, frame_buffers,
+      frames_per_channel, &AudioRendererSinkImpl::UpdateSourceStatusFunc,
       &AudioRendererSinkImpl::ConsumeFramesFunc,
       &AudioRendererSinkImpl::ErrorFunc, this);
   if (!SbAudioSinkIsValid(audio_sink_)) {
@@ -128,11 +124,6 @@ void AudioRendererSinkImpl::Start(
 bool AudioRendererSinkImpl::IsAudioSampleTypeSupported(
     SbMediaAudioSampleType audio_sample_type) const {
   return SbAudioSinkIsAudioSampleTypeSupported(audio_sample_type);
-}
-
-bool AudioRendererSinkImpl::IsAudioFrameStorageTypeSupported(
-    SbMediaAudioFrameStorageType audio_frame_storage_type) const {
-  return SbAudioSinkIsAudioFrameStorageTypeSupported(audio_frame_storage_type);
 }
 
 int AudioRendererSinkImpl::GetNearestSupportedSampleFrequency(

--- a/starboard/shared/starboard/player/filter/audio_renderer_sink_impl.h
+++ b/starboard/shared/starboard/player/filter/audio_renderer_sink_impl.h
@@ -56,7 +56,6 @@ class AudioRendererSinkImpl : public AudioRendererSink {
              int channels,
              int sampling_frequency_hz,
              SbMediaAudioSampleType audio_sample_type,
-             SbMediaAudioFrameStorageType audio_frame_storage_type,
              SbAudioSinkFrameBuffers frame_buffers,
              int frames_per_channel,
              RenderCallback* render_callback) override;
@@ -71,8 +70,6 @@ class AudioRendererSinkImpl : public AudioRendererSink {
   // AudioRendererSink methods
   bool IsAudioSampleTypeSupported(
       SbMediaAudioSampleType audio_sample_type) const override;
-  bool IsAudioFrameStorageTypeSupported(
-      SbMediaAudioFrameStorageType audio_frame_storage_type) const override;
   int GetNearestSupportedSampleFrequency(
       int sampling_frequency_hz) const override;
 

--- a/starboard/shared/starboard/player/filter/audio_time_stretcher.cc
+++ b/starboard/shared/starboard/player/filter/audio_time_stretcher.cc
@@ -274,9 +274,8 @@ void AudioTimeStretcher::GetOptimalBlock() {
 
     // |optimal_index| is in frames and it is relative to the beginning of the
     // |search_block_|.
-    optimal_index = OptimalIndex(&search_block_, &target_block_,
-                                 kSbMediaAudioFrameStorageTypeInterleaved,
-                                 exclude_interval);
+    optimal_index =
+        OptimalIndex(&search_block_, &target_block_, exclude_interval);
 
     // Translate |index| w.r.t. the beginning of |audio_buffer_| and extract the
     // optimal block.

--- a/starboard/shared/starboard/player/filter/mock_audio_decoder.h
+++ b/starboard/shared/starboard/player/filter/mock_audio_decoder.h
@@ -29,9 +29,8 @@ namespace starboard {
 
 class MockAudioDecoder : public AudioDecoder {
  public:
-  MockAudioDecoder(SbMediaAudioSampleType sample_type,
-                   SbMediaAudioFrameStorageType storage_type,
-                   int samples_per_second) {}
+  MockAudioDecoder(SbMediaAudioSampleType sample_type, int samples_per_second) {
+  }
 
   MOCK_METHOD2(Initialize, void(const OutputCB&, const ErrorCB&));
   MOCK_METHOD2(Decode, void(const InputBuffers&, const ConsumedCB&));

--- a/starboard/shared/starboard/player/filter/mock_audio_renderer_sink.h
+++ b/starboard/shared/starboard/player/filter/mock_audio_renderer_sink.h
@@ -33,18 +33,14 @@ class MockAudioRendererSink : public AudioRendererSink {
                           int* min_frames_per_append));
   MOCK_CONST_METHOD1(IsAudioSampleTypeSupported,
                      bool(SbMediaAudioSampleType audio_sample_type));
-  MOCK_CONST_METHOD1(
-      IsAudioFrameStorageTypeSupported,
-      bool(SbMediaAudioFrameStorageType audio_frame_storage_type));
   MOCK_CONST_METHOD1(GetNearestSupportedSampleFrequency,
                      int(int sampling_frequency_hz));
   MOCK_CONST_METHOD0(HasStarted, bool());
-  MOCK_METHOD8(Start,
+  MOCK_METHOD7(Start,
                void(int64_t media_start_time,
                     int channels,
                     int sampling_frequency_hz,
                     SbMediaAudioSampleType audio_sample_type,
-                    SbMediaAudioFrameStorageType audio_frame_storage_type,
                     SbAudioSinkFrameBuffers frame_buffers,
                     int frames_per_channel,
                     RenderCallback* render_callback));

--- a/starboard/shared/starboard/player/filter/testing/audio_renderer_internal_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_renderer_internal_test.cc
@@ -49,24 +49,17 @@ class AudioRendererTest : public ::testing::Test {
   static const int kDefaultSamplesPerSecond;
   static const SbMediaAudioSampleType kDefaultAudioSampleType =
       kSbMediaAudioSampleTypeFloat32;
-  static const SbMediaAudioFrameStorageType kDefaultAudioFrameStorageType =
-      kSbMediaAudioFrameStorageTypeInterleaved;
 
-  AudioRendererTest() {
-    ResetToFormat(kSbMediaAudioSampleTypeFloat32,
-                  kSbMediaAudioFrameStorageTypeInterleaved);
-  }
+  AudioRendererTest() { ResetToFormat(kSbMediaAudioSampleTypeFloat32); }
 
   // This function should be called in the fixture before any other functions
   // to set the desired format of the decoder.
-  void ResetToFormat(SbMediaAudioSampleType sample_type,
-                     SbMediaAudioFrameStorageType storage_type) {
+  void ResetToFormat(SbMediaAudioSampleType sample_type) {
     audio_renderer_.reset(NULL);
     sample_type_ = sample_type;
-    storage_type_ = storage_type;
     audio_renderer_sink_ = new ::testing::StrictMock<MockAudioRendererSink>;
-    audio_decoder_ = new MockAudioDecoder(sample_type_, storage_type_,
-                                          kDefaultSamplesPerSecond);
+    audio_decoder_ =
+        new MockAudioDecoder(sample_type_, kDefaultSamplesPerSecond);
 
     ON_CALL(*audio_decoder_, Read(_))
         .WillByDefault(DoAll(SetArgPointee<0>(kDefaultSamplesPerSecond),
@@ -74,11 +67,11 @@ class AudioRendererTest : public ::testing::Test {
                                return std::optional<DecodedAudio>(
                                    DecodedAudio::CreateEOSBuffer());
                              })));
-    ON_CALL(*audio_renderer_sink_, Start(_, _, _, _, _, _, _, _))
+    ON_CALL(*audio_renderer_sink_, Start(_, _, _, _, _, _, _))
         .WillByDefault(DoAll(InvokeWithoutArgs([this]() {
                                audio_renderer_sink_->SetHasStarted(true);
                              }),
-                             SaveArg<7>(&renderer_callback_)));
+                             SaveArg<6>(&renderer_callback_)));
     ON_CALL(*audio_renderer_sink_, Stop())
         .WillByDefault(InvokeWithoutArgs([this]() {
           audio_renderer_sink_->SetHasStarted(false);
@@ -229,7 +222,6 @@ class AudioRendererTest : public ::testing::Test {
   void OnEnded() {}
 
   SbMediaAudioSampleType sample_type_;
-  SbMediaAudioFrameStorageType storage_type_;
 
   JobQueue job_queue_;
   std::set<const void*> buffers_in_decoder_;
@@ -314,10 +306,9 @@ TEST_F(AudioRendererTest, SunnyDay) {
 
   {
     InSequence seq;
-    EXPECT_CALL(
-        *audio_renderer_sink_,
-        Start(0, kDefaultNumberOfChannels, kDefaultSamplesPerSecond,
-              kDefaultAudioSampleType, kDefaultAudioFrameStorageType, _, _, _));
+    EXPECT_CALL(*audio_renderer_sink_,
+                Start(0, kDefaultNumberOfChannels, kDefaultSamplesPerSecond,
+                      kDefaultAudioSampleType, _, _, _));
   }
 
   Seek(0);
@@ -394,15 +385,13 @@ TEST_F(AudioRendererTest, SunnyDayWithDoublePlaybackRateAndInt16Samples) {
 
   // Resets |audio_renderer_sink_|, so all the gtest codes need to be below
   // this line.
-  ResetToFormat(kSbMediaAudioSampleTypeInt16Deprecated,
-                kSbMediaAudioFrameStorageTypeInterleaved);
+  ResetToFormat(kSbMediaAudioSampleTypeInt16Deprecated);
 
   {
     ::testing::InSequence seq;
-    EXPECT_CALL(
-        *audio_renderer_sink_,
-        Start(0, kDefaultNumberOfChannels, kDefaultSamplesPerSecond,
-              kDefaultAudioSampleType, kDefaultAudioFrameStorageType, _, _, _));
+    EXPECT_CALL(*audio_renderer_sink_,
+                Start(0, kDefaultNumberOfChannels, kDefaultSamplesPerSecond,
+                      kDefaultAudioSampleType, _, _, _));
   }
 
   // It is OK to set the rate to 1.0 any number of times.
@@ -474,10 +463,9 @@ TEST_F(AudioRendererTest, StartPlayBeforePreroll) {
 
   {
     ::testing::InSequence seq;
-    EXPECT_CALL(
-        *audio_renderer_sink_,
-        Start(0, kDefaultNumberOfChannels, kDefaultSamplesPerSecond,
-              kDefaultAudioSampleType, kDefaultAudioFrameStorageType, _, _, _));
+    EXPECT_CALL(*audio_renderer_sink_,
+                Start(0, kDefaultNumberOfChannels, kDefaultSamplesPerSecond,
+                      kDefaultAudioSampleType, _, _, _));
   }
 
   Seek(0);
@@ -541,10 +529,9 @@ TEST_F(AudioRendererTest, DecoderReturnsEOSWithoutAnyData) {
 
   {
     ::testing::InSequence seq;
-    EXPECT_CALL(
-        *audio_renderer_sink_,
-        Start(0, kDefaultNumberOfChannels, kDefaultSamplesPerSecond,
-              kDefaultAudioSampleType, kDefaultAudioFrameStorageType, _, _, _));
+    EXPECT_CALL(*audio_renderer_sink_,
+                Start(0, kDefaultNumberOfChannels, kDefaultSamplesPerSecond,
+                      kDefaultAudioSampleType, _, _, _));
   }
 
   Seek(0);
@@ -584,10 +571,9 @@ TEST_F(AudioRendererTest, DecoderConsumeAllInputBeforeReturningData) {
 
   {
     ::testing::InSequence seq;
-    EXPECT_CALL(
-        *audio_renderer_sink_,
-        Start(0, kDefaultNumberOfChannels, kDefaultSamplesPerSecond,
-              kDefaultAudioSampleType, kDefaultAudioFrameStorageType, _, _, _));
+    EXPECT_CALL(*audio_renderer_sink_,
+                Start(0, kDefaultNumberOfChannels, kDefaultSamplesPerSecond,
+                      kDefaultAudioSampleType, _, _, _));
   }
 
   Seek(0);
@@ -633,10 +619,9 @@ TEST_F(AudioRendererTest, MoreNumberOfOutputBuffersThanInputBuffers) {
 
   {
     ::testing::InSequence seq;
-    EXPECT_CALL(
-        *audio_renderer_sink_,
-        Start(0, kDefaultNumberOfChannels, kDefaultSamplesPerSecond,
-              kDefaultAudioSampleType, kDefaultAudioFrameStorageType, _, _, _));
+    EXPECT_CALL(*audio_renderer_sink_,
+                Start(0, kDefaultNumberOfChannels, kDefaultSamplesPerSecond,
+                      kDefaultAudioSampleType, _, _, _));
   }
 
   Seek(0);
@@ -726,11 +711,10 @@ TEST_F(AudioRendererTest, LessNumberOfOutputBuffersThanInputBuffers) {
     ::testing::InSequence seq;
     EXPECT_CALL(*audio_renderer_sink_, HasStarted())
         .WillRepeatedly(Return(false));
-    EXPECT_CALL(
-        *audio_renderer_sink_,
-        Start(0, kDefaultNumberOfChannels, kDefaultSamplesPerSecond,
-              kDefaultAudioSampleType, kDefaultAudioFrameStorageType, _, _, _))
-        .WillOnce(SaveArg<7>(&renderer_callback_));
+    EXPECT_CALL(*audio_renderer_sink_,
+                Start(0, kDefaultNumberOfChannels, kDefaultSamplesPerSecond,
+                      kDefaultAudioSampleType, _, _, _))
+        .WillOnce(SaveArg<6>(&renderer_callback_));
     EXPECT_CALL(*audio_renderer_sink_, HasStarted())
         .WillRepeatedly(Return(true));
   }
@@ -814,16 +798,15 @@ TEST_F(AudioRendererTest, Seek) {
 
   {
     ::testing::InSequence seq;
-    EXPECT_CALL(
-        *audio_renderer_sink_,
-        Start(0, kDefaultNumberOfChannels, kDefaultSamplesPerSecond,
-              kDefaultAudioSampleType, kDefaultAudioFrameStorageType, _, _, _));
+    EXPECT_CALL(*audio_renderer_sink_,
+                Start(0, kDefaultNumberOfChannels, kDefaultSamplesPerSecond,
+                      kDefaultAudioSampleType, _, _, _));
     EXPECT_CALL(*audio_renderer_sink_, Reset());
     EXPECT_CALL(*audio_decoder_, Reset());
     EXPECT_CALL(
         *audio_renderer_sink_,
         Start(kSeekTime, kDefaultNumberOfChannels, kDefaultSamplesPerSecond,
-              kDefaultAudioSampleType, kDefaultAudioFrameStorageType, _, _, _));
+              kDefaultAudioSampleType, _, _, _));
   }
 
   Seek(0);

--- a/starboard/shared/starboard/player/filter/testing/wsola_internal_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/wsola_internal_test.cc
@@ -74,8 +74,7 @@ TEST(WsolaInternalTest, OptimalIndex_ExactMatch) {
   Interval exclude_interval = {-1, -1};  // No exclusion
 
   int optimal_index =
-      OptimalIndex(&search_block, &target_block,
-                   kSbMediaAudioFrameStorageTypeInterleaved, exclude_interval);
+      OptimalIndex(&search_block, &target_block, exclude_interval);
   // Due to floating point precision and quadratic interpolation, it might not
   // be exactly 25, but should be very close. We test for a small range.
   EXPECT_NEAR(optimal_index, 25, 1);
@@ -93,8 +92,7 @@ TEST(WsolaInternalTest, OptimalIndex_NoMatch) {
   Interval exclude_interval = {-1, -1};  // No exclusion
 
   int optimal_index =
-      OptimalIndex(&search_block, &target_block,
-                   kSbMediaAudioFrameStorageTypeInterleaved, exclude_interval);
+      OptimalIndex(&search_block, &target_block, exclude_interval);
   // With no clear match, the result is less predictable, but it shouldn't crash
   // and should return a valid index within the search range.
   EXPECT_GE(optimal_index, 0);
@@ -124,8 +122,7 @@ TEST(WsolaInternalTest, OptimalIndex_ExcludeInterval) {
   Interval exclude_interval = {5, 15};  // Exclude indices from 5 to 15
 
   int optimal_index =
-      OptimalIndex(&search_block, &target_block,
-                   kSbMediaAudioFrameStorageTypeInterleaved, exclude_interval);
+      OptimalIndex(&search_block, &target_block, exclude_interval);
 
   // The match at 10 should be excluded, so it should find the match at 50.
   EXPECT_EQ(optimal_index, 50);
@@ -148,8 +145,7 @@ TEST(WsolaInternalTest, OptimalIndex_SmallBlocks) {
   Interval exclude_interval = {-1, -1};
 
   int optimal_index =
-      OptimalIndex(&search_block, &target_block,
-                   kSbMediaAudioFrameStorageTypeInterleaved, exclude_interval);
+      OptimalIndex(&search_block, &target_block, exclude_interval);
   EXPECT_NEAR(optimal_index, 10, 1);
 }
 

--- a/starboard/shared/starboard/player/filter/wsola_internal.cc
+++ b/starboard/shared/starboard/player/filter/wsola_internal.cc
@@ -300,11 +300,9 @@ int FullSearch(int low_limit,
 
 int OptimalIndex(const DecodedAudio* search_block,
                  const DecodedAudio* target_block,
-                 SbMediaAudioFrameStorageType storage_type,
                  Interval exclude_interval) {
   int channels = search_block->channels();
   SB_DCHECK_EQ(channels, target_block->channels());
-  SB_DCHECK_EQ(storage_type, kSbMediaAudioFrameStorageTypeInterleaved);
 
   int target_size = target_block->frames();
   int num_candidate_blocks = search_block->frames() - (target_size - 1);

--- a/starboard/shared/starboard/player/filter/wsola_internal.h
+++ b/starboard/shared/starboard/player/filter/wsola_internal.h
@@ -25,7 +25,6 @@
 
 #include <utility>
 
-#include "starboard/media.h"
 #include "starboard/shared/internal_only.h"
 #include "starboard/shared/starboard/player/decoded_audio_internal.h"
 
@@ -38,7 +37,6 @@ typedef std::pair<int, int> Interval;
 // |exclude_interval| is an interval that is excluded from the search.
 int OptimalIndex(const DecodedAudio* search_block,
                  const DecodedAudio* target_block,
-                 SbMediaAudioFrameStorageType storage_type,
                  Interval exclude_interval);
 
 // Return a "periodic" Hann window(https://en.wikipedia.org/wiki/Hann_function).


### PR DESCRIPTION
This change is part of the ongoing effort to remove planar audio frame
storage type support from the first-party implementation.

Obsolete storage_type parameters, methods, and members have been
removed from various player filter components, including
OptimalIndex(), MockAudioDecoder, and AudioRendererSink. A related
TODO regarding planar audio sink support was also removed.

Bug: 272837615
