### PR TITLE
components/update_client: Remove custom VerifyFileHash256() implemention

### DIFF
--- a/components/update_client/utils.cc
+++ b/components/update_client/utils.cc
@@ -96,7 +96,6 @@ std::string GetCrxIdFromPublicKeyHash(base::span<const uint8_t> pk_hash) {
 
 #if BUILDFLAG(IS_STARBOARD)
 #if defined(IN_MEMORY_UPDATES)
-
 bool VerifyHash256(const std::string* content,
                    const std::string& expected_hash_str) {
   std::vector<uint8_t> expected_hash;
@@ -110,49 +109,6 @@ bool VerifyHash256(const std::string* content,
       crypto::SecureHash::Create(crypto::SecureHash::SHA256));
 
   hasher->Update(content->c_str(), content->size());
-  hasher->Finish(actual_hash, sizeof(actual_hash));
-
-  return base::span(actual_hash) == base::span(expected_hash);
-}
-#else  // defined(IN_MEMORY_UPDATES)
-bool VerifyFileHash256(const base::FilePath& filepath,
-                       const std::string& expected_hash_str) {
-  std::vector<uint8_t> expected_hash;
-  if (!base::HexStringToBytes(expected_hash_str, &expected_hash) ||
-      expected_hash.size() != crypto::kSHA256Length) {
-    return false;
-  }
-
-  base::File source_file(filepath,
-                         base::File::FLAG_OPEN | base::File::FLAG_READ);
-  if (!source_file.IsValid()) {
-    DPLOG(ERROR) << "VerifyFileHash256(): Unable to open source file: "
-                 << filepath.value();
-    return false;
-  }
-
-  const size_t kBufferSize = 32768;
-  std::vector<char> buffer(kBufferSize);
-  uint8_t actual_hash[crypto::kSHA256Length] = {0};
-  std::unique_ptr<crypto::SecureHash> hasher(
-      crypto::SecureHash::Create(crypto::SecureHash::SHA256));
-
-  while (true) {
-    int bytes_read = source_file.ReadAtCurrentPos(&buffer[0], buffer.size());
-    if (bytes_read < 0) {
-      DPLOG(ERROR) << "VerifyFileHash256(): error reading from source file: "
-                   << filepath.value();
-
-      return false;
-    }
-
-    if (bytes_read == 0) {
-      break;
-    }
-
-    hasher->Update(&buffer[0], bytes_read);
-  }
-
   hasher->Finish(actual_hash, sizeof(actual_hash));
 
   return base::span(actual_hash) == base::span(expected_hash);


### PR DESCRIPTION
This Starboard-specific implementation was added in #10141 with code forward-ported from the 26.eap branch.

In main (M138), the non-Starboard version behaves very similarly (it just uses a smaller buffer size for the chunks it reads), so it is possible to drop the custom version. Not only do we no longer have to worry about maintaining custom code that makes calls to //crypto code, but it also makes rebases easier.

Fixed: 559011262