### PR TITLE
android: Mark immutable member variables as final

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/BaseStarboardBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/BaseStarboardBridge.java
@@ -80,17 +80,18 @@ public class BaseStarboardBridge {
 
   private Surface mVideoSurface;
   private final Object mVideoSurfaceLock = new Object();
-  private CobaltSystemConfigChangeReceiver mSysConfigChangeReceiver;
-  private CobaltTextToSpeechHelper mTtsHelper;
+  private final CobaltSystemConfigChangeReceiver mSysConfigChangeReceiver;
+  private final CobaltTextToSpeechHelper mTtsHelper;
   // TODO(cobalt): Re-enable these classes or remove if unnecessary.
-  private AudioOutputManager mAudioOutputManager;
-  private AudioPermissionRequester mAudioPermissionRequester;
-  private ResourceOverlay mResourceOverlay;
-  private AdvertisingId mAdvertisingId;
+  private final AudioOutputManager mAudioOutputManager;
+  private final AudioPermissionRequester mAudioPermissionRequester;
+  private final ResourceOverlay mResourceOverlay;
+  private final AdvertisingId mAdvertisingId;
   private final Context mAppContext;
   protected final Holder<Activity> mActivityHolder;
   private final Holder<Service> mServiceHolder;
-  // Maps each live Activity to whether it is currently started (Boolean.TRUE) or stopped (Boolean.FALSE).
+  // Maps each live Activity to whether it is currently started (Boolean.TRUE) or stopped
+  // (Boolean.FALSE).
   // Backed by WeakHashMap to prevent pinning Activity instances in the singleton bridge.
   private final Map<Activity, Boolean> mActivities =
       Collections.synchronizedMap(new WeakHashMap<>());
@@ -146,7 +147,12 @@ public class BaseStarboardBridge {
     mActivityHolder = activityHolder;
     mServiceHolder = serviceHolder;
     mArgs = new String[0];
+    mSysConfigChangeReceiver = null;
+    mTtsHelper = null;
     mAudioOutputManager = new AudioOutputManager(appContext);
+    mAudioPermissionRequester = null;
+    mResourceOverlay = null;
+    mAdvertisingId = null;
     mIsAmatiDevice = false;
     mNativeApp = 0;
   }
@@ -262,7 +268,8 @@ public class BaseStarboardBridge {
       Log.w(
           TAG,
           String.format(
-              "onActivityStart: New activity %s starting while there are previous %d activities are still active.",
+              "onActivityStart: New activity %s starting while there are previous %d activities are"
+                  + " still active.",
               activity, activeActivityCount));
     }
     mActivities.put(activity, Boolean.TRUE);
@@ -296,7 +303,8 @@ public class BaseStarboardBridge {
         }
         Log.i(
             TAG,
-            "onActivityStop: Another activity is still started; skipping suspend and foreground change.");
+            "onActivityStop: Another activity is still started; skipping suspend and foreground"
+                + " change.");
       }
     } else {
       beforeSuspend();
@@ -336,7 +344,8 @@ public class BaseStarboardBridge {
         Log.w(
             TAG,
             String.format(
-                "onActivityDestroy: %d CobaltService instance(s) still open after last activity destroyed; force cleaning up.",
+                "onActivityDestroy: %d CobaltService instance(s) still open after last activity"
+                    + " destroyed; force cleaning up.",
                 mCobaltServices.size()));
         closeAllCobaltService();
       }
@@ -740,9 +749,9 @@ public class BaseStarboardBridge {
   /**
    * Called when a VideoSurfaceView creates its underlying Surface.
    *
-   * Note: Starboard assumes a single active video surface at any given time for
-   * punch-out video decoding. During activity recreation or overlapping transitions,
-   * the newest activity's surface supersedes any previous surface as the active target.
+   * <p>Note: Starboard assumes a single active video surface at any given time for punch-out video
+   * decoding. During activity recreation or overlapping transitions, the newest activity's surface
+   * supersedes any previous surface as the active target.
    */
   public void onVideoSurfaceCreated(Surface surface) {
     Log.i(TAG, String.format("onVideoSurfaceCreated: surface=%s", surface));
@@ -755,9 +764,9 @@ public class BaseStarboardBridge {
   /**
    * Called when a VideoSurfaceView destroys its underlying Surface.
    *
-   * If this destruction event is for an old surface that was already superseded by a newer
-   * activity's surface, it is safely ignored so that the active video decoding target is not
-   * torn down prematurely.
+   * <p>If this destruction event is for an old surface that was already superseded by a newer
+   * activity's surface, it is safely ignored so that the active video decoding target is not torn
+   * down prematurely.
    */
   public void onVideoSurfaceDestroyed(Surface surface) {
     Log.i(TAG, String.format("onVideoSurfaceDestroyed: surface=%s", surface));
@@ -765,7 +774,8 @@ public class BaseStarboardBridge {
     synchronized (mVideoSurfaceLock) {
       if (isActivityLifecycleCoordinationEnabled()) {
         // If this destruction is for a surface that is no longer active (e.g. from an old activity
-        // during an overlapping activity transition), ignore it to avoid tearing down the new surface.
+        // during an overlapping activity transition), ignore it to avoid tearing down the new
+        // surface.
         if (mVideoSurface != surface) {
           Log.i(
               TAG,
@@ -846,8 +856,7 @@ public class BaseStarboardBridge {
       mCobaltServices.put(nativeService, service);
       Log.i(
           TAG,
-          String.format(
-              "Opened platform service %s [handle: 0x%x].", serviceName, nativeService));
+          String.format("Opened platform service %s [handle: 0x%x].", serviceName, nativeService));
     }
     return service;
   }
@@ -857,7 +866,8 @@ public class BaseStarboardBridge {
       return null;
     }
     CobaltService matchedService = null;
-    // Count matching instances across open handles to detect and warn if name-based lookup is ambiguous.
+    // Count matching instances across open handles to detect and warn if name-based lookup is
+    // ambiguous.
     int count = 0;
     for (CobaltService service : mCobaltServices.values()) {
       if (!serviceName.equals(service.getServiceName())) {

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -87,8 +87,9 @@ public abstract class CobaltActivity extends BaseCobaltActivity {
 
   // Maintain the list of JavaScript-exposed objects as a member variable
   // to prevent them from being garbage collected prematurely.
-  private List<CobaltJavaScriptAndroidObject> mJavaScriptAndroidObjectList = new ArrayList<>();
-  private Map<String, String> mJavaSwitches = new HashMap<>();
+  private final List<CobaltJavaScriptAndroidObject> mJavaScriptAndroidObjectList =
+      new ArrayList<>();
+  private final Map<String, String> mJavaSwitches = new HashMap<>();
 
   @SuppressWarnings("unused")
   private CobaltA11yHelper mA11yHelper;
@@ -310,7 +311,8 @@ public abstract class CobaltActivity extends BaseCobaltActivity {
                   Log.i(TAG, "Browser process init succeeded");
 
                   if (isDestroyed() || isFinishing()) {
-                    Log.w(TAG, "Activity is finishing or destroyed; skipping finishInitialization.");
+                    Log.w(
+                        TAG, "Activity is finishing or destroyed; skipping finishInitialization.");
                     return;
                   }
 

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltMediaSession.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltMediaSession.java
@@ -64,7 +64,7 @@ public class CobaltMediaSession implements ArtworkLoader.Callback {
   private Set<Integer> mActions;
   private MediaPosition mPosition;
   private Bitmap mArtworkImage;
-  private MediaSessionCompat.Callback mMediaSessionCallback;
+  private final MediaSessionCompat.Callback mMediaSessionCallback;
   private LifecycleCallback mLifecycleCallback = null;
 
   // TODO: decouple LifecycleCallback and CobaltMediaSession implementation.

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltService.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltService.java
@@ -26,12 +26,13 @@ import org.jni_zero.NativeMethods;
  * Abstract class that provides an interface for Cobalt to interact with a platform service.
  *
  * <p>Threading model:
+ *
  * <ul>
- *   <li>{@code openCobaltService}, {@code closeCobaltService}, and {@link #receiveFromClient}
- *       are invoked on the browser UI thread (Android main looper) and are serialized with
- *       Activity lifecycle callbacks.</li>
+ *   <li>{@code openCobaltService}, {@code closeCobaltService}, and {@link #receiveFromClient} are
+ *       invoked on the browser UI thread (Android main looper) and are serialized with Activity
+ *       lifecycle callbacks.
  *   <li>{@link #sendToClient} may be invoked from any thread; synchronization ensures safety
- *       against concurrent {@link #onClose}.</li>
+ *       against concurrent {@link #onClose}.
  * </ul>
  */
 public abstract class CobaltService {

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java
@@ -31,8 +31,8 @@ public class StarboardBridge extends BaseStarboardBridge {
     StarboardBridge getStarboardBridge();
   }
 
-  private CobaltMediaSession mCobaltMediaSession;
-  private VolumeStateReceiver mVolumeStateReceiver;
+  private final CobaltMediaSession mCobaltMediaSession;
+  private final VolumeStateReceiver mVolumeStateReceiver;
   private volatile PlatformError mPlatformError;
 
   public StarboardBridge(

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/AudioOutputManager.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/AudioOutputManager.java
@@ -39,7 +39,7 @@ import org.jni_zero.NativeMethods;
 @JNINamespace("starboard")
 public class AudioOutputManager {
   @NonNull private final List<AudioTrackBridge> mAudioTrackBridgeList;
-  private Context mContext;
+  private final Context mContext;
 
   boolean mHasRegisteredAudioDeviceCallback = false;
 

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/AudioTrackBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/AudioTrackBridge.java
@@ -49,8 +49,9 @@ public class AudioTrackBridge {
   // mRawAudioTimestamp is used to retrieve the timestamp directly from android.media.AudioTrack.
   // mAudioTimestamp is a wrapper that ensures the framePosition is monotonically increasing
   // before it is passed to the native side.
-  private android.media.AudioTimestamp mRawAudioTimestamp = new android.media.AudioTimestamp();
-  private AudioTimestamp mAudioTimestamp = new AudioTimestamp(0, 0);
+  private final android.media.AudioTimestamp mRawAudioTimestamp =
+      new android.media.AudioTimestamp();
+  private final AudioTimestamp mAudioTimestamp = new AudioTimestamp(0, 0);
 
   private final Object mPositionLock = new Object();
 

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
@@ -72,7 +72,7 @@ class MediaCodecBridge {
   private volatile boolean mIsFlushing = false;
   private final boolean mEnableIgnoreCallbacksDuringFlushing;
 
-  private MediaCodec.Callback mCallback;
+  private final MediaCodec.Callback mCallback;
   private double mPlaybackRate = 1.0;
   private int mFps = 30;
   private double mOperatingRate = mPlaybackRate * mFps;
@@ -80,7 +80,7 @@ class MediaCodecBridge {
   private final boolean mIsTunnelingPlayback;
   private final boolean mEnableFrameRendererListener;
 
-  private MediaCodec.OnFrameRenderedListener mFrameRendererListener;
+  private final MediaCodec.OnFrameRenderedListener mFrameRendererListener;
   private MediaCodec.OnFirstTunnelFrameReadyListener mFirstTunnelFrameReadyListener;
 
   private boolean shouldSkipVideoFrame(long presentationTimeUs, boolean isDecodeOnly) {
@@ -381,6 +381,8 @@ class MediaCodecBridge {
       } else {
         mMediaCodec.get().setOnFrameRenderedListener(mFrameRendererListener, null);
       }
+    } else {
+      mFrameRendererListener = null;
     }
 
     if (mIsTunnelingPlayback) {

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaDrmBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaDrmBridge.java
@@ -98,7 +98,7 @@ public class MediaDrmBridge {
 
   // The map of all opened sessions (excluding mMediaCryptoSession) to their
   // mime types.
-  private HashMap<ByteBuffer, String> mSessionIds = new HashMap<>();
+  private final HashMap<ByteBuffer, String> mSessionIds = new HashMap<>();
 
   private MediaCrypto mMediaCrypto;
 

--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/BaseStarboardBridgeTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/BaseStarboardBridgeTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import android.app.Activity;
 import android.app.Service;
@@ -341,7 +340,8 @@ public class BaseStarboardBridgeTest {
     assertEquals(surface2, bridge.getVideoSurface());
     verify(mockVideoNatives).onVideoSurfaceChanged(surface2);
 
-    // When coordination is disabled (legacy), destroying surface1 resets surface and notifies JNI null
+    // When coordination is disabled (legacy), destroying surface1 resets surface and notifies JNI
+    // null
     bridge.onVideoSurfaceDestroyed(surface1);
     assertNull(bridge.getVideoSurface());
     verify(mockVideoNatives).onVideoSurfaceChanged(null);
@@ -375,7 +375,8 @@ public class BaseStarboardBridgeTest {
     bridge.onActivityStart(act2);
     assertEquals(2, service.startOrResumeCount);
 
-    // When coordination is disabled, stopping act1 immediately calls beforeSuspend even though act2 is active
+    // When coordination is disabled, stopping act1 immediately calls beforeSuspend even though act2
+    // is active
     bridge.onActivityStop(act1);
     assertEquals(1, service.suspendCount);
 


### PR DESCRIPTION
Add the final modifier to member variables across dev.cobalt packages
that are initialized at declaration or unconditionally in constructors.
This change ensures these fields cannot be accidentally reassigned
and improves code readability by explicitly indicating which variables
are intended to be immutable.

This PR also fixes Java lint errors/warnings introduced in #12095 

Bug: 559141172