### PR TITLE
tvos: Wire DRM system to URL player bridge

### DIFF
--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -312,6 +312,13 @@ void StarboardRenderer::SetCdm(CdmContext* cdm_context,
   std::move(cdm_attached_cb).Run(true);
   LOG(INFO) << "CDM set successfully.";
 
+#if BUILDFLAG(IS_IOS_TVOS)
+  // Wire DRM to URL player bridge if it was created before CDM arrived.
+  if (IsUrlPlayer() && player_bridge_ && SbDrmSystemIsValid(drm_system_)) {
+    player_bridge_->SetDrmSystem(drm_system_);
+  }
+#endif  // BUILDFLAG(IS_IOS_TVOS)
+
   if (state_ != STATE_INIT_PENDING_CDM) {
     return;
   }
@@ -772,6 +779,10 @@ void StarboardRenderer::CreatePlayerBridge() {
         /*pipeline_identifier=*/""
 #endif  // BUILDFLAG(COBALT_MEDIA_ENABLE_CVAL)
         ));
+    // Wire DRM if CDM arrived before bridge creation.
+    if (SbDrmSystemIsValid(drm_system_)) {
+      player_bridge_->SetDrmSystem(drm_system_);
+    }
   } else {
 #endif  // BUILDFLAG(IS_IOS_TVOS)
     player_bridge_.reset(new SbPlayerBridge(


### PR DESCRIPTION
tvos: Wire DRM system to URL player bridge

Unlike the normal Widevine path where StarboardRenderer defers player
bridge creation until the CDM is available (via STATE_INIT_PENDING_CDM),
the URL player path creates the bridge immediately during Initialize()
because AVPlayer needs to be running to discover encrypted content and
fire OnEncryptedMediaInitDataEncountered. This means the CDM always
arrives after the bridge already exists.

The normal SbPlayerBridge constructor takes drm_system_ as a parameter,
so the Widevine path never needs post-creation wiring. The URL player
constructor does not accept a DRM system, so we need to call
SetDrmSystem() after the fact.

We wire from two sites to handle both possible orderings:
- SetCdm(): bridge already exists, CDM just arrived (common case)
- CreatePlayerBridge(): CDM was set first, bridge created later
  (happens when get_sb_window_handle_cb_ delays bridge creation)

Whichever runs second finds both pieces ready and does the wiring.

Bug: 498421484
Bug: 549709375