### PR TITLE
starboard: Remove dead Evergreen Lite guards

### DIFF
--- a/cobalt/site/docs/gen/starboard/doc/evergreen/cobalt_evergreen_lite.md
+++ b/cobalt/site/docs/gen/starboard/doc/evergreen/cobalt_evergreen_lite.md
@@ -81,9 +81,9 @@ Same as the [Evergreen full doc](cobalt_evergreen_overview.md).
 
 ## Building Cobalt Evergreen Components
 
-`kSbSystemPathStorageDirectory` is not required to implement. The rest of the
-implementation is the same as the Evergreen Full doc -
-[cobalt_evergreen_overview.md](cobalt_evergreen_overview.md).
+`kSbSystemPathStorageDirectory` is not required to implement. Set both
+`sb_evergreen_compatible` and `sb_evergreen_compatible_lite` to `1`s in the `gyp`
+platform config. The remaining is the same as the Evergreen full doc.
 
 ## How does the update work with Evergreen Lite?
 
@@ -171,6 +171,7 @@ binaries - `kSbSystemPathStorageDirectory `and configure the slots as instructed
 in the Evergreen full doc
 *   Configure icu table under `kSbSystemPathStorageDirectory` to be shared
     among slots
+*   Set `sb_evergreen_compatible_lite` to 0
 *   Implement the handling of pending updates
 *   Rebuild and rerun `nplb_evergreen_compat_tests`
 *   Launch Cobalt with loader app without the `evergreen_lite` flag

--- a/cobalt/site/docs/gen/starboard/doc/evergreen/cobalt_evergreen_lite.md
+++ b/cobalt/site/docs/gen/starboard/doc/evergreen/cobalt_evergreen_lite.md
@@ -81,9 +81,9 @@ Same as the [Evergreen full doc](cobalt_evergreen_overview.md).
 
 ## Building Cobalt Evergreen Components
 
-`kSbSystemPathStorageDirectory` is not required to implement. Set both
-`sb_evergreen_compatible` and `sb_evergreen_compatible_lite` to `1`s in the `gyp`
-platform config. The remaining is the same as the Evergreen full doc.
+`kSbSystemPathStorageDirectory` is not required to implement. The remaining is
+the same as the Evergreen Full doc -
+[cobalt_evergreen_overview.md](cobalt_evergreen_overview.md).
 
 ## How does the update work with Evergreen Lite?
 
@@ -171,7 +171,6 @@ binaries - `kSbSystemPathStorageDirectory `and configure the slots as instructed
 in the Evergreen full doc
 *   Configure icu table under `kSbSystemPathStorageDirectory` to be shared
     among slots
-*   Set `sb_evergreen_compatible_lite` to 0
 *   Implement the handling of pending updates
 *   Rebuild and rerun `nplb_evergreen_compat_tests`
 *   Launch Cobalt with loader app without the `evergreen_lite` flag

--- a/cobalt/site/docs/gen/starboard/doc/evergreen/cobalt_evergreen_lite.md
+++ b/cobalt/site/docs/gen/starboard/doc/evergreen/cobalt_evergreen_lite.md
@@ -81,8 +81,8 @@ Same as the [Evergreen full doc](cobalt_evergreen_overview.md).
 
 ## Building Cobalt Evergreen Components
 
-`kSbSystemPathStorageDirectory` is not required to implement. The remaining is
-the same as the Evergreen Full doc -
+`kSbSystemPathStorageDirectory` is not required to implement. The rest of the
+implementation is the same as the Evergreen Full doc -
 [cobalt_evergreen_overview.md](cobalt_evergreen_overview.md).
 
 ## How does the update work with Evergreen Lite?

--- a/starboard/doc/evergreen/cobalt_evergreen_lite.md
+++ b/starboard/doc/evergreen/cobalt_evergreen_lite.md
@@ -78,8 +78,8 @@ Same as the [Evergreen full doc](cobalt_evergreen_overview.md).
 
 ## Building Cobalt Evergreen Components
 
-`kSbSystemPathStorageDirectory` is not required to implement. The remaining is
-the same as the Evergreen Full doc -
+`kSbSystemPathStorageDirectory` is not required to implement. The rest of the
+implementation is the same as the Evergreen Full doc -
 [cobalt_evergreen_overview.md](cobalt_evergreen_overview.md).
 
 ## How does the update work with Evergreen Lite?

--- a/starboard/doc/evergreen/cobalt_evergreen_lite.md
+++ b/starboard/doc/evergreen/cobalt_evergreen_lite.md
@@ -78,9 +78,9 @@ Same as the [Evergreen full doc](cobalt_evergreen_overview.md).
 
 ## Building Cobalt Evergreen Components
 
-`kSbSystemPathStorageDirectory` is not required to implement. Set both
-`sb_evergreen_compatible` and `sb_evergreen_compatible_lite` to `1`s in the `gyp`
-platform config. The remaining is the same as the Evergreen full doc.
+`kSbSystemPathStorageDirectory` is not required to implement. The remaining is
+the same as the Evergreen Full doc -
+[cobalt_evergreen_overview.md](cobalt_evergreen_overview.md).
 
 ## How does the update work with Evergreen Lite?
 
@@ -168,7 +168,6 @@ binaries - `kSbSystemPathStorageDirectory `and configure the slots as instructed
 in the Evergreen full doc
 *   Configure icu table under `kSbSystemPathStorageDirectory` to be shared
     among slots
-*   Set `sb_evergreen_compatible_lite` to 0
 *   Implement the handling of pending updates
 *   Rebuild and rerun `nplb_evergreen_compat_tests`
 *   Launch Cobalt with loader app without the `evergreen_lite` flag

--- a/starboard/loader_app/installation_manager.cc
+++ b/starboard/loader_app/installation_manager.cc
@@ -24,17 +24,15 @@
 #include <string>
 #include <vector>
 
+#include "starboard/common/check_op.h"
 #include "starboard/common/file.h"
 #include "starboard/common/log.h"
+#include "starboard/common/once.h"
 #include "starboard/common/string.h"
 #include "starboard/configuration_constants.h"
 #include "starboard/extension/loader_app_metrics.h"
 #include "starboard/loader_app/installation_store.pb.h"
-#if !SB_IS(EVERGREEN_COMPATIBLE_LITE)
 #include "starboard/loader_app/pending_restart.h"  // nogncheck
-#endif  // !SB_IS(EVERGREEN_COMPATIBLE_LITE)
-#include "starboard/common/check_op.h"
-#include "starboard/common/once.h"
 #include "starboard/loader_app/record_loader_app_status.h"
 
 namespace loader_app {
@@ -596,9 +594,7 @@ bool InstallationManager::SaveInstallationStore() {
   std::vector<char> buf(buf_size, 0);
 
   int result = installation_store_.roll_forward_to_installation();
-#if !SB_IS(EVERGREEN_COMPATIBLE_LITE)
   loader_app::SetPendingRestart(result != -1);
-#endif
 
   installation_store_.SerializeToArray(buf.data(),
                                        installation_store_.ByteSizeLong());

--- a/starboard/shared/signal/suspend_signals.cc
+++ b/starboard/shared/signal/suspend_signals.cc
@@ -26,9 +26,9 @@
 #include "starboard/shared/starboard/application.h"
 #include "starboard/system.h"
 
-#if BUILDFLAG(IS_STARBOARD) && !SB_IS(EVERGREEN_COMPATIBLE_LITE)
+#if BUILDFLAG(IS_STARBOARD)
 #include "starboard/loader_app/pending_restart.h"  // nogncheck
-#endif  // BUILDFLAG(IS_STARBOARD) && !SB_IS(EVERGREEN_COMPATIBLE_LITE)
+#endif
 
 namespace starboard {
 

--- a/starboard/shared/signal/system_request_freeze.cc
+++ b/starboard/shared/signal/system_request_freeze.cc
@@ -19,9 +19,9 @@
 #include "starboard/shared/signal/signal_internal.h"
 #include "starboard/shared/starboard/application.h"
 
-#if BUILDFLAG(IS_STARBOARD) && !SB_IS(EVERGREEN_COMPATIBLE_LITE)
+#if BUILDFLAG(IS_STARBOARD)
 #include "starboard/loader_app/pending_restart.h"
-#endif  // BUILDFLAG(IS_STARBOARD) && !SB_IS(EVERGREEN_COMPATIBLE_LITE)
+#endif
 
 void FreezeDone(void* /*context*/) {
   // Stop all thread execution after fully transitioning into Frozen.
@@ -33,7 +33,7 @@ void FreezeDone(void* /*context*/) {
 }
 
 void SbSystemRequestFreeze() {
-#if BUILDFLAG(IS_STARBOARD) && !SB_IS(EVERGREEN_COMPATIBLE_LITE)
+#if BUILDFLAG(IS_STARBOARD)
   if (::loader_app::IsPendingRestart()) {
     SbLogRawFormatF("\nPending update restart . Stopping.\n");
     SbLogFlush();
@@ -45,5 +45,5 @@ void SbSystemRequestFreeze() {
 #else
   // Let the platform decide if directly transit into Frozen.
   starboard::Application::Get()->Freeze(NULL, &FreezeDone);
-#endif  // BUILDFLAG(IS_STARBOARD) && !SB_IS(EVERGREEN_COMPATIBLE_LITE)
+#endif  // BUILDFLAG(IS_STARBOARD)
 }


### PR DESCRIPTION
`SB_IS(EVERGREEN_COMPATIBLE_LITE)` has not been defined since the `sb_evergreen_compatible_enable_lite` GN arg was removed in https://github.com/youtube/cobalt/commit/10b7c61c2c41a8250ac5823d6904a25f9250ac65. Evergreen Lite is selected at runtime with the --evergreen_lite loader flag.

Bug: 272635054