### PR TITLE
[staging] content/browser: Exclude digital_credentials/ from the build

### DIFF
--- a/content/browser/BUILD.gn
+++ b/content/browser/BUILD.gn
@@ -3759,6 +3759,7 @@ source_set("browser") {
                          "private_aggregation/*",
                          "aggregation_service/*",
                          "fenced_frame/*",
+                         "digital_credentials/*",
                          "webid/*",
                          "in_memory_federated_permission_context.*",
                          "devtools/protocol/fedcm_handler.*",


### PR DESCRIPTION
This fixes a crash that was possibly introduced by the 141.7377 roll in PR #12305: https://crrev.com/c/6867972 moved the digital_credentials/ code out of webid/, so it was added to the build and invoked functions in webid/ that were not included.

This caused loader errors in linux-modular builds: cobalt_loader crashed when invoked with errors like

```
out/linux-x64x11-modular_devel/libcobalt.so: undefined symbol: _ZN7content5sdjwt3Jwt5ParseERKNSt4__Cr17basic_string_viewIcNS2_11char_traitsIcEEEE
```

Bug: 553860126