### PR TITLE
cobalt: Scope use_relative_vtables_abi evergreen override to starboard

### DIFF
--- a/build/config/compiler/compiler.gni
+++ b/build/config/compiler/compiler.gni
@@ -147,7 +147,7 @@ declare_args() {
   use_sized_deallocation = is_clang && is_asan
 }
 
-if (is_cobalt) {
+if (is_starboard) {
   use_relative_vtables_abi =
       sb_is_evergreen && (current_toolchain == default_toolchain)
 }


### PR DESCRIPTION
The previous PR https://github.com/youtube/cobalt/pull/12064 enabled use_relative_vtables_abi for Evergreen toolchains using `is_cobalt`, which unintentionally overrode and disabled the default behavior for Android x64.

This replaces `is_cobalt` with `is_starboard` so that the Evergreen override only applies to Starboard.

Bug: 548710121
TAG=agy
CONV=b770761d-b524-49f1-a13a-332907b3ac86