### PR TITLE
BACKPORT: media: Clear the media client in RendererImplTest's destructor

### DIFF
--- a/media/renderers/renderer_impl_unittest.cc
+++ b/media/renderers/renderer_impl_unittest.cc
@@ -96,7 +96,10 @@ class RendererImplTest : public ::testing::Test {
   RendererImplTest(const RendererImplTest&) = delete;
   RendererImplTest& operator=(const RendererImplTest&) = delete;
 
-  ~RendererImplTest() override { Destroy(); }
+  ~RendererImplTest() override {
+    Destroy();
+    SetMediaClient(nullptr);
+  }
 
  protected:
   void Destroy() {


### PR DESCRIPTION
BACKPORT: media: Clear the media client in RendererImplTest's destructor

For m140.7339 roll, there was crashes while running `media_unittests`
for evergreen-x64. The below CL fixes it in upstream.

Bug: 552827012

---
Original CL message:

media: Clear the media client in RendererImplTest's destructor

RendererImplTest's constructor points the process-global media client at
its StrictMock<MockMediaClient> member, but the destructor never clears
it. The global is therefore left dangling once the fixture member is
destroyed, and any later test in the same process that calls
GetMediaClient() (StreamParserBuffer::CopyFrom(), for instance, which
asks the client for a media allocator) reads freed memory.

Pair the set in the constructor with a matching clear in the destructor,
as KeySystemsTest already does.

TEST : out/rel/media_unittests --single-process-tests \
          --gtest_filter='RendererImplTest.*:*FrameProcessorTest.*'

Change-Id: I13466cf7d240feaa6d273c8fc1e3229a064fea06
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8293641
Reviewed-by: Ted (Chromium) Meyer <tmathmeyer@chromium.org>
Commit-Queue: Abhijeet Kandalkar <abhijeet@igalia.com>
Cr-Commit-Position: refs/heads/main@{#1689678}
