### PR TITLE
android: Enable 720p UI on low-end devices

### DIFF
--- a/cobalt/android/BUILD.gn
+++ b/cobalt/android/BUILD.gn
@@ -190,6 +190,7 @@ android_library("cobalt_main_java") {
     "apk/app/src/main/java/dev/cobalt/media/VideoSurfaceView.java",
     "apk/app/src/main/java/dev/cobalt/util/AssetLoader.java",
     "apk/app/src/main/java/dev/cobalt/util/CobaltPrefNamesTestHelper.java",
+    "apk/app/src/main/java/dev/cobalt/util/DeviceUtil.java",
     "apk/app/src/main/java/dev/cobalt/util/DisplayUtil.java",
     "apk/app/src/main/java/dev/cobalt/util/Holder.java",
     "apk/app/src/main/java/dev/cobalt/util/IsEmulator.java",
@@ -374,6 +375,7 @@ robolectric_binary("cobalt_coat_junit_tests") {
     "apk/app/src/test/java/dev/cobalt/coat/PlatformErrorTest.java",
     "apk/app/src/test/java/dev/cobalt/coat/ShellManagerTest.java",
     "apk/app/src/test/java/dev/cobalt/media/MediaCodecOutputTrackerTest.java",
+    "apk/app/src/test/java/dev/cobalt/util/DeviceUtilTest.java",
     "apk/app/src/test/java/dev/cobalt/util/JavaSwitchesTest.java",
     "apk/app/src/test/java/dev/cobalt/util/StartupGuardTest.java",
   ]

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
@@ -44,8 +44,6 @@ public final class CommandLineOverrideHelper {
     paramOverrides.add("--force-video-overlays");
     // Autoplay video with url.
     paramOverrides.add("--autoplay-policy=no-user-gesture-required");
-    // Disable rescaling Webpage.
-    paramOverrides.add("--force-device-scale-factor=1");
     // Enable low end device mode.
     paramOverrides.add("--enable-low-end-device-mode");
     // Disables RGBA_4444 textures which

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/DeviceUtil.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/DeviceUtil.java
@@ -1,0 +1,98 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dev.cobalt.util;
+
+import android.content.Context;
+import android.util.DisplayMetrics;
+import androidx.annotation.VisibleForTesting;
+import org.chromium.base.ContextUtils;
+import org.chromium.base.SysUtils;
+
+/**
+ * Utility methods for querying device hardware capabilities and constraints.
+ *
+ * <p>This class is used to determine hardware-based configurations at runtime, such as adjusting
+ * the UI scale factor on low-memory devices.
+ *
+ * <p>This is a non-instantiable utility class with no instance lifetime or ownership; its static
+ * helper methods exist for the lifetime of the application.
+ *
+ * <p>This class is thread-safe and its static methods can be called from any thread.
+ */
+public final class DeviceUtil {
+  private DeviceUtil() {} // Prevent instantiation.
+
+  // Physical RAM threshold for 1GB RAM devices in KB (1024 * 1024 KB).
+  public static final int ONE_GB_RAM_THRESHOLD_KB = 1024 * 1024;
+
+  // Threshold (in pixels) for the larger display dimension to qualify as at least 1080p.
+  // 1600 is chosen as the midpoint between 720p (1280px) and 1080p (1920px). Using the
+  // maximum dimension is orientation-independent (landscape vs. portrait) and provides
+  // a safe margin for system decor (e.g. navigation/status bars) reducing available pixels.
+  public static final int DISPLAY_1080P_MIN_MAX_DIMENSION_PX = 1600;
+
+  private static Boolean sIs1GbDeviceForTesting;
+  private static Boolean sIsDisplayAtLeast1080pForTesting;
+
+  @VisibleForTesting
+  public static void setIs1GbDeviceForTesting(Boolean is1Gb) {
+    sIs1GbDeviceForTesting = is1Gb;
+  }
+
+  @VisibleForTesting
+  public static void setIsDisplayAtLeast1080pForTesting(Boolean is1080p) {
+    sIsDisplayAtLeast1080pForTesting = is1080p;
+  }
+
+  @VisibleForTesting
+  public static void resetForTesting() {
+    sIs1GbDeviceForTesting = null;
+    sIsDisplayAtLeast1080pForTesting = null;
+  }
+
+  /**
+   * Returns true if the device has 1 GB RAM or less.
+   *
+   * <p>Note: SysUtils.isLowEndDevice() cannot be used because Cobalt enables
+   * --enable-low-end-device-mode by default, which causes isLowEndDevice() to return true for all
+   * devices. We query SysUtils.amountOfPhysicalMemoryKB() directly instead.
+   */
+  public static boolean is1GbDevice() {
+    if (sIs1GbDeviceForTesting != null) {
+      return sIs1GbDeviceForTesting;
+    }
+    int physicalRamKb = SysUtils.amountOfPhysicalMemoryKB();
+    return physicalRamKb > 0 && physicalRamKb <= ONE_GB_RAM_THRESHOLD_KB;
+  }
+
+  /** Returns true if the display resolution is at least 1080p. */
+  public static boolean isDisplayAtLeast1080p() {
+    if (sIsDisplayAtLeast1080pForTesting != null) {
+      return sIsDisplayAtLeast1080pForTesting;
+    }
+    try {
+      Context context = ContextUtils.getApplicationContext();
+      if (context != null) {
+        DisplayMetrics metrics = context.getResources().getDisplayMetrics();
+        return metrics != null
+            && Math.max(metrics.widthPixels, metrics.heightPixels)
+                >= DISPLAY_1080P_MIN_MAX_DIMENSION_PX;
+      }
+    } catch (Throwable t) {
+      // Ignored if context is not available.
+    }
+    return false;
+  }
+}

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -42,6 +42,7 @@ public class JavaSwitches {
   public static final String DEFAULT_INITIAL_OLD_SPACE_SIZE = "64";
   public static final String DEFAULT_MAX_OLD_SPACE_SIZE = "512";
   public static final String DEFAULT_FORCE_GPU_MEM_AVAILABLE_MB = "64";
+  public static final String DEFAULT_FORCE_DEVICE_SCALE_FACTOR = "1";
 
   public static final String ENABLE_QUIC = "EnableQUIC";
 
@@ -188,6 +189,9 @@ public class JavaSwitches {
   public static final String ENABLE_ACTIVITY_LIFECYCLE_COORDINATION =
       "EnableActivityLifecycleCoordination";
 
+  /** Flag to force 720p UI for 1GB RAM devices on 1080p+ displays for A/B testing. */
+  public static final String FORCE_720P_UI_ON_1GB_DEVICES = "Force720pUiOn1GbDevices";
+
   private static Boolean sOverrideForTesting;
 
   public static void setOverrideForTesting(Boolean override) {
@@ -311,6 +315,7 @@ public class JavaSwitches {
             + DEFAULT_INITIAL_OLD_SPACE_SIZE
             + ";--max-old-space-size="
             + DEFAULT_MAX_OLD_SPACE_SIZE);
+    defaultArgs.add("--force-device-scale-factor=" + DEFAULT_FORCE_DEVICE_SCALE_FACTOR);
     return defaultArgs;
   }
 
@@ -547,6 +552,14 @@ public class JavaSwitches {
 
     if (javaSwitches.containsKey(JavaSwitches.ENABLE_ACTIVITY_LIFECYCLE_COORDINATION)) {
       extraCommandLineArgs.add("--enable-activity-lifecycle-coordination");
+    }
+
+    if (javaSwitches.containsKey(JavaSwitches.FORCE_720P_UI_ON_1GB_DEVICES)
+        && DeviceUtil.is1GbDevice()
+        && DeviceUtil.isDisplayAtLeast1080p()) {
+      extraCommandLineArgs.add("--force-device-scale-factor=1.5");
+    } else {
+      extraCommandLineArgs.add("--force-device-scale-factor=" + DEFAULT_FORCE_DEVICE_SCALE_FACTOR);
     }
 
     return extraCommandLineArgs;

--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/CommandLineOverrideHelperTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/CommandLineOverrideHelperTest.java
@@ -86,9 +86,7 @@ public class CommandLineOverrideHelperTest {
     String actual = CommandLine.getInstance().getSwitchValue("autoplay-policy");
     Assert.assertEquals(expected, actual);
 
-    expected = "1";
-    actual = CommandLine.getInstance().getSwitchValue("force-device-scale-factor");
-    Assert.assertEquals(expected, actual);
+    Assert.assertFalse(CommandLine.getInstance().hasSwitch("force-device-scale-factor"));
 
     actual = CommandLine.getInstance().getSwitchValue("enable-features");
     expected = CommandLineOverrideHelper.getDefaultEnableFeatureOverridesList().toString();
@@ -169,6 +167,16 @@ public class CommandLineOverrideHelperTest {
     CommandLineOverrideHelper.getFlagOverrides(commandLineArgs);
 
     Assert.assertEquals("*", CommandLine.getInstance().getSwitchValue("remote-allow-origins"));
+  }
+
+  @Test
+  public void testFlagOverrides_ForceDeviceScaleFactorFromParams() {
+    List<String> commandLineArgs = Arrays.asList("--force-device-scale-factor=1.5");
+    CommandLineOverrideHelper.getFlagOverrides(commandLineArgs);
+
+    Assert.assertTrue(CommandLine.getInstance().hasSwitch("force-device-scale-factor"));
+    String actual = CommandLine.getInstance().getSwitchValue("force-device-scale-factor");
+    Assert.assertEquals("1.5", actual);
   }
 
   @Test

--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/util/DeviceUtilTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/util/DeviceUtilTest.java
@@ -1,0 +1,122 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dev.cobalt.util;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.util.DisplayMetrics;
+import org.chromium.base.ContextUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+/** Unit tests for {@link DeviceUtil}. */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class DeviceUtilTest {
+
+  @Before
+  public void setUp() {
+    ContextUtils.initApplicationContextForTests(RuntimeEnvironment.getApplication());
+    DeviceUtil.resetForTesting();
+  }
+
+  @After
+  public void tearDown() {
+    DeviceUtil.resetForTesting();
+  }
+
+  @Test
+  public void testIs1GbDevice_OverrideTrue() {
+    DeviceUtil.setIs1GbDeviceForTesting(true);
+    assertThat(DeviceUtil.is1GbDevice()).isTrue();
+  }
+
+  @Test
+  public void testIs1GbDevice_OverrideFalse() {
+    DeviceUtil.setIs1GbDeviceForTesting(false);
+    assertThat(DeviceUtil.is1GbDevice()).isFalse();
+  }
+
+  @Test
+  public void testIsDisplayAtLeast1080p_OverrideTrue() {
+    DeviceUtil.setIsDisplayAtLeast1080pForTesting(true);
+    assertThat(DeviceUtil.isDisplayAtLeast1080p()).isTrue();
+  }
+
+  @Test
+  public void testIsDisplayAtLeast1080p_OverrideFalse() {
+    DeviceUtil.setIsDisplayAtLeast1080pForTesting(false);
+    assertThat(DeviceUtil.isDisplayAtLeast1080p()).isFalse();
+  }
+
+  @Test
+  public void testResetForTesting() {
+    boolean defaultIs1Gb = DeviceUtil.is1GbDevice();
+    boolean defaultIs1080p = DeviceUtil.isDisplayAtLeast1080p();
+
+    DeviceUtil.setIs1GbDeviceForTesting(!defaultIs1Gb);
+    DeviceUtil.setIsDisplayAtLeast1080pForTesting(!defaultIs1080p);
+
+    assertThat(DeviceUtil.is1GbDevice()).isEqualTo(!defaultIs1Gb);
+    assertThat(DeviceUtil.isDisplayAtLeast1080p()).isEqualTo(!defaultIs1080p);
+
+    DeviceUtil.resetForTesting();
+
+    assertThat(DeviceUtil.is1GbDevice()).isEqualTo(defaultIs1Gb);
+    assertThat(DeviceUtil.isDisplayAtLeast1080p()).isEqualTo(defaultIs1080p);
+  }
+
+  @Test
+  public void testIsDisplayAtLeast1080p_DisplayMetrics_Landscape1080p() {
+    DisplayMetrics metrics = RuntimeEnvironment.getApplication().getResources().getDisplayMetrics();
+    metrics.widthPixels = 1920;
+    metrics.heightPixels = 1080;
+
+    assertThat(DeviceUtil.isDisplayAtLeast1080p()).isTrue();
+  }
+
+  @Test
+  public void testIsDisplayAtLeast1080p_DisplayMetrics_Portrait1080p() {
+    DisplayMetrics metrics = RuntimeEnvironment.getApplication().getResources().getDisplayMetrics();
+    metrics.widthPixels = 1080;
+    metrics.heightPixels = 1920;
+
+    assertThat(DeviceUtil.isDisplayAtLeast1080p()).isTrue();
+  }
+
+  @Test
+  public void testIsDisplayAtLeast1080p_DisplayMetrics_Portrait720p() {
+    DisplayMetrics metrics = RuntimeEnvironment.getApplication().getResources().getDisplayMetrics();
+    metrics.widthPixels = 720;
+    metrics.heightPixels = 1280;
+
+    // Portrait 720p has height 1280 > 1080, but max dimension 1280 < 1600.
+    assertThat(DeviceUtil.isDisplayAtLeast1080p()).isFalse();
+  }
+
+  @Test
+  public void testIsDisplayAtLeast1080p_DisplayMetrics_Landscape720p() {
+    DisplayMetrics metrics = RuntimeEnvironment.getApplication().getResources().getDisplayMetrics();
+    metrics.widthPixels = 1280;
+    metrics.heightPixels = 720;
+
+    assertThat(DeviceUtil.isDisplayAtLeast1080p()).isFalse();
+  }
+}

--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/util/JavaSwitchesTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/util/JavaSwitchesTest.java
@@ -40,12 +40,14 @@ public class JavaSwitchesTest {
     ContextUtils.initApplicationContextForTests(RuntimeEnvironment.getApplication());
     clearConfigFiles();
     JavaSwitches.setOverrideForTesting(null);
+    DeviceUtil.resetForTesting();
   }
 
   @After
   public void tearDown() {
     JavaSwitches.setOverrideForTesting(null);
     clearConfigFiles();
+    DeviceUtil.resetForTesting();
   }
 
   private void clearConfigFiles() {
@@ -378,6 +380,15 @@ public class JavaSwitchesTest {
 
     // Default JS flags should still be present
     assertThat(args).contains("--js-flags=--initial-old-space-size=64;--max-old-space-size=512");
+    assertThat(args).contains("--force-device-scale-factor=1");
+  }
+
+  @Test
+  public void testGetDefaultCommandLineArgs() {
+    List<String> args = JavaSwitches.getDefaultCommandLineArgs();
+    assertThat(args).contains("--disable-quic");
+    assertThat(args).contains("--js-flags=--initial-old-space-size=64;--max-old-space-size=512");
+    assertThat(args).contains("--force-device-scale-factor=1");
   }
 
   @Test
@@ -419,5 +430,63 @@ public class JavaSwitchesTest {
     assertThat(args).doesNotContain("--force-gpu-mem-available-mb=");
     assertThat(args).doesNotContain("--cc-image-cache-limit-items=");
     assertThat(args).doesNotContain("--max-http-cache-size=");
+  }
+
+  @Test
+  public void testGetExtraCommandLineArgs_DefaultScaleFactor() {
+    List<String> args = JavaSwitches.getExtraCommandLineArgs(null);
+    assertThat(args).contains("--force-device-scale-factor=1");
+    assertThat(args).doesNotContain("--force-device-scale-factor=1.5");
+  }
+
+  @Test
+  public void testGetExtraCommandLineArgs_Force720pUiOn1GbDevices_1GbAnd1080p() {
+    Map<String, String> switches = new HashMap<>();
+    switches.put(JavaSwitches.FORCE_720P_UI_ON_1GB_DEVICES, "1");
+
+    DeviceUtil.setIs1GbDeviceForTesting(true);
+    DeviceUtil.setIsDisplayAtLeast1080pForTesting(true);
+
+    List<String> args = JavaSwitches.getExtraCommandLineArgs(switches);
+    assertThat(args).contains("--force-device-scale-factor=1.5");
+    assertThat(args).doesNotContain("--force-device-scale-factor=1");
+  }
+
+  @Test
+  public void testGetExtraCommandLineArgs_Force720pUiOn1GbDevices_1GbAnd720p() {
+    Map<String, String> switches = new HashMap<>();
+    switches.put(JavaSwitches.FORCE_720P_UI_ON_1GB_DEVICES, "1");
+
+    DeviceUtil.setIs1GbDeviceForTesting(true);
+    DeviceUtil.setIsDisplayAtLeast1080pForTesting(false);
+
+    List<String> args = JavaSwitches.getExtraCommandLineArgs(switches);
+    assertThat(args).contains("--force-device-scale-factor=1");
+    assertThat(args).doesNotContain("--force-device-scale-factor=1.5");
+  }
+
+  @Test
+  public void testGetExtraCommandLineArgs_Force720pUiOn1GbDevices_2GbAnd1080p() {
+    Map<String, String> switches = new HashMap<>();
+    switches.put(JavaSwitches.FORCE_720P_UI_ON_1GB_DEVICES, "1");
+
+    DeviceUtil.setIs1GbDeviceForTesting(false);
+    DeviceUtil.setIsDisplayAtLeast1080pForTesting(true);
+
+    List<String> args = JavaSwitches.getExtraCommandLineArgs(switches);
+    assertThat(args).contains("--force-device-scale-factor=1");
+    assertThat(args).doesNotContain("--force-device-scale-factor=1.5");
+  }
+
+  @Test
+  public void testGetExtraCommandLineArgs_Force720pUiOn1GbDevices_SwitchAbsent() {
+    Map<String, String> switches = new HashMap<>();
+
+    DeviceUtil.setIs1GbDeviceForTesting(true);
+    DeviceUtil.setIsDisplayAtLeast1080pForTesting(true);
+
+    List<String> args = JavaSwitches.getExtraCommandLineArgs(switches);
+    assertThat(args).contains("--force-device-scale-factor=1");
+    assertThat(args).doesNotContain("--force-device-scale-factor=1.5");
   }
 }


### PR DESCRIPTION
Introduce logic to conditionally force a 720p UI on low-memory Android
devices. When the Force720pUiOn1GbDevices switch is enabled, devices
with 1 GB of RAM or less running on 1080p or larger displays will use
a device scale factor of 1.5 to render the UI at 720p.

This change helps reduce memory pressure and improve performance on
resource-constrained hardware. It includes a new DeviceUtil class to
query hardware capabilities and corresponding unit tests.

Issue: 558324832