### PR TITLE
tvos: Add platform DRM key system registration

### DIFF
--- a/cobalt/renderer/BUILD.gn
+++ b/cobalt/renderer/BUILD.gn
@@ -43,6 +43,10 @@ source_set("renderer") {
 
   if (use_starboard_media) {
     deps += [ "//media/mojo/clients" ]
+
+    if (is_ios && is_internal_build) {
+      deps += [ "//cobalt/internal/cobalt/components/cdm/renderer/starboard:platform_drm_key_system_info" ]
+    }
   }
 }
 

--- a/cobalt/renderer/cobalt_content_renderer_client.cc
+++ b/cobalt/renderer/cobalt_content_renderer_client.cc
@@ -52,6 +52,9 @@
 
 #if BUILDFLAG(IS_IOS_TVOS)
 #include "media/starboard/url_player_demuxer.h"
+#if defined(COBALT_INTERNAL_BUILD)
+#include "cobalt/internal/cobalt/components/cdm/renderer/starboard/platform_drm_key_system_info.h"
+#endif  // defined(COBALT_INTERNAL_BUILD)
 #endif  // BUILDFLAG(IS_IOS_TVOS)
 
 namespace cobalt {
@@ -263,6 +266,16 @@ void AddStarboardCmaKeySystems(::media::KeySystemInfos* key_system_infos) {
       ::media::EmeFeatureSupport::ALWAYS_ENABLED,    // Persistent state.
       ::media::EmeFeatureSupport::ALWAYS_ENABLED));  // Distinctive
                                                      // identifier.
+
+#if BUILDFLAG(IS_IOS_TVOS) && defined(COBALT_INTERNAL_BUILD)
+  key_system_infos->push_back(std::make_unique<cdm::PlatformDrmKeySystemInfo>(
+      codecs,                                        // Regular codecs.
+      kEncryptionSchemes,                            // Encryption schemes.
+      codecs,                                        // Hardware secure codecs.
+      ::media::EmeFeatureSupport::ALWAYS_ENABLED,    // Persistent state.
+      ::media::EmeFeatureSupport::ALWAYS_ENABLED));  // Distinctive
+                                                     // identifier.
+#endif  // BUILDFLAG(IS_IOS_TVOS) && defined(COBALT_INTERNAL_BUILD)
 }
 
 std::unique_ptr<::media::KeySystemSupportRegistration>


### PR DESCRIPTION
Register the platform DRM key system in the Cobalt content renderer
client for internal tvOS builds.

This registration is required to prevent NotSupportedError when
the YouTube application calls `requestMediaKeySystemAccess`. By
providing the platform-specific KeySystemInfo, the renderer can
successfully advertise supported initialization data types and
encryption schemes, enabling the creation of MediaKeys for the
platform DRM.

Supported by internal build only.

Bug: 501343649
Bug: 498421484