### PR TITLE
ci: Install google-java-format in pre-commit container and enforce check in CI

### DIFF
--- a/cobalt/docker/pre-commit/Dockerfile
+++ b/cobalt/docker/pre-commit/Dockerfile
@@ -7,11 +7,18 @@ ARG BASE_IMAGE_SHA=sha256:be15f84c44c4ee68b4f187128f0278df1b0f424c04fb5f08b09896
 FROM marketplace.gcr.io/google/debian12@${BASE_IMAGE_SHA}
 
 ### Install dependencies.
+ARG GJF_VERSION=1.24.0
+ARG GJF_SHA256=7ad0e533221a38bd485245305e133c9965b94669cbb2e6da81d54eda8bd9a055
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
     git \
     gn \
     python3 \
     python3-pip \
+    && curl -fsSL --retry 3 --retry-connrefused "https://github.com/google/google-java-format/releases/download/v${GJF_VERSION}/google-java-format_linux-x86-64" -o /usr/local/bin/google-java-format \
+    && echo "${GJF_SHA256}  /usr/local/bin/google-java-format" | sha256sum -c - \
+    && chmod +x /usr/local/bin/google-java-format \
     && rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 COPY requirements.txt /tmp/
 RUN python3 -m pip install --no-cache-dir --break-system-packages --require-hashes -r /tmp/requirements.txt \

--- a/cobalt/precommit/google_java_format_wrapper.py
+++ b/cobalt/precommit/google_java_format_wrapper.py
@@ -15,7 +15,9 @@
 # limitations under the License.
 """Wrapper to run google-java-format tool."""
 
+import os
 import platform
+import shutil
 import subprocess
 import sys
 
@@ -23,9 +25,19 @@ if __name__ == '__main__':
   if platform.system() != 'Linux':
     sys.exit(0)
 
+  gjf = (
+      shutil.which('google-java-format') or
+      shutil.which('google-java-format', path='/usr/bin'))
+  if not gjf:
+    if os.environ.get('CI') == 'true':
+      print('google-java-format not found in CI.', file=sys.stderr)
+      sys.exit(1)
+    print('google-java-format not found, skipping.')
+    sys.exit(0)
+
   google_java_format_args = sys.argv[1:]
   try:
-    sys.exit(subprocess.call(['google-java-format'] + google_java_format_args))
+    sys.exit(subprocess.call([gjf] + google_java_format_args))
   except FileNotFoundError:
     print('google-java-format not found, skipping.')
     sys.exit(0)


### PR DESCRIPTION
### Changes
* **Install standalone `google-java-format` in pre-commit Docker container**:
  - In `cobalt/docker/pre-commit/Dockerfile`, installs `ca-certificates` and `curl`, downloads the standalone `google-java-format` native binary (v1.24.0) with SHA-256 verification directly to `/usr/local/bin/google-java-format`.
  - Uses `--retry 3 --retry-connrefused` to guard against transient download flakiness.
* **Locate binary and enforce check in CI**:
  - In `cobalt/precommit/google_java_format_wrapper.py`, locates the binary using `shutil.which('google-java-format')` (with fallback to `/usr/bin/google-java-format`).
  - If the binary is not found:
    - Fails with exit code 1 when `CI == 'true'` (`google-java-format not found in CI.`) so unformatted Java files cannot silently pass in CI workflows.
    - Exits 0 with a skip message in local non-CI environments if uninstalled.

TAG=agy
CONV=78cf5b91-1d69-423a-b8de-13b62fcff854
Fix: 559164645