### PR TITLE
android: Enable use_relative_vtables_abi for Android arm32

### DIFF
--- a/build/config/compiler/compiler.gni
+++ b/build/config/compiler/compiler.gni
@@ -150,6 +150,9 @@ declare_args() {
 if (is_starboard) {
   use_relative_vtables_abi =
       sb_is_evergreen && (current_toolchain == default_toolchain)
+} else if (is_android) {
+  use_relative_vtables_abi = (current_cpu == "arm64" || current_cpu == "arm") &&
+                             use_custom_libcxx && !is_component_build
 }
 
 # To try out this combination, delete this assert.


### PR DESCRIPTION
cobalt: Enable use_relative_vtables_abi for Android arm32

This modifies the Chromium upstream logic to enable the relative
vtables ABI feature on 32-bit Android arm builds alongside arm64.

**Optimization Impact (Android arm32 ATV Hardware):**
* **Binary Footprint:** ~2.00 MB reduction in native ELF `.rel.dyn` relocations.
* **APK Package Size:** ~1.71 MB physical disk savings (from 82MB -> 80MB).
* **Live Video Playback:** ~3.9 MB stable reduction in `dev.cobalt.coat` Peak VmRSS (and ~3.3 MB total PSS savings) by isolating the vtables tightly into shared `.rodata` and avoiding CoW faults.

Bug: 548710121
TAG=agy