### PR TITLE
android: Replace synchronized methods with private lock objects and atomic primitives

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/ArtworkLoader.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/ArtworkLoader.java
@@ -21,6 +21,7 @@ import android.os.Looper;
 import android.util.Pair;
 import android.util.Size;
 import androidx.annotation.CheckResult;
+import androidx.annotation.GuardedBy;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import dev.cobalt.util.DisplayUtil;
@@ -35,9 +36,21 @@ public class ArtworkLoader {
     void onArtworkLoaded(Bitmap bitmap);
   }
 
-  @VisibleForTesting @NonNull volatile String mRequestedArtworkUrl = "";
-  @VisibleForTesting @NonNull volatile String mCurrentArtworkUrl = "";
-  @VisibleForTesting volatile Bitmap mCurrentArtwork = null;
+  private final Object mLock = new Object();
+
+  @GuardedBy("mLock")
+  @VisibleForTesting
+  @NonNull
+  String mRequestedArtworkUrl = "";
+
+  @GuardedBy("mLock")
+  @VisibleForTesting
+  @NonNull
+  String mCurrentArtworkUrl = "";
+
+  @GuardedBy("mLock")
+  @VisibleForTesting
+  Bitmap mCurrentArtwork = null;
 
   private final Handler mHandler = new Handler(Looper.getMainLooper());
   private final ArtworkDownloader mArtworkDownloader;
@@ -58,7 +71,7 @@ public class ArtworkLoader {
    * Returns a cached image if available. If not cached, returns null and starts downloading it in
    * the background, and then when ready the callback will be called with the image.
    */
-  public synchronized Bitmap getOrLoadArtwork(List<MediaImage> images) {
+  public Bitmap getOrLoadArtwork(List<MediaImage> images) {
     if (images == null || images.isEmpty()) {
       return null;
     }
@@ -66,14 +79,17 @@ public class ArtworkLoader {
     MediaImage image = getBestFitImage(images, DisplayUtil.getDisplaySize());
     String url = image.getSrc().getSpec();
 
-    // Check if this artwork is already loaded or requested.
-    if (url.equals(mCurrentArtworkUrl)) {
-      return mCurrentArtwork;
-    } else if (url.equals(mRequestedArtworkUrl)) {
-      return null;
+    synchronized (mLock) {
+      // Check if this artwork is already loaded or requested.
+      if (url.equals(mCurrentArtworkUrl)) {
+        return mCurrentArtwork;
+      } else if (url.equals(mRequestedArtworkUrl)) {
+        return null;
+      }
+
+      mRequestedArtworkUrl = url;
     }
 
-    mRequestedArtworkUrl = url;
     new DownloadArtworkThread(url, this).start();
     return null;
   }
@@ -137,26 +153,29 @@ public class ArtworkLoader {
    *
    * @param urlBitmapPair A pair containing the URL and the downloaded Bitmap.
    */
-  public synchronized void onDownloadFinished(Pair<String, Bitmap> urlBitmapPair) {
+  public void onDownloadFinished(Pair<String, Bitmap> urlBitmapPair) {
     String url = urlBitmapPair.first;
     Bitmap bitmap = urlBitmapPair.second;
+    final Bitmap oldArtwork;
 
-    if (!mRequestedArtworkUrl.equals(url)) {
-      if (bitmap != null) {
-        bitmap.recycle();
+    synchronized (mLock) {
+      if (!mRequestedArtworkUrl.equals(url)) {
+        if (bitmap != null) {
+          bitmap.recycle();
+        }
+        return;
       }
-      return;
+
+      mRequestedArtworkUrl = "";
+
+      if (bitmap == null) {
+        return;
+      }
+
+      oldArtwork = mCurrentArtwork;
+      mCurrentArtworkUrl = url;
+      mCurrentArtwork = bitmap;
     }
-
-    mRequestedArtworkUrl = "";
-
-    if (bitmap == null) {
-      return;
-    }
-
-    final Bitmap oldArtwork = mCurrentArtwork;
-    mCurrentArtworkUrl = url;
-    mCurrentArtwork = bitmap;
 
     mHandler.post(
         new Runnable() {

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/AudioPermissionRequester.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/AudioPermissionRequester.java
@@ -24,13 +24,13 @@ import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import dev.cobalt.util.Holder;
 import dev.cobalt.util.Log;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.jni_zero.CalledByNative;
 
 /** Helper class that requests the record audio permission. */
 public class AudioPermissionRequester {
   private final Holder<Activity> mActivityHolder;
-  // Only use in synchronized methods.
-  private boolean mRequestAudioPermissionStarted;
+  private final AtomicBoolean mRequestAudioPermissionStarted = new AtomicBoolean(false);
 
   public AudioPermissionRequester(Context context, Holder<Activity> activityHolder) {
     this.mActivityHolder = activityHolder;
@@ -41,7 +41,7 @@ public class AudioPermissionRequester {
    * if the permission is not granted yet and starts to request the RECORD_AUDIO permission.
    */
   @CalledByNative
-  public synchronized boolean requestRecordAudioPermission() {
+  public boolean requestRecordAudioPermission() {
     Activity activity = mActivityHolder.get();
     if (activity == null) {
       return false;
@@ -52,23 +52,22 @@ public class AudioPermissionRequester {
       return true;
     }
 
-    if (!mRequestAudioPermissionStarted) {
+    if (mRequestAudioPermissionStarted.compareAndSet(false, true)) {
       ActivityCompat.requestPermissions(
           activity, new String[] {Manifest.permission.RECORD_AUDIO}, R.id.rc_record_audio);
-      mRequestAudioPermissionStarted = true;
     }
 
     return false;
   }
 
   /** Handles the RECORD_AUDIO request result. */
-  public synchronized void onRequestPermissionsResult(
+  public void onRequestPermissionsResult(
       int requestCode, String[] permissions, int[] grantResults) {
     if (requestCode == R.id.rc_record_audio) {
       boolean success =
           grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED;
       Log.i(TAG, "RECORD_AUDIO permission request " + (success ? "GRANTED" : "DENIED"));
-      mRequestAudioPermissionStarted = false;
+      mRequestAudioPermissionStarted.set(false);
     }
   }
 }

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/VideoDecoderCache.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/VideoDecoderCache.java
@@ -19,6 +19,7 @@ import android.media.MediaCodecInfo.CodecCapabilities;
 import android.media.MediaCodecInfo.VideoCapabilities;
 import android.media.MediaCodecList;
 import android.util.Range;
+import androidx.annotation.GuardedBy;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -54,9 +55,12 @@ public class VideoDecoderCache {
   private static final int DEFAULT_CACHE_TTL_MILLIS = 1000;
 
   private static Map<String, List<CachedDecoder>> sCache = new HashMap<>();
+
+  @GuardedBy("sCache")
   private static long sLastCacheUpdateAt = 0;
 
-  private static synchronized boolean isExpired(int cacheTtlOverride) {
+  @GuardedBy("sCache")
+  private static boolean isExpired(int cacheTtlOverride) {
     long cacheTtl = cacheTtlOverride >= 0 ? cacheTtlOverride : DEFAULT_CACHE_TTL_MILLIS;
     return System.currentTimeMillis() - sLastCacheUpdateAt >= cacheTtl;
   }

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/SynchronizedHolder.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/SynchronizedHolder.java
@@ -14,31 +14,32 @@
 
 package dev.cobalt.util;
 
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 /**
- * Generic holder class to turn null checks into a known RuntimeException. Access is synchronized,
- * so access from multiple threads is safe.
+ * Generic holder class to turn null checks into a known RuntimeException. Access is thread-safe.
  *
  * @param <T> The type of the value to hold.
  * @param <E> The type of the exception to throw if the value is null.
  */
 public class SynchronizedHolder<T, E extends RuntimeException> {
-  private T mValue;
+  private final AtomicReference<T> mValue = new AtomicReference<>();
   private final Supplier<E> mExceptionSupplier;
 
   public SynchronizedHolder(Supplier<E> exceptionSupplier) {
     mExceptionSupplier = exceptionSupplier;
   }
 
-  public synchronized T get() {
-    if (mValue == null) {
+  public T get() {
+    T value = mValue.get();
+    if (value == null) {
       throw mExceptionSupplier.get();
     }
-    return mValue;
+    return value;
   }
 
-  public synchronized void set(T value) {
-    mValue = value;
+  public void set(T value) {
+    mValue.set(value);
   }
 }

--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/ArtworkDownloaderDefaultTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/ArtworkDownloaderDefaultTest.java
@@ -65,7 +65,7 @@ public class ArtworkDownloaderDefaultTest {
     ArtworkLoader artworkLoader =
         new ArtworkLoader(mock(ArtworkLoader.Callback.class), mDownloader) {
           @Override
-          public synchronized void onDownloadFinished(Pair<String, Bitmap> urlBitmapPair) {
+          public void onDownloadFinished(Pair<String, Bitmap> urlBitmapPair) {
             super.onDownloadFinished(urlBitmapPair);
             // In this test, the download is expected to fail, so the bitmap should be null.
             // In this test environment, the download fails because the URL is not accessible,


### PR DESCRIPTION
Replace method-level synchronized modifiers with private lock objects
and atomic primitives.

Using method-level synchronization exposes an object's monitor lock to
external clients, which can lead to unintentional contention or
deadlocks. Encapsulating synchronization within private lock objects
hides the locking mechanism. Additionally, using atomic primitives
for state checks prevents holding monitor locks during IPC calls or
long-running operations.


Bug: 559107944