### PR TITLE
media: Restore EGL context on resume after sleep

### DIFF
--- a/media/gpu/starboard/starboard_gpu_factory_impl.cc
+++ b/media/gpu/starboard/starboard_gpu_factory_impl.cc
@@ -49,11 +49,17 @@ void StarboardGpuFactoryImpl::Initialize(base::UnguessableToken channel_token,
                                          int32_t route_id,
                                          base::OnceClosure callback) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  if (stub_) {
+    stub_->RemoveDestructionObserver(this);
+    stub_ = nullptr;
+  }
   stub_ = get_stub_cb_.Run(channel_token, route_id);
   if (stub_) {
     stub_->AddDestructionObserver(this);
   }
-  std::move(callback).Run();
+  if (callback) {
+    std::move(callback).Run();
+  }
 }
 
 void StarboardGpuFactoryImpl::RunSbDecodeTargetFunctionOnGpu(

--- a/media/gpu/starboard/starboard_gpu_factory_impl.cc
+++ b/media/gpu/starboard/starboard_gpu_factory_impl.cc
@@ -49,6 +49,8 @@ void StarboardGpuFactoryImpl::Initialize(base::UnguessableToken channel_token,
                                          int32_t route_id,
                                          base::OnceClosure callback) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  // Unbind destruction observer from previous |stub_| if re-initializing on an
+  // existing instance.
   if (stub_) {
     stub_->RemoveDestructionObserver(this);
     stub_ = nullptr;

--- a/media/mojo/clients/starboard/starboard_renderer_client.cc
+++ b/media/mojo/clients/starboard/starboard_renderer_client.cc
@@ -62,7 +62,8 @@ StarboardRendererClient::StarboardRendererClient(
     RequestOverlayInfoCB request_overlay_info_cb
 #endif  // BUILDFLAG(IS_ANDROID)
     ,
-    bool bypass_mojo_for_media)
+    bool bypass_mojo_for_media,
+    GetGpuFactoriesCB get_gpu_factories_cb)
     : MojoRendererWrapper(std::move(mojo_renderer)),
       media_task_runner_(media_task_runner),
       media_log_(std::move(media_log)),
@@ -72,7 +73,8 @@ StarboardRendererClient::StarboardRendererClient(
       pending_client_extension_receiver_(std::move(client_extension_receiver)),
       client_extension_receiver_(this),
       get_sb_window_handle_callback_(get_sb_window_handle_callback),
-      gpu_factories_(gpu_factories)
+      gpu_factories_(gpu_factories),
+      get_gpu_factories_cb_(std::move(get_gpu_factories_cb))
 #if BUILDFLAG(IS_ANDROID)
       ,
       request_overlay_info_cb_(std::move(request_overlay_info_cb))
@@ -370,10 +372,26 @@ void StarboardRendererClient::OnGpuChannelTokenReady(
     base::OnceClosure complete_cb,
     const base::UnguessableToken& channel_token) {
   DCHECK(media_task_runner_->RunsTasksInCurrentSequence());
+
+  if (!channel_token && get_gpu_factories_cb_) {
+    GpuVideoAcceleratorFactories* fresh_factories = get_gpu_factories_cb_.Run();
+    if (fresh_factories != gpu_factories_) {
+      gpu_factories_ = fresh_factories;
+      if (gpu_factories_) {
+        gpu_factories_->GetChannelToken(base::BindOnce(
+            &StarboardRendererClient::OnGpuChannelTokenReady,
+            weak_factory_.GetWeakPtr(), std::move(command_buffer_id),
+            std::move(complete_cb)));
+        return;
+      }
+    }
+  }
+
   if (channel_token) {
     command_buffer_id = mojom::CommandBufferId::New();
     command_buffer_id->channel_token = std::move(channel_token);
-    command_buffer_id->route_id = gpu_factories_->GetCommandBufferRouteId();
+    command_buffer_id->route_id =
+        gpu_factories_ ? gpu_factories_->GetCommandBufferRouteId() : 0;
   }
   InitAndConstructMojoRenderer(std::move(command_buffer_id),
                                std::move(complete_cb));

--- a/media/mojo/clients/starboard/starboard_renderer_client.cc
+++ b/media/mojo/clients/starboard/starboard_renderer_client.cc
@@ -357,8 +357,8 @@ void StarboardRendererClient::InitAndBindMojoRenderer(
   if (gpu_factories_) {
     gpu_factories_->GetChannelToken(
         base::BindOnce(&StarboardRendererClient::OnGpuChannelTokenReady,
-                       weak_factory_.GetWeakPtr(), std::move(command_buffer_id),
-                       std::move(complete_cb)));
+                       token_request_weak_factory_.GetWeakPtr(),
+                       std::move(command_buffer_id), std::move(complete_cb)));
     return;
   }
 
@@ -378,10 +378,11 @@ void StarboardRendererClient::OnGpuChannelTokenReady(
     if (fresh_factories != gpu_factories_) {
       gpu_factories_ = fresh_factories;
       if (gpu_factories_) {
+        token_request_weak_factory_.InvalidateWeakPtrs();
         gpu_factories_->GetChannelToken(base::BindOnce(
             &StarboardRendererClient::OnGpuChannelTokenReady,
-            weak_factory_.GetWeakPtr(), std::move(command_buffer_id),
-            std::move(complete_cb)));
+            token_request_weak_factory_.GetWeakPtr(),
+            std::move(command_buffer_id), std::move(complete_cb)));
         return;
       }
     }

--- a/media/mojo/clients/starboard/starboard_renderer_client.h
+++ b/media/mojo/clients/starboard/starboard_renderer_client.h
@@ -207,6 +207,8 @@ class MEDIA_EXPORT StarboardRendererClient
   // NOTE: Do not add member variables after weak_factory_
   // It should be the first one destroyed among all members.
   // See base/memory/weak_ptr.h.
+  base::WeakPtrFactory<StarboardRendererClient> token_request_weak_factory_{
+      this};
   base::WeakPtrFactory<StarboardRendererClient> weak_factory_{this};
 };
 

--- a/media/mojo/clients/starboard/starboard_renderer_client.h
+++ b/media/mojo/clients/starboard/starboard_renderer_client.h
@@ -57,6 +57,8 @@ class MEDIA_EXPORT StarboardRendererClient
  public:
   using RendererExtension = mojom::StarboardRendererExtension;
   using ClientExtension = media::mojom::StarboardRendererClientExtension;
+  using GetGpuFactoriesCB =
+      base::RepeatingCallback<GpuVideoAcceleratorFactories*()>;
 
   StarboardRendererClient(
       const scoped_refptr<base::SequencedTaskRunner>& media_task_runner,
@@ -73,7 +75,8 @@ class MEDIA_EXPORT StarboardRendererClient
       RequestOverlayInfoCB request_overlay_info_cb
 #endif  // BUILDFLAG(IS_ANDROID)
       ,
-      bool bypass_mojo_for_media = false);
+      bool bypass_mojo_for_media = false,
+      GetGpuFactoriesCB get_gpu_factories_cb = GetGpuFactoriesCB());
 
   StarboardRendererClient(const StarboardRendererClient&) = delete;
   StarboardRendererClient& operator=(const StarboardRendererClient&) = delete;
@@ -170,6 +173,7 @@ class MEDIA_EXPORT StarboardRendererClient
   mojo::Receiver<ClientExtension> client_extension_receiver_;
   const GetSbWindowHandleCallback get_sb_window_handle_callback_;
   raw_ptr<GpuVideoAcceleratorFactories> gpu_factories_ = nullptr;
+  GetGpuFactoriesCB get_gpu_factories_cb_;
 #if BUILDFLAG(IS_ANDROID)
   RequestOverlayInfoCB request_overlay_info_cb_;
 #endif  // BUILDFLAG(IS_ANDROID)

--- a/media/mojo/clients/starboard/starboard_renderer_client_factory.cc
+++ b/media/mojo/clients/starboard/starboard_renderer_client_factory.cc
@@ -126,7 +126,8 @@ std::unique_ptr<Renderer> StarboardRendererClientFactory::CreateRenderer(
       std::move(request_overlay_info_cb)
 #endif  // BUILDFLAG(IS_ANDROID)
           ,
-      config.experimental_features.GetBool(kMediaBypassMojoForMedia));
+      config.experimental_features.GetBool(kMediaBypassMojoForMedia),
+      get_gpu_factories_cb_);
 }
 
 }  // namespace media

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.cc
@@ -339,16 +339,18 @@ void StarboardRendererWrapper::OnGpuChannelTokenReady(
   current_shared_image_ = nullptr;
   last_texture_service_ids_.clear();
 
+  // Forward token updates (e.g. after sleep/wake context loss) to update
+  // |stub_| on the GPU thread.
+  base::UnguessableToken channel_token;
+  int32_t route_id = 0;
   if (command_buffer_id_) {
-    GetGpuFactory()
-        ->AsyncCall(&StarboardGpuFactory::Initialize)
-        .WithArgs(command_buffer_id_->channel_token,
-                  command_buffer_id_->route_id, base::NullCallback());
-  } else {
-    GetGpuFactory()
-        ->AsyncCall(&StarboardGpuFactory::Initialize)
-        .WithArgs(base::UnguessableToken(), 0, base::NullCallback());
+    channel_token = command_buffer_id_->channel_token;
+    route_id = command_buffer_id_->route_id;
   }
+
+  GetGpuFactory()
+      ->AsyncCall(&StarboardGpuFactory::Initialize)
+      .WithArgs(std::move(channel_token), route_id, base::NullCallback());
 }
 
 void StarboardRendererWrapper::GetCurrentVideoFrame(

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.cc
@@ -334,6 +334,21 @@ void StarboardRendererWrapper::OnGpuChannelTokenReady(
     mojom::CommandBufferIdPtr command_buffer_id) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
   command_buffer_id_ = std::move(command_buffer_id);
+
+  // Clear cached shared image and texture service IDs from previous context.
+  current_shared_image_ = nullptr;
+  last_texture_service_ids_.clear();
+
+  if (command_buffer_id_) {
+    GetGpuFactory()
+        ->AsyncCall(&StarboardGpuFactory::Initialize)
+        .WithArgs(command_buffer_id_->channel_token,
+                  command_buffer_id_->route_id, base::NullCallback());
+  } else {
+    GetGpuFactory()
+        ->AsyncCall(&StarboardGpuFactory::Initialize)
+        .WithArgs(base::UnguessableToken(), 0, base::NullCallback());
+  }
 }
 
 void StarboardRendererWrapper::GetCurrentVideoFrame(

--- a/media/mojo/services/starboard/starboard_renderer_wrapper_unittest.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper_unittest.cc
@@ -137,7 +137,9 @@ class MockStarboardGpuFactory : public StarboardGpuFactory {
   void Initialize(base::UnguessableToken channel_token,
                   int32_t route_id,
                   base::OnceClosure callback) override {
-    std::move(callback).Run();
+    if (callback) {
+      std::move(callback).Run();
+    }
   }
 
   void RunSbDecodeTargetFunctionOnGpu(


### PR DESCRIPTION
Update the StarboardRendererWrapper and client to properly restore
the EGL context after a sleep event. This ensures that the renderer
can obtain a fresh GPU channel token and re-initialize the GPU
factory with a valid token when the previous context is lost.
To prevent race conditions where multiple requests to receive
the GPU token occur, we also add a weak pointer,
`token_request_weak_feactory_` to terminate any pending token
calls when a new instance occurs.

The change also clears cached shared images and texture service IDs
from the previous context to prevent the use of stale resources.

This change also updates the StarboardRendererWrapper test to
ensure that the mock GPUFactory can safely handle null callbacks.

Bug: 555127326