### PR TITLE
android: Fix static splash image scaling on 720P

### DIFF
--- a/cobalt/shell/embedded_resources/loader_embedded_resources/splash.html
+++ b/cobalt/shell/embedded_resources/loader_embedded_resources/splash.html
@@ -79,12 +79,22 @@
         })
         .then(imageBlob => {
           const imageUrl = URL.createObjectURL(imageBlob);
-          placeholderEl.style.backgroundImage = `url(${imageUrl})`;
-          placeholderEl.style.opacity = '100%';
+          const image = new Image();
+          image.onload = () => {
+            const scale = (window.innerWidth > 0 && window.innerHeight > 0)
+                ? Math.max(window.innerWidth / 1920, window.innerHeight / 1080)
+                : 1;
+            const width = image.naturalWidth * scale;
+            const height = image.naturalHeight * scale;
+            placeholderEl.style.backgroundSize = `${width}px ${height}px`;
+            placeholderEl.style.backgroundImage = `url(${imageUrl})`;
+            placeholderEl.style.opacity = '100%';
+          };
+          image.src = imageUrl;
           // set timeout to align with timeout for splash video
           setTimeout(() => {
-              afterImageLoad && afterImageLoad();
-            }, 1000);
+            afterImageLoad && afterImageLoad();
+          }, 1000);
         })
         .catch(error => {
           console.error('Failed to fetch splash image:', error);


### PR DESCRIPTION
The background size of static splash images is now scaled relative to a
1080P baseline resolution. This ensures that the splash logo maintains
intended proportions on lower-resolution displays like 720P, preventing
visual inconsistencies caused by static sizing.

Bug: 558632685