### PR TITLE
ci: restrict GITHUB_TOKEN to contents: read in autoroll workflows

### DIFF
--- a/.github/workflows/autoroll_chromium.yaml
+++ b/.github/workflows/autoroll_chromium.yaml
@@ -23,9 +23,7 @@ jobs:
       GIT_COMMITTER_NAME: "cobalt-github-releaser-bot"
       GIT_COMMITTER_EMAIL: "cobalt-github-releaser-bot@google.com"
     permissions:
-      contents: write
-      pull-requests: write
-      actions: write
+      contents: read
     defaults:
       run:
         working-directory: src

--- a/.github/workflows/autoroll_main.yaml
+++ b/.github/workflows/autoroll_main.yaml
@@ -22,8 +22,7 @@ jobs:
       GIT_COMMITTER_NAME: "cobalt-github-releaser-bot"
       GIT_COMMITTER_EMAIL: "cobalt-github-releaser-bot@google.com"
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     defaults:
       run:
         working-directory: src


### PR DESCRIPTION
### Summary
This PR restricts the default `GITHUB_TOKEN` permissions to `contents: read` in `.github/workflows/autoroll_chromium.yaml` and `.github/workflows/autoroll_main.yaml`, following the principle of least privilege and resolving GitHub Code Scanning alerts [#2114](https://github.com/youtube/cobalt/security/code-scanning/2114) and [#2115](https://github.com/youtube/cobalt/security/code-scanning/2115).

### Rationale
Both autoroll workflows use `secrets.CHERRY_PICK_TOKEN` for `actions/checkout`, `git push`, and all GitHub CLI / API commands (`gh pr list`, `gh pr view`, `gh pr create`, `gh api`). The ambient `GITHUB_TOKEN` is never used for write operations. Declaring write permissions on the ambient token is unnecessary and triggers Token-Permissions security alerts.

Tag: agy
Conv: 3255f0f1-2d74-4738-8c96-5d0daf5251ed
Bug: 559260716