### PR TITLE
[Cobalt] Use BUILDFLAG(COBALT_IS_RELEASE_BUILD) in CobaltContentBrows…

### DIFF
--- a/cobalt/browser/cobalt_content_browser_client.cc
+++ b/cobalt/browser/cobalt_content_browser_client.cc
@@ -308,7 +308,7 @@ CobaltContentBrowserClient::CreateBrowserMainParts(
 
 std::unique_ptr<content::DevToolsManagerDelegate>
 CobaltContentBrowserClient::CreateDevToolsManagerDelegate() {
-#if defined(COBALT_IS_RELEASE_BUILD)
+#if BUILDFLAG(COBALT_IS_RELEASE_BUILD)
   return nullptr;
 #else
   return content::ShellContentBrowserClient::CreateDevToolsManagerDelegate();
@@ -366,11 +366,11 @@ void CobaltContentBrowserClient::OverrideWebPreferences(
     content::SiteInstance& main_frame_site,
     blink::web_pref::WebPreferences* prefs) {
   CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-#if !defined(COBALT_IS_RELEASE_BUILD)
+#if !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
   // Allow creating a ws: connection on a https: page to allow current
   // testing set up. See b/377410179.
   prefs->allow_running_insecure_content = true;
-#endif  // !defined(COBALT_IS_RELEASE_BUILD)
+#endif  // !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
   content::ShellContentBrowserClient::OverrideWebPreferences(
       web_contents, main_frame_site, prefs);
 }


### PR DESCRIPTION
…erClient

Fix the preprocessor guards in CobaltContentBrowserClient that check COBALT_IS_RELEASE_BUILD using defined(...) instead of BUILDFLAG(COBALT_IS_RELEASE_BUILD).

COBALT_IS_RELEASE_BUILD is defined through Chromium's buildflag system (ENABLE_BUILDFLAG_COBALT_IS_RELEASE_BUILD), so defined(COBALT_IS_RELEASE_BUILD) is always false. This caused allow_running_insecure_content to be enabled in release builds and CreateDevToolsManagerDelegate to fall through to the default delegate.

Bug: 545796867