### PR TITLE
media: Record historical video download throughput

### DIFF
--- a/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
@@ -35,6 +35,7 @@
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
 #include "media/starboard/decoder_buffer_allocator.h"
+#include "third_party/blink/renderer/platform/loader/fetch/resource_fetcher.h"
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 namespace blink {
@@ -188,6 +189,14 @@ ScriptPromise<IDLUndefined> H5vccSettings::set(
         script_state, exception_context, name, *value, [](int int_value) {
           ::media::SetVideoBufferSizeReductionPercent(int_value);
           return true;
+        });
+  }
+  if (name == "Media.RecordVideoDownloadThroughput") {
+    return ProcessSettingAs<bool>(
+        script_state, exception_context, name, *value,
+        [](bool enable) -> Result {
+          ResourceFetcher::SetRecordVideoDownloadThroughput(enable);
+          return base::ok();
         });
   }
 #else   // BUILDFLAG(USE_STARBOARD_MEDIA)

--- a/third_party/blink/renderer/modules/mediasource/media_source.cc
+++ b/third_party/blink/renderer/modules/mediasource/media_source.cc
@@ -63,6 +63,7 @@
 #include "build/build_config.h"
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
 #include "media/base/starboard/sbmedia_interface.h"
+#include "third_party/blink/renderer/platform/loader/fetch/resource_fetcher.h"
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 using blink::WebMediaSource;
@@ -601,6 +602,13 @@ bool MediaSource::IsTypeSupportedInternal(ExecutionContext* context,
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   // Interupt Chromium's IsTypeSupported() from here for better performance.
+  std::optional<double> median_throughput_kbps =
+      ResourceFetcher::GetMedianVideoDownloadThroughputKbps();
+  if (median_throughput_kbps.has_value()) {
+    LOG(INFO) << "MediaSource::isTypeSupported: median_throughput_kbps="
+              << *median_throughput_kbps << " ("
+              << (*median_throughput_kbps / 1000.0) << " Mbps)";
+  }
   auto ascii = type.Ascii();
   SbMediaSupportType support_type =
       ::media::GetSbMediaInterface()->CanPlayMimeAndKeySystem(ascii.c_str(),

--- a/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.cc
+++ b/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.cc
@@ -33,6 +33,11 @@
 #include <string>
 #include <string_view>
 #include <utility>
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+#include <atomic>
+#include <deque>
+#include <vector>
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 #include "base/auto_reset.h"
 #include "base/containers/contains.h"
@@ -109,11 +114,48 @@
 #include "third_party/blink/renderer/platform/wtf/text/wtf_string.h"
 #include "third_party/blink/renderer/platform/wtf/wtf.h"
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+#include "base/no_destructor.h"
+#include "base/synchronization/lock.h"
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+
 namespace blink {
 
 constexpr uint32_t ResourceFetcher::kKeepaliveInflightBytesQuota;
 
 namespace {
+
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+constexpr size_t kMaxThroughputSamples = 20;
+
+std::atomic<bool> g_record_video_download_throughput{false};
+std::atomic<double> g_median_video_download_throughput_kbps{-1.0};
+
+void RecordVideoDownloadThroughputKbps(double throughput_kbps) {
+  static base::NoDestructor<base::Lock> lock;
+  static base::NoDestructor<std::deque<double>> samples;
+  base::AutoLock auto_lock(*lock);
+
+  samples->push_back(throughput_kbps);
+  if (samples->size() > kMaxThroughputSamples) {
+    samples->pop_front();
+  }
+
+  std::vector<double> sorted(samples->begin(), samples->end());
+  const size_t n = sorted.size();
+  const size_t mid = n / 2;
+  std::nth_element(sorted.begin(), sorted.begin() + mid, sorted.end());
+  double median = sorted[mid];
+  if (n % 2 == 0) {
+    const double upper_mid = sorted[mid];
+    std::nth_element(sorted.begin(), sorted.begin() + (mid - 1),
+                     sorted.begin() + mid);
+    median = (sorted[mid - 1] + upper_mid) / 2.0;
+  }
+  g_median_video_download_throughput_kbps.store(median,
+                                                std::memory_order_relaxed);
+}
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 constexpr base::TimeDelta kKeepaliveLoadersTimeout = base::Seconds(30);
 
@@ -493,6 +535,23 @@ mojom::blink::RequestContextType ResourceFetcher::DetermineRequestContext(
   }
   NOTREACHED();
 }
+
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+// static
+void ResourceFetcher::SetRecordVideoDownloadThroughput(bool enable) {
+  g_record_video_download_throughput.store(enable, std::memory_order_relaxed);
+}
+
+// static
+std::optional<double> ResourceFetcher::GetMedianVideoDownloadThroughputKbps() {
+  if (!g_record_video_download_throughput.load(std::memory_order_relaxed)) {
+    return std::nullopt;
+  }
+  double median = g_median_video_download_throughput_kbps.load(
+      std::memory_order_relaxed);
+  return median >= 0.0 ? std::make_optional(median) : std::nullopt;
+}
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 network::mojom::RequestDestination ResourceFetcher::DetermineRequestDestination(
     ResourceType type) {
@@ -2527,6 +2586,22 @@ void ResourceFetcher::HandleLoaderFinish(Resource* resource,
 
   const int64_t encoded_data_length =
       resource->GetResponse().EncodedDataLength();
+
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  if (g_record_video_download_throughput.load(std::memory_order_relaxed) &&
+      encoded_data_length >= 65536 &&
+      resource->Url().Host().ToString().EndsWith("googlevideo.com") &&
+      resource->GetResponse().GetResourceLoadTiming()) {
+    base::TimeTicks headers_end =
+        resource->GetResponse().GetResourceLoadTiming()->ReceiveHeadersEnd();
+    base::TimeDelta body_duration = response_end - headers_end;
+    if (body_duration.is_positive()) {
+      double throughput_kbps =
+          (encoded_data_length * 8.0) / body_duration.InSecondsF() / 1000.0;
+      RecordVideoDownloadThroughputKbps(throughput_kbps);
+    }
+  }
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   PendingResourceTimingInfo info = resource_timing_info_map_.Take(resource);
   if (!info.is_null()) {

--- a/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.h
+++ b/third_party/blink/renderer/platform/loader/fetch/resource_fetcher.h
@@ -34,6 +34,7 @@
 
 #include "base/task/single_thread_task_runner.h"
 #include "base/unguessable_token.h"
+#include "build/build_config.h"
 #include "services/metrics/public/cpp/mojo_ukm_recorder.h"
 #include "third_party/blink/public/common/features.h"
 #include "third_party/blink/public/common/subresource_load_metrics.h"
@@ -197,6 +198,14 @@ class PLATFORM_EXPORT ResourceFetcher
 
   Resource* CachedResource(const KURL&) const;
   bool ResourceHasBeenEmulatedLoadStartedForInspector(const KURL&) const;
+
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  static void SetRecordVideoDownloadThroughput(bool enable);
+  // Returns the median throughput (in kbps) of the last 20 completed
+  // googlevideo.com downloads (>= 64 KB) in O(1) time, or std::nullopt if no
+  // samples have been recorded yet or tracking is disabled.
+  static std::optional<double> GetMedianVideoDownloadThroughputKbps();
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   // Registers an callback to be called with the resource priority of the fetch
   // made to the specified URL. When `new_load_only` is set to false,


### PR DESCRIPTION
Introduce a mechanism to track and calculate the median download
throughput for video segments fetched from googlevideo.com. This
implementation maintains a rolling window of the 20 most recent
samples to provide a stable measurement of network performance.

A new H5VCC setting, Media.RecordVideoDownloadThroughput, is added to
control this feature. The median throughput is used to inform media
type support checks and is reported via UMA histograms for telemetry
analysis.

Bug: 557961321