### PR TITLE
ci: Download on-host test artifacts on demand using test filters

### DIFF
--- a/.github/actions/on_host_tests/action.yaml
+++ b/.github/actions/on_host_tests/action.yaml
@@ -38,19 +38,6 @@ runs:
         git config --global --add safe.directory "${GITHUB_WORKSPACE}"
         git sparse-checkout add --skip-checks testing build third_party/catapult third_party/logdog
         git submodule update --init third_party/catapult
-    - name: Download and Extract Test Artifacts from GCS
-      shell: bash
-      env:
-        WORKFLOW: ${{ github.workflow }}
-        PLATFORM: ${{ matrix.platform }}
-      run: |
-        set -eux
-        project_name=$(gcloud config get-value project)
-        gcloud storage cp \
-          "gs://${project_name}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${PLATFORM}/test_artifacts.tar.zstd" \
-          test_artifacts.tar.zstd
-        tar -I 'zstd -T0' -xf test_artifacts.tar.zstd
-        rm -f test_artifacts.tar.zstd
     - name: Prepare Test Filters
       id: prepare-test-filters
       uses: ./.github/actions/prepare_test_filters
@@ -100,8 +87,19 @@ runs:
         TEST_EXECUTABLES_JSON: ${{ inputs.test_executables_json }}
         PLATFORM: ${{ matrix.platform }}
         FILTER_DIR: ${{ steps.prepare-test-filters.outputs.filter_dir }}
+        WORKFLOW: ${{ github.workflow }}
       run: |
         set -exo pipefail
+
+        project_name=$(gcloud config get-value project)
+        gcs_bucket="gs://${project_name}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${PLATFORM}"
+
+        download_archive() {
+          local archive="$1_deps.tar.zstd"
+          gcloud storage cp "${gcs_bucket}/${archive}" "${archive}"
+          tar -I 'zstd -T0' -xf "${archive}"
+          rm -f "${archive}"
+        }
 
         failed_suites=""
 
@@ -123,6 +121,21 @@ runs:
 
           echo "Test filter evaluated to: ${test_filter}"
 
+          xml_path="${test_output}/${test_executable}_result.xml"
+          log_path="${test_output}/${test_executable}_log.txt"
+
+          if [[ "${test_filter}" == "-*" ]]; then
+            echo "Skipped due to test filter." > "${log_path}"
+            printf '<?xml version="1.0" encoding="UTF-8"?>\n<testsuites tests="0" failures="0" errors="0" time="0"></testsuites>\n' > "${xml_path}"
+            continue
+          fi
+
+          # Download and extract target archive if not already extracted.
+          wrapper_path="$(dirname "${test_executable_path}")/bin/run_${test_executable}"
+          if [[ ! -x "${wrapper_path}" && ! -x "./${test_executable_path}" ]]; then
+            download_archive "${test_executable_name}"
+          fi
+
           gtest_shard_index="${GTEST_SHARD_INDEX}"
           gtest_total_shards="${GTEST_TOTAL_SHARDS}"
           if [[ "${test_filter}" != -* && "${test_filter}" != "*" ]]; then
@@ -131,38 +144,28 @@ runs:
             gtest_total_shards="1"
           fi
 
-          xml_path="${test_output}/${test_executable}_result.xml"
-          log_path="${test_output}/${test_executable}_log.txt"
-          # TODO: Investigate test_runner.py
-
           # Check if a wrapper script was generated for the test (e.g. by test_runner_script).
           # If so, use it as the entrypoint to run tests.
-          wrapper_path="$(dirname "${test_executable_path}")/bin/run_${test_executable}"
           if [[ -x "${wrapper_path}" ]]; then
             ENTRYPOINT="./${wrapper_path}"
           else
             ENTRYPOINT="./${test_executable_path}"
           fi
 
-          if [ "${test_filter}" == "-*" ]; then
-            echo "Skipped due to test filter." > "${log_path}"
-            printf '<?xml version="1.0" encoding="UTF-8"?>\n<testsuites tests="0" failures="0" errors="0" time="0"></testsuites>\n' > "${xml_path}"
-          else
-            /usr/bin/xvfb-run -a --server-args="${XVFB_SERVER_ARGS}" \
-                stdbuf -i0 -o0 -e0 "${ENTRYPOINT}" \
-                --single-process-tests \
-                --gtest_shard_index="${gtest_shard_index}" \
-                --gtest_total_shards="${gtest_total_shards}" \
-                --gtest_output="xml:${xml_path}" \
-                --gtest_filter="${test_filter}" 2>&1 | tee "${log_path}" || {
-              failed_suites="${failed_suites} ${test_executable}"
-            }
+          /usr/bin/xvfb-run -a --server-args="${XVFB_SERVER_ARGS}" \
+              stdbuf -i0 -o0 -e0 "${ENTRYPOINT}" \
+              --single-process-tests \
+              --gtest_shard_index="${gtest_shard_index}" \
+              --gtest_total_shards="${gtest_total_shards}" \
+              --gtest_output="xml:${xml_path}" \
+              --gtest_filter="${test_filter}" 2>&1 | tee "${log_path}" || {
+            failed_suites="${failed_suites} ${test_executable}"
+          }
 
-            if [[ ! -f "${xml_path}" ]]; then
-              # Test binary crashed. Generate a fake JUnit XML report with the last run test.
-              if [ -f "${log_path}" ]; then
-                python3 "${GITHUB_WORKSPACE}/.github/scripts/generate_crash_report.py" "${log_path}" "${xml_path}"
-              fi
+          if [[ ! -f "${xml_path}" ]]; then
+            # Test binary crashed. Generate a fake JUnit XML report with the last run test.
+            if [[ -f "${log_path}" ]]; then
+              python3 "${GITHUB_WORKSPACE}/.github/scripts/generate_crash_report.py" "${log_path}" "${xml_path}"
             fi
           fi
         done
@@ -181,9 +184,21 @@ runs:
       env:
         TEST_EXECUTABLES_JSON: ${{ inputs.test_executables_json }}
         GTEST_SHARD_INDEX: ${{ matrix.shard }}
+        PLATFORM: ${{ matrix.platform }}
         FILTER_DIR: ${{ steps.prepare-test-filters.outputs.filter_dir }}
+        WORKFLOW: ${{ github.workflow }}
       run: |
         set -exo pipefail
+
+        project_name=$(gcloud config get-value project)
+        gcs_bucket="gs://${project_name}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${PLATFORM}"
+
+        download_archive() {
+          local archive="$1_deps.tar.zstd"
+          gcloud storage cp "${gcs_bucket}/${archive}" "${archive}"
+          tar -I 'zstd -T0' -xf "${archive}"
+          rm -f "${archive}"
+        }
 
         failed_suites=""
 
@@ -206,23 +221,29 @@ runs:
           xml_path="${test_output}/${test_executable_name}_result.xml"
           log_path="${test_output}/${test_executable_name}_log.txt"
 
-          if [ "${test_filter}" == "-*" ]; then
+          if [[ "${test_filter}" == "-*" ]]; then
             echo "Skipped due to test filter." > "${log_path}"
             printf '<?xml version="1.0" encoding="UTF-8"?>\n<testsuites tests="0" failures="0" errors="0" time="0"></testsuites>\n' > "${xml_path}"
-          else
-            echo "Running tests for target: ${test_executable_name}"
+            continue
+          fi
 
-            # Run JUnit tests and generate JSON report, then convert to XML.
-            # TODO(b/524653685): Eventually refactor tests to output JSON natively and remove this XML conversion shortcut.
-            json_path="${test_output}/${test_executable_name}_result.json"
-            stdbuf -i0 -o0 -e0 ./"${test_executable_path}" --json-results-file="${json_path}" 2>&1 | tee "${log_path}" || {
-              failed_suites="${failed_suites} ${test_executable_name}"
-            }
-            if [[ -f "${json_path}" ]]; then
-              python3 "${GITHUB_WORKSPACE}/.github/scripts/convert_json_to_junit_xml.py" "${json_path}" "${xml_path}"
-            elif [ -f "${log_path}" ]; then
-              python3 "${GITHUB_WORKSPACE}/.github/scripts/generate_crash_report.py" "${log_path}" "${xml_path}"
-            fi
+          echo "Running tests for target: ${test_executable_name}"
+
+          # Download and extract target archive if not already extracted.
+          if [[ ! -x "./${test_executable_path}" ]]; then
+            download_archive "${test_executable_name}"
+          fi
+
+          # Run JUnit tests and generate JSON report, then convert to XML.
+          # TODO(b/524653685): Eventually refactor tests to output JSON natively and remove this XML conversion shortcut.
+          json_path="${test_output}/${test_executable_name}_result.json"
+          stdbuf -i0 -o0 -e0 ./"${test_executable_path}" --json-results-file="${json_path}" 2>&1 | tee "${log_path}" || {
+            failed_suites="${failed_suites} ${test_executable_name}"
+          }
+          if [[ -f "${json_path}" ]]; then
+            python3 "${GITHUB_WORKSPACE}/.github/scripts/convert_json_to_junit_xml.py" "${json_path}" "${xml_path}"
+          elif [[ -f "${log_path}" ]]; then
+            python3 "${GITHUB_WORKSPACE}/.github/scripts/generate_crash_report.py" "${log_path}" "${xml_path}"
           fi
         done
 

--- a/.github/actions/upload_test_artifacts/action.yaml
+++ b/.github/actions/upload_test_artifacts/action.yaml
@@ -34,7 +34,7 @@ runs:
       env:
         PLATFORM: ${{ inputs.platform }}
       run: |
-        host_archive_flags="--compression zstd --compression-level=9"
+        host_archive_flags="--compression zstd --compression-level=9 --archive-per-target"
         android_archive_flags="--compression gz --archive-per-target --use-android-deps-path --flatten-deps"
         rdk_archive_flags="--compression gz --archive-per-target --flatten-deps"
         rdk_browser_archive_flags="--compression gz --archive-per-target --flatten-deps --strip"

--- a/cobalt/build/archive_test_artifacts.py
+++ b/cobalt/build/archive_test_artifacts.py
@@ -289,16 +289,11 @@ def create_archive(
         if archive_per_target:
           output_path = os.path.join(destination_dir,
                                      f'{target_name}_deps.tar.{compression}')
-          if flatten_deps:
-            _make_tar(
-                output_path,
-                compression,
-                compression_level,
-                [(target_deps, staged_out_dir),
-                 (target_src_root_deps, source_dir)],
-            )
-          else:
-            raise ValueError('Unsupported configuration.')
+          file_lists = ([(target_deps, staged_out_dir),
+                         (target_src_root_deps,
+                          source_dir)] if flatten_deps else [(target_deps,
+                                                              source_dir)])
+          _make_tar(output_path, compression, compression_level, file_lists)
 
   # Linux tests and deps are all bundled into a single tar file.
   if not archive_per_target:
@@ -364,8 +359,9 @@ def main():
       'directories both at the root of the deps archive.')
   args = parser.parse_args()
 
-  if args.flatten_deps != args.archive_per_target:
-    raise ValueError('Unsupported configuration.')
+  if args.flatten_deps and not args.archive_per_target:
+    raise ValueError(
+        'Unsupported configuration: flatten_deps requires archive_per_target.')
 
   create_archive(
       targets=args.targets,

--- a/cobalt/build/test_archive_test_artifacts.py
+++ b/cobalt/build/test_archive_test_artifacts.py
@@ -292,6 +292,39 @@ class TestArchiveTestArtifacts(unittest.TestCase):
     self.assertFalse(mock_run.called)
     self.assertTrue(mock_make_tar.called)
 
+  @mock.patch('archive_test_artifacts._make_tar')
+  def test_create_archive_linux_style_per_target(self, mock_make_tar):
+    target_name = 'my_test'
+    deps_file = os.path.join(self.out_dir, f'{target_name}.runtime_deps')
+    with open(deps_file, 'w', encoding='utf-8') as f:
+      f.write('base_unittests\n')
+      f.write('../../cobalt/test/data/file.txt\n')
+
+    archive_test_artifacts.create_archive(
+        targets=['cobalt/test:my_test'],
+        source_dir=self.source_dir,
+        out_dir=self.out_dir,
+        destination_dir=self.dest_dir,
+        archive_per_target=True,
+        use_android_deps_path=False,
+        compression='gz',
+        compression_level=1,
+        flatten_deps=False,
+        strip_binaries=False)
+
+    self.assertTrue(mock_make_tar.called)
+    archive_path = mock_make_tar.call_args[0][0]
+    self.assertTrue(archive_path.endswith('my_test_deps.tar.gz'))
+
+    file_lists = mock_make_tar.call_args[0][3]
+    self.assertEqual(len(file_lists), 1)
+    target_deps, src_dir = file_lists[0]
+    self.assertEqual(src_dir, self.source_dir)
+    self.assertIn(
+        os.path.relpath(os.path.join(self.out_dir, 'base_unittests')),
+        target_deps)
+    self.assertIn('cobalt/test/data/file.txt', target_deps)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/starboard/shared/starboard/player/file_cache_reader.cc
+++ b/starboard/shared/starboard/player/file_cache_reader.cc
@@ -49,9 +49,15 @@ std::string ResolveTestFileName(const char* filename) {
   if (!does_path_exist) {
     // If |path| doesn't exist it could be due to |content_path_as_string| not
     // including the starboard_toolchain's output folder, i.e. it's e.g.
-    // out/linux.../content when it should be out/linux.../starboard/content.
+    // out/linux.../content when it should be out/linux.../starboard/content,
+    // or out/linux... when test assets are under out/linux.../starboard.
     // TODO(b/384819454): Use EvergreenConfig here to overwrite the path. For
-    // the time being, just try inserting "starboard" in the path and try again.
+    // the time being, try appending "starboard" or inserting "starboard".
+    path = content_path_as_string + kSbFileSepChar + "starboard" +
+           path_inside_content;
+    does_path_exist = stat(path.c_str(), &info) == 0 && S_ISDIR(info.st_mode);
+  }
+  if (!does_path_exist) {
     std::size_t last_separation_char_pos =
         content_path_as_string.find_last_of(kSbFileSepChar);
     path = content_path_as_string.substr(0, last_separation_char_pos) +


### PR DESCRIPTION
Reorder filter preparation before artifact download in on_host_tests.
Skip downloads for test targets with filter "-*", and download
active target archives from GCS on demand.

Tag: agy
Conv: 8b3bc5ff-f54b-4937-b691-e6ab1ebb7508
Bug: 558866720

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>