### PR TITLE
Cache user agent only after FeatureList has been initialized

### DIFF
--- a/cobalt/browser/cobalt_content_browser_client.cc
+++ b/cobalt/browser/cobalt_content_browser_client.cc
@@ -15,6 +15,7 @@
 #include "cobalt/browser/cobalt_content_browser_client.h"
 
 #include <string>
+#include <atomic>
 
 #include "base/base_switches.h"
 #include "base/command_line.h"
@@ -203,8 +204,14 @@ static void JNI_CobaltContentBrowserClient_DispatchFocus(JNIEnv*) {
 
 std::string GetCobaltUserAgent() {
   const UserAgentPlatformInfo platform_info;
-  static const std::string user_agent_str = platform_info.ToString();
-  return user_agent_str;
+  if (base::FeatureList::GetInstance()) {
+    static const std::string user_agent_str = platform_info.ToString();
+    return user_agent_str;
+  }
+  static std::atomic<int> pre_feature_list_call_count{0};
+  base::UmaHistogramCounts100("Cobalt.UserAgent.PreFeatureListCallCount",
+                              ++pre_feature_list_call_count);
+  return platform_info.ToString();
 }
 
 blink::UserAgentMetadata GetCobaltUserAgentMetadata() {

--- a/cobalt/browser/cobalt_content_browser_client_unittest.cc
+++ b/cobalt/browser/cobalt_content_browser_client_unittest.cc
@@ -14,11 +14,16 @@
 
 #include "cobalt/browser/cobalt_content_browser_client.h"
 
+#include <memory>
 #include <string>
 #include <variant>
 
+#include "base/feature_list.h"
+#include "base/test/metrics/histogram_tester.h"
+#include "base/test/scoped_feature_list.h"
 #include "base/test/task_environment.h"
 #include "build/build_config.h"
+#include "cobalt/browser/features.h"
 #include "cobalt/browser/global_features.h"
 #include "content/public/browser/overlay_window.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -63,6 +68,56 @@ TEST_F(CobaltContentBrowserClientTest,
 #else
   EXPECT_EQ(window, nullptr);
 #endif
+}
+
+TEST_F(CobaltContentBrowserClientTest,
+       GetUserAgentDefersCachingUntilFeatureListInitialized) {
+  std::unique_ptr<base::FeatureList> prev_feature_list =
+      base::FeatureList::ClearInstanceForTesting();
+
+  CobaltContentBrowserClient client(/*startup_timestamp=*/absl::nullopt,
+                                    /*deep_link=*/"",
+                                    /*is_visible=*/true);
+  base::HistogramTester histogram_tester;
+
+  // When FeatureList is null, dynamic UA is returned without the Finch token,
+  // static caching is deferred, and PreFeatureListCallCount is logged to UMA.
+  std::string ua_pre1 = client.GetUserAgent();
+  EXPECT_FALSE(ua_pre1.empty());
+  EXPECT_EQ(ua_pre1.find("Finch/"), std::string::npos);
+  histogram_tester.ExpectTotalCount("Cobalt.UserAgent.PreFeatureListCallCount",
+                                    1);
+
+  std::string ua_pre2 = client.GetUserAgent();
+  EXPECT_FALSE(ua_pre2.empty());
+  histogram_tester.ExpectTotalCount("Cobalt.UserAgent.PreFeatureListCallCount",
+                                    2);
+
+  // Initialize FeatureList with the Finch token feature enabled.
+  {
+    base::test::ScopedFeatureList scoped_feature_list;
+    scoped_feature_list.InitAndEnableFeatureWithParameters(
+        features::kEnableUserAgentFinchToken,
+        {{features::kUserAgentFinchTokenParam.name, "finch_test_token"}});
+
+    // With FeatureList initialized, UA contains the Finch token and is cached.
+    // PreFeatureListCallCount UMA metric should not be logged.
+    std::string ua_post1 = client.GetUserAgent();
+    EXPECT_FALSE(ua_post1.empty());
+    EXPECT_NE(ua_post1.find("Finch/finch_test_token"), std::string::npos);
+    histogram_tester.ExpectTotalCount("Cobalt.UserAgent.PreFeatureListCallCount",
+                                      2);
+
+    // Subsequent calls return the cached UA string.
+    std::string ua_post2 = client.GetUserAgent();
+    EXPECT_EQ(ua_post1, ua_post2);
+    histogram_tester.ExpectTotalCount("Cobalt.UserAgent.PreFeatureListCallCount",
+                                      2);
+  }
+
+  if (prev_feature_list) {
+    base::FeatureList::RestoreInstanceForTesting(std::move(prev_feature_list));
+  }
 }
 
 }  // namespace

--- a/tools/metrics/histograms/metadata/cobalt/histograms.xml
+++ b/tools/metrics/histograms/metadata/cobalt/histograms.xml
@@ -587,6 +587,16 @@ Always run the pretty print utility on this file after editing:
   </summary>
 </histogram>
 
+<histogram name="Cobalt.UserAgent.PreFeatureListCallCount" units="calls"
+    expires_after="never">
+  <owner>vmo@google.com</owner>
+  <summary>
+    Records the number of times GetCobaltUserAgent() is called before
+    base::FeatureList is initialized (i.e. when FeatureList::GetInstance() is
+    null).
+  </summary>
+</histogram>
+
 <histogram name="Cobalt.WebContentsObserver.FailedNavigation" enum="Boolean"
     expires_after="never">
   <owner>charleykim@google.com</owner>


### PR DESCRIPTION
Also add UMA logging to detect how often user agent is retrieved when FeatureList has not been initialized yet.

Bug: 549296516