### PR TITLE
media: Support capping 720p video resolution

### DIFF
--- a/media/base/BUILD.gn
+++ b/media/base/BUILD.gn
@@ -726,7 +726,8 @@ source_set("unit_tests") {
     sources += [
       "starboard/experimental_features_unittest.cc",
       "starboard/ipc_param_traits_unittest.cc",
-      "starboard/starboard_renderer_config_unittest.cc"
+      "starboard/sbmedia_interface_unittest.cc",
+      "starboard/starboard_renderer_config_unittest.cc",
     ]
   }
 }

--- a/media/base/media_switches.cc
+++ b/media/base/media_switches.cc
@@ -517,6 +517,11 @@ BASE_FEATURE(kCobaltUsingAndroidOverlay,
 BASE_FEATURE(kCobaltBypassMojoForMedia,
              "CobaltBypassMojoForMedia",
              base::FEATURE_DISABLED_BY_DEFAULT);
+// When enabled, Cobalt reports video resolutions above 720p (1280x720) as
+// unsupported in MediaSource.isTypeSupported().
+BASE_FEATURE(kCobaltCapResolutionTo720p,
+             "CobaltCapResolutionTo720p",
+             base::FEATURE_DISABLED_BY_DEFAULT);
 // When enabled, Cobalt routes media frame buffer allocations into Starboard's
 // media memory pool via Chromium M126+ ExternalMemoryAllocator interface.
 BASE_FEATURE(kCobaltUseExternalMediaMemoryPool,

--- a/media/base/media_switches.h
+++ b/media/base/media_switches.h
@@ -232,6 +232,7 @@ MEDIA_EXPORT extern const base::FeatureParam<base::TimeDelta> kAudioWriteDuratio
 MEDIA_EXPORT BASE_DECLARE_FEATURE(kCobaltUsingAndroidOverlay);
 #endif  // BUILDFLAG(IS_ANDROID)
 MEDIA_EXPORT BASE_DECLARE_FEATURE(kCobaltBypassMojoForMedia);
+MEDIA_EXPORT BASE_DECLARE_FEATURE(kCobaltCapResolutionTo720p);
 MEDIA_EXPORT BASE_DECLARE_FEATURE(kCobaltUseExternalMediaMemoryPool);
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 #if BUILDFLAG(IS_CHROMEOS)

--- a/media/base/starboard/sbmedia_interface.cc
+++ b/media/base/starboard/sbmedia_interface.cc
@@ -15,9 +15,15 @@
 #include "media/base/starboard/sbmedia_interface.h"
 
 #include <atomic>
+#include <limits>
+#include <string_view>
 
 #include "base/check.h"
+#include "base/feature_list.h"
+#include "base/logging.h"
 #include "base/no_destructor.h"
+#include "base/strings/string_util.h"
+#include "media/base/media_switches.h"
 
 namespace media {
 
@@ -27,9 +33,68 @@ std::atomic<SbMediaInterface*> g_sbmedia_interface_for_testing{nullptr};
 
 }  // namespace
 
+int ExtractMimeIntParam(std::string_view mime, std::string_view key) {
+  size_t pos = 0;
+  while ((pos = mime.find(key, pos)) != std::string_view::npos) {
+    if (pos == 0 || mime[pos - 1] == ';' ||
+        base::IsAsciiWhitespace(mime[pos - 1])) {
+      size_t eq_pos = pos + key.length();
+      while (eq_pos < mime.length() && base::IsAsciiWhitespace(mime[eq_pos])) {
+        eq_pos++;
+      }
+      if (eq_pos < mime.length() && mime[eq_pos] == '=') {
+        size_t val_start = eq_pos + 1;
+        while (val_start < mime.length() &&
+               (base::IsAsciiWhitespace(mime[val_start]) ||
+                mime[val_start] == '"')) {
+          val_start++;
+        }
+        int val = 0;
+        size_t val_end = val_start;
+        while (val_end < mime.length() && base::IsAsciiDigit(mime[val_end])) {
+          int digit = mime[val_end] - '0';
+          if (val > (std::numeric_limits<int>::max() - digit) / 10) {
+            return std::numeric_limits<int>::max();
+          }
+          val = val * 10 + digit;
+          val_end++;
+        }
+        if (val_end > val_start) {
+          return val;
+        }
+      }
+    }
+    pos += key.length();
+  }
+  return 0;
+}
+
+bool Exceeds720p(const char* mime) {
+  if (!mime) {
+    return false;
+  }
+  std::string_view mime_str(mime);
+  int height = ExtractMimeIntParam(mime_str, "height");
+  if (height > 720) {
+    return true;
+  }
+  int width = ExtractMimeIntParam(mime_str, "width");
+  if (width > 1280) {
+    return true;
+  }
+  return false;
+}
+
 SbMediaSupportType DefaultSbMediaInterface::CanPlayMimeAndKeySystem(
     const char* mime,
     const char* key_system) const {
+  if (base::FeatureList::IsEnabled(kCobaltCapResolutionTo720p) &&
+      Exceeds720p(mime)) {
+    // TODO(cobalt, b/557961321): enable with constrained network link.
+    LOG(INFO) << "CobaltCapResolutionTo720p: format exceeds 720p cap: "
+              << (mime ? mime : "(null)");
+    return kSbMediaSupportTypeNotSupported;
+  }
   return SbMediaCanPlayMimeAndKeySystem(mime, key_system);
 }
 

--- a/media/base/starboard/sbmedia_interface.h
+++ b/media/base/starboard/sbmedia_interface.h
@@ -17,6 +17,8 @@
 
 #include <stdint.h>
 
+#include <string_view>
+
 #include "media/base/media_export.h"
 #include "starboard/media.h"
 
@@ -98,6 +100,14 @@ MEDIA_EXPORT SbMediaInterface* GetSbMediaInterface();
 
 // Sets a custom SbMediaInterface for testing.
 MEDIA_EXPORT void SetSbMediaInterfaceForTesting(SbMediaInterface* interface);
+
+// Parses an integer parameter value from a MIME string (e.g. "width",
+// "height").
+MEDIA_EXPORT int ExtractMimeIntParam(std::string_view mime,
+                                     std::string_view key);
+
+// Returns true if the MIME string specifies width > 1280 or height > 720.
+MEDIA_EXPORT bool Exceeds720p(const char* mime);
 
 }  // namespace media
 

--- a/media/base/starboard/sbmedia_interface_unittest.cc
+++ b/media/base/starboard/sbmedia_interface_unittest.cc
@@ -1,0 +1,125 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "media/base/starboard/sbmedia_interface.h"
+
+#include <limits>
+
+#include "base/test/scoped_feature_list.h"
+#include "media/base/media_switches.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace media {
+
+TEST(SbMediaInterfaceTest, ExtractMimeIntParam) {
+  const char kMime720p[] =
+      "video/mp4; codecs=\"avc1.4d401f\"; width=1280; height=720; "
+      "framerate=30; bitrate=2496430";
+  EXPECT_EQ(ExtractMimeIntParam(kMime720p, "width"), 1280);
+  EXPECT_EQ(ExtractMimeIntParam(kMime720p, "height"), 720);
+  EXPECT_EQ(ExtractMimeIntParam(kMime720p, "framerate"), 30);
+  EXPECT_EQ(ExtractMimeIntParam(kMime720p, "bitrate"), 2496430);
+  EXPECT_EQ(ExtractMimeIntParam(kMime720p, "channels"), 0);
+
+  // Quoted integer values and whitespace around '='.
+  EXPECT_EQ(ExtractMimeIntParam("video/mp4; width = \"1920\" ; height = 1080",
+                                "width"),
+            1920);
+  EXPECT_EQ(ExtractMimeIntParam("video/mp4; width = \"1920\" ; height = 1080",
+                                "height"),
+            1080);
+
+  // Should not match substrings like "max_height" when searching for "height".
+  EXPECT_EQ(
+      ExtractMimeIntParam("video/mp4; max_height=2160; height=720", "height"),
+      720);
+  EXPECT_EQ(ExtractMimeIntParam("video/mp4; max_height=2160", "height"), 0);
+
+  // Integer overflow clamps to INT_MAX.
+  EXPECT_EQ(
+      ExtractMimeIntParam("video/mp4; width=999999999999999999999", "width"),
+      std::numeric_limits<int>::max());
+}
+
+TEST(SbMediaInterfaceTest, Exceeds720p) {
+  EXPECT_FALSE(Exceeds720p(nullptr));
+  EXPECT_FALSE(Exceeds720p(""));
+
+  // Audio queries (no width/height)
+  EXPECT_FALSE(Exceeds720p("audio/mp4; codecs=\"mp4a.40.2\"; channels=2"));
+  EXPECT_FALSE(Exceeds720p("audio/webm; codecs=\"opus\"; channels=2"));
+  EXPECT_FALSE(Exceeds720p("audio/mp4; codecs=\"ec-3\"; channels=6"));
+  EXPECT_FALSE(Exceeds720p("audio/mp4; codecs=\"ac-3\"; channels=6"));
+  EXPECT_FALSE(Exceeds720p("audio/mp4; codecs=\"iamf.001.001.Opus\""));
+
+  // <= 720p video queries
+  EXPECT_FALSE(Exceeds720p(
+      "video/webm; codecs=\"vp09.00.51.08.01.01.01.01.00\"; width=640; "
+      "height=360; framerate=30; bitrate=280000"));
+  EXPECT_FALSE(
+      Exceeds720p("video/mp4; codecs=\"av01.0.04M.08\"; width=854; height=480; "
+                  "framerate=30; bitrate=787121; eotf=bt709"));
+  EXPECT_FALSE(Exceeds720p(
+      "video/webm; codecs=\"vp09.00.51.08.01.01.01.01.00\"; width=1280; "
+      "height=720; framerate=30; bitrate=1862827; eotf=bt709"));
+  EXPECT_FALSE(
+      Exceeds720p("video/mp4; codecs=\"avc1.4d401f\"; width=1280; height=720; "
+                  "framerate=30; bitrate=2496430"));
+
+  // > 720p video queries
+  EXPECT_TRUE(
+      Exceeds720p("video/mp4; codecs=\"avc1.64002a\"; width=1920; height=1080; "
+                  "framerate=60; bitrate=6933529"));
+  EXPECT_TRUE(Exceeds720p(
+      "video/mp4; codecs=\"av01.0.13M.08\"; width=3840; height=2160; "
+      "framerate=60; bitrate=17443607; eotf=bt709"));
+  EXPECT_TRUE(Exceeds720p(
+      "video/webm; codecs=\"vp09.00.51.08.01.01.01.01.00\"; width=3840; "
+      "height=2160; framerate=60; bitrate=26523399; eotf=bt709"));
+
+  // Boundary checks (721p height or 1281 width)
+  EXPECT_TRUE(
+      Exceeds720p("video/mp4; codecs=\"avc1.640028\"; width=1280; height=721; "
+                  "framerate=30"));
+  EXPECT_TRUE(
+      Exceeds720p("video/mp4; codecs=\"avc1.640028\"; width=1281; height=720; "
+                  "framerate=30"));
+}
+
+TEST(SbMediaInterfaceTest, CapResolutionTo720pFeature) {
+  DefaultSbMediaInterface sb_media;
+
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeature(kCobaltCapResolutionTo720p);
+
+  // > 720p formats must be rejected with kSbMediaSupportTypeNotSupported
+  EXPECT_EQ(sb_media.CanPlayMimeAndKeySystem(
+                "video/mp4; codecs=\"avc1.64002a\"; width=1920; height=1080; "
+                "framerate=60; bitrate=6933529",
+                ""),
+            kSbMediaSupportTypeNotSupported);
+  EXPECT_EQ(sb_media.CanPlayMimeAndKeySystem(
+                "video/mp4; codecs=\"av01.0.13M.08\"; width=3840; height=2160; "
+                "framerate=60; bitrate=17443607; eotf=bt709",
+                ""),
+            kSbMediaSupportTypeNotSupported);
+  EXPECT_EQ(
+      sb_media.CanPlayMimeAndKeySystem(
+          "video/webm; codecs=\"vp09.00.51.08.01.01.01.01.00\"; width=3840; "
+          "height=2160; framerate=60; bitrate=26523399; eotf=bt709",
+          ""),
+      kSbMediaSupportTypeNotSupported);
+}
+
+}  // namespace media


### PR DESCRIPTION
Introduces the `CobaltCapResolutionTo720p` base::Feature flag.
When enabled, `DefaultSbMediaInterface::CanPlayMimeAndKeySystem` checks
the `width` and `height` parameters in the MIME string and returns
`kSbMediaSupportTypeNotSupported` for video formats exceeding 720p
(`width > 1280` or `height > 720`). This causes `MediaSource.isTypeSupported`
to return `false` for >720p representations, allowing ABR to cap video
selection to 720p and below on constrained low-end devices.

Also adds unit tests in `sbmedia_interface_unittest.cc` covering MIME
parameter extraction and 720p resolution capping.

Issue: 557961321