### PR TITLE
cobalt: Ensure startup URL starts with YTLR in Gold builds

### DIFF
--- a/cobalt/app/app_event_runner.cc
+++ b/cobalt/app/app_event_runner.cc
@@ -346,6 +346,7 @@ class AppEventRunnerImpl : public AppEventRunner,
           const char* initial_deep_link) {
     CreateMainDelegate(startup_timestamp, is_visible, initial_deep_link);
     content::ContentMainParams params(GetMainDelegate());
+    std::string fallback_link;
 #if BUILDFLAG(IS_STARBOARD)
     cobalt::CommandLinePreprocessor init_cmd_line(argc, argv);
     const auto& init_argv = init_cmd_line.argv();
@@ -355,6 +356,10 @@ class AppEventRunnerImpl : public AppEventRunner,
     std::vector<const char*> args;
     for (const auto& arg : init_argv) {
       args.push_back(arg.c_str());
+    }
+    if (!initial_deep_link && init_cmd_line.cmd_line().HasSwitch("link")) {
+      fallback_link = init_cmd_line.cmd_line().GetSwitchValueASCII("link");
+      initial_deep_link = fallback_link.c_str();
     }
 #endif
     if (initial_deep_link) {

--- a/cobalt/app/cobalt_switch_defaults.cc
+++ b/cobalt/app/cobalt_switch_defaults.cc
@@ -24,6 +24,7 @@
 #include "base/files/file_path.h"
 #include "base/logging.h"
 #include "base/strings/strcat.h"
+#include "build/buildflag.h"
 #include "cobalt/shell/common/shell_switches.h"
 
 namespace {
@@ -117,6 +118,25 @@ CommandLinePreprocessor::CommandLinePreprocessor(
     startup_url_ = first_arg;
   }
   CHECK(!startup_url_.empty());
+
+#if BUILDFLAG(COBALT_IS_RELEASE_BUILD)
+  // In Gold builds, Cobalt must only load YouTube Living Room (YTLR).
+  // If the provided startup URL does not start with
+  // "https://www.youtube.com/tv", redirect it to YTLR and forward the given URL
+  // as a deep link.
+  if (!startup_url_.starts_with(::switches::kDefaultURL)) {
+    LOG(WARNING) << "Non-YTLR startup URL \"" << startup_url_
+                 << "\" provided in Gold build. Forcing startup URL to \""
+                 << ::switches::kDefaultURL << "\"";
+    if (!cmd_line_.HasSwitch("link") ||
+        cmd_line_.GetSwitchValueASCII("link").empty()) {
+      cmd_line_.AppendSwitchNative("link", startup_url_);
+    }
+    startup_url_ = ::switches::kDefaultURL;
+    cmd_line_.AppendSwitchNative(cobalt::switches::kInitialURL,
+                                 ::switches::kDefaultURL);
+  }
+#endif
 }
 
 const base::CommandLine::StringVector CommandLinePreprocessor::argv() const {

--- a/cobalt/app/cobalt_switch_defaults.h
+++ b/cobalt/app/cobalt_switch_defaults.h
@@ -33,6 +33,7 @@ class CommandLinePreprocessor {
   CommandLinePreprocessor(int argc, const char* const* argv);
 
   const base::CommandLine::StringVector argv() const;
+  const base::CommandLine& cmd_line() const { return cmd_line_; }
 
 #ifdef UNIT_TEST
   const base::CommandLine& get_cmd_line_for_test() const { return cmd_line_; }

--- a/cobalt/app/cobalt_switch_defaults_starboard_test.cc
+++ b/cobalt/app/cobalt_switch_defaults_starboard_test.cc
@@ -147,6 +147,7 @@ TEST(CobaltSwitchDefaultsTest, AlwaysEnabledSwitches) {
   // Other default switches are subject to changes later down the line.
 }
 
+#if !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
 TEST(CobaltSwitchDefaultsTest, StartupURLSwitch) {
   const auto input_argv = std::to_array<const char*>({
       "PROGRAM",
@@ -178,6 +179,38 @@ TEST(CobaltSwitchDefaultsTest, StartupURLArg) {
   EXPECT_EQ("data:,",
             GetSwitchValue(cmd_line_pxr, cobalt::switches::kInitialURL));
 }
+#else
+TEST(CobaltSwitchDefaultsTest, GoldStartupURLRedirectsNonYTLRToDeepLink) {
+  const auto input_argv = std::to_array<const char*>({
+      "PROGRAM",
+      "--url=https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+  });
+  const int input_argc = static_cast<int>(input_argv.size());
+  CommandLinePreprocessor cmd_line_pxr(input_argc, input_argv.data());
+
+  EXPECT_EQ("https://www.youtube.com/tv",
+            cmd_line_pxr.get_startup_url_for_test());
+  EXPECT_EQ("https://www.youtube.com/tv",
+            GetSwitchValue(cmd_line_pxr, cobalt::switches::kInitialURL));
+  EXPECT_EQ("https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            GetSwitchValue(cmd_line_pxr, "link"));
+}
+
+TEST(CobaltSwitchDefaultsTest, GoldStartupURLPreservesValidYTLR) {
+  const auto input_argv = std::to_array<const char*>({
+      "PROGRAM",
+      "--url=https://www.youtube.com/tv?v=dQw4w9WgXcQ",
+  });
+  const int input_argc = static_cast<int>(input_argv.size());
+  CommandLinePreprocessor cmd_line_pxr(input_argc, input_argv.data());
+
+  EXPECT_EQ("https://www.youtube.com/tv?v=dQw4w9WgXcQ",
+            cmd_line_pxr.get_startup_url_for_test());
+  EXPECT_EQ("https://www.youtube.com/tv?v=dQw4w9WgXcQ",
+            GetSwitchValue(cmd_line_pxr, cobalt::switches::kInitialURL));
+  EXPECT_FALSE(HasSwitch(cmd_line_pxr, "link"));
+}
+#endif  // BUILDFLAG(COBALT_IS_RELEASE_BUILD)
 
 TEST(CobaltSwitchDefaultsTest, StartupURLDefault) {
   const auto input_argv = std::to_array<const char*>({"PROGRAM"});


### PR DESCRIPTION
In Gold builds, Cobalt must only load YouTube Living Room (YTLR). Ensure that the startup URL starts with "https://www.youtube.com/tv".

If a non-YTLR URL is provided (for example, if a platform incorrectly passes a video watch URL via "--url" instead of "--link"), normalize the startup URL to YTLR and preserve the original URL by forwarding it as a deep link to DeepLinkManager.

Bug: 503024637