### PR TITLE
build: Remove obsolete ARM binutils

### DIFF
--- a/cobalt/docker/linux/Dockerfile
+++ b/cobalt/docker/linux/Dockerfile
@@ -39,10 +39,3 @@ RUN cd /tmp \
     && tar xf "${GCLOUD}" -C /usr/local --strip-components=1 google-cloud-sdk/bin google-cloud-sdk/lib \
     && rm "${GCLOUD}" \
     && gcloud --version
-
-# binutils* needed for evergreen
-RUN apt update -qqy \
-    && apt install -qqy --no-install-recommends \
-        binutils-aarch64-linux-gnu \
-        binutils-arm-linux-gnueabi \
-    && rm -rf /var/lib/apt/lists/*

--- a/cobalt/docker/rdk/Dockerfile
+++ b/cobalt/docker/rdk/Dockerfile
@@ -64,8 +64,6 @@ RUN apt update -qqy \
         g++-multilib \
         bzip2 \
         libxml2 \
-        binutils-aarch64-linux-gnu \
-        binutils-arm-linux-gnueabi \
         libglib2.0-dev \
         pkg-config \
         libtool \

--- a/cobalt/site/docs/development/setup-aosp.md
+++ b/cobalt/site/docs/development/setup-aosp.md
@@ -11,14 +11,7 @@ Before following these instructions, make sure you have set up your workstation 
 
 1. Follow all steps in [Set up your environment - Linux](setup-linux.md) to install basic system dependencies, `depot_tools`, clone the Cobalt repository, and run `build/install-build-deps.sh`.
 
-2. Install host binutils packages for ARM cross-compilation symbol stripping:
-
-   ```bash
-   sudo apt install -y binutils-arm-linux-gnueabi    # For 32-bit aosp-arm
-   # sudo apt install -y binutils-aarch64-linux-gnu # For 64-bit aosp-arm64
-   ```
-
-3. Ensure your root `.gclient` file includes `android` in `target_os`:
+2. Ensure your root `.gclient` file includes `android` in `target_os`:
 
    ```python
    target_os = [ 'linux', 'android' ]
@@ -31,7 +24,7 @@ Before following these instructions, make sure you have set up your workstation 
    gclient sync
    ```
 
-4. Set up an Android debug keystore required for signing development APKs:
+3. Set up an Android debug keystore required for signing development APKs:
 
    ```bash
    keytool -genkey -v -keystore ~/.android/debug.keystore -storepass android -alias androiddebugkey -keypass android -keyalg RSA -keysize 2048 -validity 10000

--- a/cobalt/site/docs/development/setup-rdk.md
+++ b/cobalt/site/docs/development/setup-rdk.md
@@ -93,9 +93,6 @@ cd ~/chromium/src
 # Run installer
 ./build/install-build-deps.sh
 
-# Install host binutils for ARM
-sudo apt-get update && sudo apt-get install -y binutils-arm-linux-gnueabi
-
 # Install sysroot for ARM
 python3 build/linux/sysroot_scripts/install-sysroot.py --arch=arm
 ```


### PR DESCRIPTION
The cross binutils packages were only required for the strip tool of
the Evergreen toolchains. https://github.com/youtube/cobalt/pull/11799 ("build:
Use llvm-strip for hermetic Linux builds") replaced that with llvm-strip
from the bundled clang toolchain.

Remove the outdated install instructions from setup-aosp.md and setup-rdk.md, and remove the corresponding packages from the Linux and RDK Dockerfiles.

Bug: 526434311