### PR TITLE
h5vcc: Use BigBuffer for PlatformService::Send response to fix use-af…

### DIFF
--- a/cobalt/browser/h5vcc_platform_service/platform_service_impl.cc
+++ b/cobalt/browser/h5vcc_platform_service/platform_service_impl.cc
@@ -162,9 +162,21 @@ void PlatformServiceImpl::Send(base::span<const uint8_t> data,
     return;
   }
 
+  if (output_length == 0) {
+    std::move(callback).Run(mojo_base::BigBuffer(), std::nullopt);
+    return;
+  }
+
+  if (!response_ptr) {
+    LOG(ERROR) << "Send failed: null response with non-zero length for "
+               << service_name_;
+    std::move(callback).Run(std::nullopt, "Failed to retrieve response data.");
+    return;
+  }
+
   std::move(callback).Run(
-      base::span<const uint8_t>(response_ptr.get(),
-                                base::checked_cast<size_t>(output_length)),
+      mojo_base::BigBuffer(base::span<const uint8_t>(
+          response_ptr.get(), base::checked_cast<size_t>(output_length))),
       std::nullopt);
 }
 

--- a/cobalt/browser/h5vcc_platform_service/platform_service_impl.h
+++ b/cobalt/browser/h5vcc_platform_service/platform_service_impl.h
@@ -21,6 +21,7 @@
 #include "base/memory/weak_ptr.h"
 #include "cobalt/browser/h5vcc_platform_service/public/mojom/h5vcc_platform_service.mojom.h"
 #include "content/public/browser/document_service.h"
+#include "mojo/public/cpp/base/big_buffer.h"
 #include "mojo/public/cpp/bindings/pending_remote.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "starboard/extension/platform_service.h"

--- a/cobalt/browser/h5vcc_platform_service/public/mojom/h5vcc_platform_service.mojom
+++ b/cobalt/browser/h5vcc_platform_service/public/mojom/h5vcc_platform_service.mojom
@@ -14,6 +14,7 @@
 
 module h5vcc_platform_service.mojom;
 
+import "mojo/public/mojom/base/big_buffer.mojom";
 import "mojo/public/mojom/base/read_only_buffer.mojom";
 
 // Interface implemented in the browser process to manage H5vccPlatformService
@@ -40,12 +41,9 @@ interface PlatformService {
   // A response with no value indicates that data could not be sent to the
   // platform service. A response with an empty array indicates that data was
   // send to the platform service but there was no synchronous response.
-  //
-  // TODO: b/371419798 - consider using mojo_base.mojom.BigBuffer for more
-  // efficient transport, as the data and response data could be large.
   [Sync]
   Send(mojo_base.mojom.ReadOnlyBuffer data)
-      => (mojo_base.mojom.ReadOnlyBuffer? response_data, string? error_message);
+      => (mojo_base.mojom.BigBuffer? response_data, string? error_message);
 };
 
 // Interface implemented by the renderer-side H5vccPlatformService to receive

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_platform_service/h_5_vcc_platform_service.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_platform_service/h_5_vcc_platform_service.cc
@@ -18,6 +18,7 @@
 
 #include "base/functional/bind.h"
 #include "base/logging.h"
+#include "mojo/public/cpp/base/big_buffer.h"
 #include "third_party/blink/public/platform/platform.h"
 #include "third_party/blink/renderer/bindings/core/v8/script_function.h"
 #include "third_party/blink/renderer/bindings/core/v8/v8_binding_for_core.h"
@@ -158,7 +159,7 @@ DOMArrayBuffer* H5vccPlatformService::send(DOMArrayBuffer* data,
   base::span<const uint8_t> input_data = data && !data->IsDetached()
                                              ? data->ByteSpan()
                                              : base::span<const uint8_t>();
-  std::optional<base::span<const uint8_t>> response_data;
+  std::optional<mojo_base::BigBuffer> response_data;
   WTF::String error_message;
 
   bool mojo_result = platform_service_remote_->Send(input_data, &response_data,
@@ -186,7 +187,7 @@ DOMArrayBuffer* H5vccPlatformService::send(DOMArrayBuffer* data,
     return nullptr;
   }
 
-  return DOMArrayBuffer::Create(response_data.value());
+  return DOMArrayBuffer::Create(base::span(*response_data));
 }
 
 void H5vccPlatformService::close() {


### PR DESCRIPTION
cobalt: Use BigBuffer for PlatformService::Send

mojo_base.mojom.ReadOnlyBuffer is typemapped to base::span<const uint8_t>, which directly references memory owned by the incoming mojo::Message.

For the [Sync] method PlatformService::Send(), the response mojo::Message is destroyed upon completion of the synchronous call before control returns to H5vccPlatformService::send(). Consequently, response_data was a dangling span, and reading it via DOMArrayBuffer::Create() caused a heap use-after-free and exposed freed memory to script.

Replace mojo_base.mojom.ReadOnlyBuffer? with mojo_base.mojom.BigBuffer? for response_data. BigBuffer owns its underlying storage, avoiding the dangling reference and supporting arbitrary response payload sizes without hitting Mojo channel limits.

Bug: 545796681