### PR TITLE
starboard: Run init_routine before SetInitialized in pthread_once wra…

### DIFF
--- a/starboard/shared/modular/starboard_layer_posix_pthread_abi_wrappers.cc
+++ b/starboard/shared/modular/starboard_layer_posix_pthread_abi_wrappers.cc
@@ -408,8 +408,8 @@ int __abi_wrap_pthread_once(musl_pthread_once_t* once_control,
   }
 
   if (!EnsureInitialized(&(INTERNAL_ONCE(once_control)->initialized_state))) {
-    SetInitialized(&(INTERNAL_ONCE(once_control)->initialized_state));
     init_routine();
+    SetInitialized(&(INTERNAL_ONCE(once_control)->initialized_state));
   }
   return 0;
 }


### PR DESCRIPTION
starboard: Fix pthread_once initialization order

Invoke init_routine() before SetInitialized() in __abi_wrap_pthread_once, ensuring concurrent callers of pthread_once() block until initialization has completed rather than observing partially-initialized state.

Bug: 545797214