### PR TITLE
tvos: Add test targets configuration for tvos-arm64-device

### DIFF
--- a/cobalt/build/testing/targets/tvos-arm64-device/test_targets.json
+++ b/cobalt/build/testing/targets/tvos-arm64-device/test_targets.json
@@ -1,0 +1,25 @@
+[
+  {
+    "TODO(b/507872542)": "Revisit this and determine how we configure tvOS tests."
+  },
+  {
+    "target": "base:base_unittests",
+    "runs_on": "device",
+    "test_type": "gtest"
+  },
+  {
+    "target": "cobalt/testing/browser_tests:cobalt_browsertests",
+    "runs_on": "device",
+    "test_type": "browsertest"
+  },
+  {
+    "target": "cobalt:cobalt_unittests",
+    "runs_on": "device",
+    "test_type": "gtest"
+  },
+  {
+    "target": "starboard:starboard_unittests_wrapper",
+    "runs_on": "device",
+    "test_type": "gtest"
+  }
+]


### PR DESCRIPTION
Add test_targets.json for the tvos-arm64-device target platform with
the same test targets as tvos-arm64-simulator, setting runs_on to device.
This enables Kokoro devel builds to locate the test target definitions,
compile the unit test targets, and package them for downstream on-device
testing.

Tag: agy
Conv: 117574e9-e2ed-4de7-8347-9db84fcdc580
Bug: 555298615

---

<sub>Stack created with [GitHub Stacks CLI](https://github.com/github/gh-stack) • [Give Feedback 💬](https://gh.io/stacks-feedback)</sub>