### PR TITLE
[POC] media: Deduplicate GPU callback execution methods

### DIFF
--- a/media/gpu/starboard/starboard_gpu_factory.h
+++ b/media/gpu/starboard/starboard_gpu_factory.h
@@ -22,7 +22,6 @@
 #include "base/unguessable_token.h"
 #include "gpu/ipc/service/command_buffer_stub.h"
 #include "gpu/ipc/service/gpu_channel_shared_image_interface.h"
-#include "starboard/decode_target.h"
 #include "ui/gfx/color_space.h"
 #include "ui/gfx/geometry/size.h"
 
@@ -48,13 +47,8 @@ class StarboardGpuFactory : public gpu::CommandBufferStub::DestructionObserver {
   virtual void Initialize(base::UnguessableToken channel_token,
                           int32_t route_id,
                           base::OnceClosure callback) = 0;
-  virtual void RunSbDecodeTargetFunctionOnGpu(
-      SbDecodeTargetGlesContextRunnerTarget target_function,
-      void* target_function_context,
-      base::WaitableEvent* done_event) = 0;
-  virtual void RunCallbackOnGpu(base::OnceCallback<void()> callback,
-                                base::WaitableEvent* done_event) = 0;
-  virtual void PostCallbackToGpu(base::OnceCallback<void()> callback) = 0;
+  virtual void RunWithGlesContext(base::OnceClosure callback,
+                                  base::WaitableEvent* done_event) = 0;
   virtual void CreateImageOnGpu(
       const gfx::Size& coded_size,
       const gfx::ColorSpace& color_space,

--- a/media/gpu/starboard/starboard_gpu_factory_impl.cc
+++ b/media/gpu/starboard/starboard_gpu_factory_impl.cc
@@ -56,34 +56,16 @@ void StarboardGpuFactoryImpl::Initialize(base::UnguessableToken channel_token,
   std::move(callback).Run();
 }
 
-void StarboardGpuFactoryImpl::RunSbDecodeTargetFunctionOnGpu(
-    SbDecodeTargetGlesContextRunnerTarget target_function,
-    void* target_function_context,
-    base::WaitableEvent* done_event) {
-  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-  if (MakeContextCurrent(stub_)) {
-    target_function(target_function_context);
-  }
-  done_event->Signal();
-}
-
-void StarboardGpuFactoryImpl::RunCallbackOnGpu(
-    base::OnceCallback<void()> callback,
+void StarboardGpuFactoryImpl::RunWithGlesContext(
+    base::OnceClosure callback,
     base::WaitableEvent* done_event) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
   if (MakeContextCurrent(stub_)) {
     std::move(callback).Run();
   }
-  done_event->Signal();
-}
-
-void StarboardGpuFactoryImpl::PostCallbackToGpu(
-    base::OnceCallback<void()> callback) {
-  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-  if (!MakeContextCurrent(stub_)) {
-    return;
+  if (done_event) {
+    done_event->Signal();
   }
-  std::move(callback).Run();
 }
 
 void StarboardGpuFactoryImpl::CreateImageOnGpu(

--- a/media/gpu/starboard/starboard_gpu_factory_impl.cc
+++ b/media/gpu/starboard/starboard_gpu_factory_impl.cc
@@ -62,6 +62,8 @@ void StarboardGpuFactoryImpl::RunWithGlesContext(
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
   if (MakeContextCurrent(stub_)) {
     std::move(callback).Run();
+  } else {
+    LOG(ERROR) << "Failed to make context current on GPU thread";
   }
   if (done_event) {
     done_event->Signal();

--- a/media/gpu/starboard/starboard_gpu_factory_impl.cc
+++ b/media/gpu/starboard/starboard_gpu_factory_impl.cc
@@ -82,25 +82,47 @@ void StarboardGpuFactoryImpl::CreateImageOnGpu(
     scoped_refptr<gpu::RefCountedLock> drdc_lock,
 #endif  // BUILDFLAG(IS_ANDROID)
     base::WaitableEvent* done_event) {
-  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-  if (MakeContextCurrent(stub_)) {
-    DCHECK_EQ(texture_service_ids.size(), texture_targets.size());
-
-    scoped_refptr<gpu::GpuChannelSharedImageInterface>
-        gpu_channel_shared_image_interface =
-            stub_->channel()->shared_image_stub()->shared_image_interface();
-
-    shared_image = gpu_channel_shared_image_interface
-                       ->CreateSharedImageForStarboardGLTexture(
-                           format, coded_size, color_space, texture_service_ids,
-                           texture_targets, decode_target
+  RunWithGlesContext(
+      base::BindOnce(
+          [](StarboardGpuFactoryImpl* self, const gfx::Size& coded_size,
+             const gfx::ColorSpace& color_space, viz::SharedImageFormat format,
+             scoped_refptr<gpu::ClientSharedImage>& shared_image,
+             const std::vector<uint32_t>& texture_service_ids,
+             const std::vector<uint32_t>& texture_targets,
+             uint64_t decode_target
 #if BUILDFLAG(IS_ANDROID)
-                           ,
-                           std::move(drdc_lock)
-#endif
-                       );
-  }
-  done_event->Signal();
+             ,
+             scoped_refptr<gpu::RefCountedLock> drdc_lock
+#endif  // BUILDFLAG(IS_ANDROID)
+          ) {
+            DCHECK_EQ(texture_service_ids.size(), texture_targets.size());
+
+            scoped_refptr<gpu::GpuChannelSharedImageInterface>
+                gpu_channel_shared_image_interface =
+                    self->stub_->channel()
+                        ->shared_image_stub()
+                        ->shared_image_interface();
+
+            shared_image =
+                gpu_channel_shared_image_interface
+                    ->CreateSharedImageForStarboardGLTexture(
+                        format, coded_size, color_space, texture_service_ids,
+                        texture_targets, decode_target
+#if BUILDFLAG(IS_ANDROID)
+                        ,
+                        std::move(drdc_lock)
+#endif  // BUILDFLAG(IS_ANDROID)
+                    );
+          },
+          base::Unretained(this), coded_size, color_space, format,
+          std::ref(shared_image), std::cref(texture_service_ids),
+          std::cref(texture_targets), decode_target
+#if BUILDFLAG(IS_ANDROID)
+          ,
+          std::move(drdc_lock)
+#endif  // BUILDFLAG(IS_ANDROID)
+              ),
+      done_event);
 }
 
 void StarboardGpuFactoryImpl::OnWillDestroyStub(bool /*have_context*/) {

--- a/media/gpu/starboard/starboard_gpu_factory_impl.h
+++ b/media/gpu/starboard/starboard_gpu_factory_impl.h
@@ -33,13 +33,8 @@ class StarboardGpuFactoryImpl : public StarboardGpuFactory {
   void Initialize(base::UnguessableToken channel_token,
                   int32_t route_id,
                   base::OnceClosure callback) override;
-  void RunSbDecodeTargetFunctionOnGpu(
-      SbDecodeTargetGlesContextRunnerTarget target_function,
-      void* target_function_context,
-      base::WaitableEvent* done_event) override;
-  void RunCallbackOnGpu(base::OnceCallback<void()> callback,
-                        base::WaitableEvent* done_event) override;
-  void PostCallbackToGpu(base::OnceCallback<void()> callback) override;
+  void RunWithGlesContext(base::OnceClosure callback,
+                          base::WaitableEvent* done_event) override;
   void CreateImageOnGpu(const gfx::Size& coded_size,
                         const gfx::ColorSpace& color_space,
                         viz::SharedImageFormat format,

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.cc
@@ -734,12 +734,7 @@ void StarboardRendererWrapper::GraphicsContextRunner(
   if (!provider || !provider->is_gpu_factory_initialized_) {
     return;
   }
-  if (provider->gpu_task_runner_->RunsTasksInCurrentSequence()) {
-    // If it is on the gpu thread, post target_function() directly on it.
-    target_function(target_function_context);
-  } else if (provider->gpu_factory_) {
-    // If it is not on the gpu thread, post target_function() with
-    // |gpu_factory_|.
+  if (provider->gpu_factory_) {
     base::WaitableEvent done_event(
         base::WaitableEvent::ResetPolicy::MANUAL,
         base::WaitableEvent::InitialState::NOT_SIGNALED);

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.cc
@@ -348,13 +348,41 @@ void StarboardRendererWrapper::OnGpuChannelTokenReady(
 void StarboardRendererWrapper::GetCurrentVideoFrame(
     GetCurrentVideoFrameCallback callback) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-  PostGpuTaskWithGlesContextAndWait(
-      base::BindOnce(&StarboardRendererWrapper::GetCurrentDecodeTarget,
-                     base::Unretained(this)));
-  if (!SbDecodeTargetIsValid(decode_target_)) {
+  auto target_holder = std::make_unique<SbDecodeTarget>(kSbDecodeTargetInvalid);
+  auto* target_ptr = target_holder.get();
+  GetGpuFactory()
+      ->AsyncCall(&StarboardGpuFactory::RunWithGlesContext)
+      .WithArgs(
+          base::BindOnce(
+              [](StarboardRenderer* renderer, SbDecodeTarget* out_target) {
+                *out_target = renderer->GetSbDecodeTarget();
+              },
+              base::Unretained(GetRenderer()), target_ptr),
+          /*done_event=*/nullptr)
+      .Then(base::BindOnce(
+          [](base::WeakPtr<StarboardRendererWrapper> self,
+             std::unique_ptr<SbDecodeTarget> holder,
+             GetCurrentVideoFrameCallback callback) {
+            if (!self) {
+              std::move(callback).Run(nullptr);
+              return;
+            }
+            self->OnDecodeTargetReady(*holder, std::move(callback));
+          },
+          weak_factory_.GetWeakPtr(), std::move(target_holder),
+          std::move(callback)));
+}
+
+void StarboardRendererWrapper::OnDecodeTargetReady(
+    SbDecodeTarget decode_target,
+    GetCurrentVideoFrameCallback callback) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  if (!SbDecodeTargetIsValid(decode_target)) {
     std::move(callback).Run(current_frame_);
     return;
   }
+
+  decode_target_ = decode_target;
 
   auto info = std::make_unique<SbDecodeTargetInfo>();
   *info = {};
@@ -648,10 +676,6 @@ StarboardRendererWrapper::GetSbDecodeTargetGraphicsContextProvider() {
   return &decode_target_graphics_context_provider_;
 }
 
-void StarboardRendererWrapper::GetCurrentDecodeTarget() {
-  decode_target_ = GetRenderer()->GetSbDecodeTarget();
-}
-
 void StarboardRendererWrapper::OnCreateImageDone(
     VideoPixelFormat format,
     const gfx::Size& coded_size,
@@ -713,8 +737,16 @@ void StarboardRendererWrapper::GraphicsContextRunner(
     return;
   }
   if (provider->gpu_factory_) {
-    provider->PostGpuTaskWithGlesContextAndWait(base::BindOnce(
-        &CallTargetFunction, target_function, target_function_context));
+    base::WaitableEvent done_event(
+        base::WaitableEvent::ResetPolicy::MANUAL,
+        base::WaitableEvent::InitialState::NOT_SIGNALED);
+    provider->GetGpuFactory()
+        ->AsyncCall(&StarboardGpuFactory::RunWithGlesContext)
+        .WithArgs(base::BindOnce(&CallTargetFunction, target_function,
+                                 target_function_context),
+                  &done_event);
+    base::ScopedAllowBaseSyncPrimitivesOutsideBlockingScope allow_wait;
+    done_event.Wait();
   }
 }
 
@@ -724,19 +756,6 @@ void StarboardRendererWrapper::PostGpuTaskWithGlesContext(
   GetGpuFactory()
       ->AsyncCall(&StarboardGpuFactory::RunWithGlesContext)
       .WithArgs(std::move(task), /*done_event=*/nullptr);
-}
-
-void StarboardRendererWrapper::PostGpuTaskWithGlesContextAndWait(
-    base::OnceClosure task) {
-  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-  base::WaitableEvent done_event(
-      base::WaitableEvent::ResetPolicy::MANUAL,
-      base::WaitableEvent::InitialState::NOT_SIGNALED);
-  GetGpuFactory()
-      ->AsyncCall(&StarboardGpuFactory::RunWithGlesContext)
-      .WithArgs(std::move(task), &done_event);
-  base::ScopedAllowBaseSyncPrimitivesOutsideBlockingScope allow_wait;
-  done_event.Wait();
 }
 
 void StarboardRendererWrapper::ReleaseDecodeTargetOnGpu(

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.cc
@@ -35,6 +35,15 @@ namespace {
 // Time interval to update media time when bypass is active. This matches
 // `kTimeUpdateInterval` in media/mojo/services/mojo_renderer_service.cc.
 constexpr auto kTimeUpdateInterval = base::Milliseconds(125);
+
+// Disable CFI checks for this function because it executes function pointers
+// provided by the Starboard library, which cannot be verified across the
+// component boundary.
+NO_SANITIZE("cfi-icall")
+void CallTargetFunction(SbDecodeTargetGlesContextRunnerTarget target_function,
+                        void* target_function_context) {
+  target_function(target_function_context);
+}
 }  // namespace
 
 // A proxy DemuxerStream that forwards Read calls to the
@@ -340,16 +349,15 @@ void StarboardRendererWrapper::GetCurrentVideoFrame(
     GetCurrentVideoFrameCallback callback) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
   {
-    // Post GetRenderer()->GetSbDecodeTarget() on the gpu thread.
-    base::OnceCallback<void()> get_current_decode_target_cb =
-        base::BindOnce(&StarboardRendererWrapper::GetCurrentDecodeTarget,
-                       base::Unretained(this));
     base::WaitableEvent done_event(
         base::WaitableEvent::ResetPolicy::MANUAL,
         base::WaitableEvent::InitialState::NOT_SIGNALED);
     GetGpuFactory()
-        ->AsyncCall(&StarboardGpuFactory::RunCallbackOnGpu)
-        .WithArgs(std::move(get_current_decode_target_cb), &done_event);
+        ->AsyncCall(&StarboardGpuFactory::RunWithGlesContext)
+        .WithArgs(
+            base::BindOnce(&StarboardRendererWrapper::GetCurrentDecodeTarget,
+                           base::Unretained(this)),
+            &done_event);
     // This call blocks because the underlying Starboard API
     // (SbPlayerGetCurrentFrame) is synchronous and needs to be executed on the
     // GPU thread.
@@ -362,16 +370,17 @@ void StarboardRendererWrapper::GetCurrentVideoFrame(
     if (!SbDecodeTargetGetInfo(decode_target_, info.get())) {
       LOG(ERROR) << "SbDecodeTargetGetInfo failed";
       GetGpuFactory()
-          ->AsyncCall(&StarboardGpuFactory::PostCallbackToGpu)
+          ->AsyncCall(&StarboardGpuFactory::RunWithGlesContext)
           .WithArgs(base::BindOnce(
-              [](void* target) {
-                SbDecodeTarget decode_target =
-                    reinterpret_cast<SbDecodeTarget>(target);
-                if (SbDecodeTargetIsValid(decode_target)) {
-                  SbDecodeTargetRelease(decode_target);
-                }
-              },
-              reinterpret_cast<void*>(decode_target_)));
+                        [](void* target) {
+                          SbDecodeTarget decode_target =
+                              reinterpret_cast<SbDecodeTarget>(target);
+                          if (SbDecodeTargetIsValid(decode_target)) {
+                            SbDecodeTargetRelease(decode_target);
+                          }
+                        },
+                        reinterpret_cast<void*>(decode_target_)),
+                    /*done_event=*/nullptr);
       decode_target_ = kSbDecodeTargetInvalid;
       std::move(callback).Run(nullptr);
       return;
@@ -411,16 +420,17 @@ void StarboardRendererWrapper::GetCurrentVideoFrame(
       LOG(ERROR) << "Unsupported SbDecodeTargetFormat: "
                  << static_cast<int>(info.get()->format);
       GetGpuFactory()
-          ->AsyncCall(&StarboardGpuFactory::PostCallbackToGpu)
+          ->AsyncCall(&StarboardGpuFactory::RunWithGlesContext)
           .WithArgs(base::BindOnce(
-              [](void* target) {
-                SbDecodeTarget decode_target =
-                    reinterpret_cast<SbDecodeTarget>(target);
-                if (SbDecodeTargetIsValid(decode_target)) {
-                  SbDecodeTargetRelease(decode_target);
-                }
-              },
-              reinterpret_cast<void*>(decode_target_)));
+                        [](void* target) {
+                          SbDecodeTarget decode_target =
+                              reinterpret_cast<SbDecodeTarget>(target);
+                          if (SbDecodeTargetIsValid(decode_target)) {
+                            SbDecodeTargetRelease(decode_target);
+                          }
+                        },
+                        reinterpret_cast<void*>(decode_target_)),
+                    /*done_event=*/nullptr);
       decode_target_ = kSbDecodeTargetInvalid;
       std::move(callback).Run(nullptr);
       return;
@@ -438,16 +448,17 @@ void StarboardRendererWrapper::GetCurrentVideoFrame(
         texture_service_ids == last_texture_service_ids_) {
       shared_image = current_shared_image_;
       GetGpuFactory()
-          ->AsyncCall(&StarboardGpuFactory::PostCallbackToGpu)
+          ->AsyncCall(&StarboardGpuFactory::RunWithGlesContext)
           .WithArgs(base::BindOnce(
-              [](void* target) {
-                SbDecodeTarget decode_target =
-                    reinterpret_cast<SbDecodeTarget>(target);
-                if (SbDecodeTargetIsValid(decode_target)) {
-                  SbDecodeTargetRelease(decode_target);
-                }
-              },
-              reinterpret_cast<void*>(decode_target_)));
+                        [](void* target) {
+                          SbDecodeTarget decode_target =
+                              reinterpret_cast<SbDecodeTarget>(target);
+                          if (SbDecodeTargetIsValid(decode_target)) {
+                            SbDecodeTargetRelease(decode_target);
+                          }
+                        },
+                        reinterpret_cast<void*>(decode_target_)),
+                    /*done_event=*/nullptr);
       decode_target_ = kSbDecodeTargetInvalid;
     } else {
       base::WaitableEvent done_event(
@@ -732,9 +743,10 @@ void StarboardRendererWrapper::GraphicsContextRunner(
     base::WaitableEvent done_event(
         base::WaitableEvent::ResetPolicy::MANUAL,
         base::WaitableEvent::InitialState::NOT_SIGNALED);
-    provider->gpu_factory_
-        .AsyncCall(&StarboardGpuFactory::RunSbDecodeTargetFunctionOnGpu)
-        .WithArgs(target_function, target_function_context, &done_event);
+    provider->gpu_factory_.AsyncCall(&StarboardGpuFactory::RunWithGlesContext)
+        .WithArgs(base::BindOnce(&CallTargetFunction, target_function,
+                                 target_function_context),
+                  &done_event);
     // Blocking is okay here to allow SbPlayer to post |target_function|
     // on gpu thread, and StarboardRenderer waits for the execution.
     base::ScopedAllowBaseSyncPrimitives allow_wait;

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.cc
@@ -351,99 +351,104 @@ void StarboardRendererWrapper::GetCurrentVideoFrame(
   PostGpuTaskWithGlesContextAndWait(
       base::BindOnce(&StarboardRendererWrapper::GetCurrentDecodeTarget,
                      base::Unretained(this)));
-  if (SbDecodeTargetIsValid(decode_target_)) {
-    auto info = std::make_unique<SbDecodeTargetInfo>();
-    *info = {};
-    if (!SbDecodeTargetGetInfo(decode_target_, info.get())) {
-      LOG(ERROR) << "SbDecodeTargetGetInfo failed";
-      ReleaseDecodeTargetOnGpu(
-          std::exchange(decode_target_, kSbDecodeTargetInvalid));
-      std::move(callback).Run(nullptr);
-      return;
-    }
-
-    VideoPixelFormat format;
-    viz::SharedImageFormat viz_format;
-    std::vector<uint32_t> texture_service_ids;
-    std::vector<uint32_t> texture_targets;
-    scoped_refptr<gpu::ClientSharedImage> shared_image;
-    int plane_count = SbDecodeTargetNumberOfPlanesForFormat(info.get()->format);
-    DCHECK_GE(plane_count, 1);
-    const SbDecodeTargetInfoPlane& plane = info.get()->planes[0];
-    auto coded_size = gfx::Size(info.get()->width, info.get()->height);
-    auto visible_rect = gfx::Rect(
-        gfx::Point(
-            static_cast<int>(std::round(std::min(plane.content_region.left,
-                                                 plane.content_region.right))),
-            static_cast<int>(std::round(std::min(
-                plane.content_region.top, plane.content_region.bottom)))),
-        gfx::Size(
-            static_cast<int>(std::round(std::abs(plane.content_region.right -
-                                                 plane.content_region.left))),
-            static_cast<int>(std::round(std::abs(
-                plane.content_region.top - plane.content_region.bottom)))));
-    auto natural_size = visible_rect.size();
-
-    if (info.get()->format == kSbDecodeTargetFormat1PlaneRGBA) {
-      DCHECK_EQ(static_cast<size_t>(plane_count), 1u);
-      format = PIXEL_FORMAT_ABGR;
-      viz_format = viz::SinglePlaneFormat::kRGBA_8888;
-    } else if (info.get()->format == kSbDecodeTargetFormat3PlaneYUVI420) {
-      DCHECK_EQ(static_cast<size_t>(plane_count), 3u);
-      format = PIXEL_FORMAT_I420;
-      viz_format = viz::MultiPlaneFormat::kI420;
-    } else {
-      LOG(ERROR) << "Unsupported SbDecodeTargetFormat: "
-                 << static_cast<int>(info.get()->format);
-      ReleaseDecodeTargetOnGpu(
-          std::exchange(decode_target_, kSbDecodeTargetInvalid));
-      std::move(callback).Run(nullptr);
-      return;
-    }
-
-    for (int plane_index = 0; plane_index < plane_count; plane_index++) {
-      texture_service_ids.push_back(info.get()->planes[plane_index].texture);
-      texture_targets.push_back(
-          info.get()->planes[plane_index].gl_texture_target);
-    }
-    DCHECK_EQ(texture_service_ids.size(), static_cast<size_t>(plane_count));
-    DCHECK_EQ(texture_targets.size(), static_cast<size_t>(plane_count));
-
-    if (current_shared_image_ &&
-        texture_service_ids == last_texture_service_ids_) {
-      shared_image = current_shared_image_;
-      ReleaseDecodeTargetOnGpu(
-          std::exchange(decode_target_, kSbDecodeTargetInvalid));
-    } else {
-      base::WaitableEvent done_event(
-          base::WaitableEvent::ResetPolicy::MANUAL,
-          base::WaitableEvent::InitialState::NOT_SIGNALED);
-      GetGpuFactory()
-          ->AsyncCall(&StarboardGpuFactory::CreateImageOnGpu)
-          .WithArgs(coded_size, GetRenderer()->color_space(), viz_format,
-                    std::ref(shared_image), std::ref(texture_service_ids),
-                    std::ref(texture_targets),
-                    reinterpret_cast<uint64_t>(decode_target_),
-#if BUILDFLAG(IS_ANDROID)
-                    GetDrDcLock(),
-#endif  // BUILDFLAG(IS_ANDROID)
-                    &done_event);
-      // Blocking is okay here to create image from textures on gpu thread.
-      base::ScopedAllowBaseSyncPrimitivesOutsideBlockingScope allow_wait;
-      done_event.Wait();
-      if (shared_image) {
-        current_shared_image_ = shared_image;
-        last_texture_service_ids_ = texture_service_ids;
-        decode_target_ = kSbDecodeTargetInvalid;
-      }
-    }
-
-    if (shared_image) {
-      CreateVideoFrame_OnImageReady(format, coded_size, visible_rect,
-                                    natural_size, std::move(shared_image));
-    }
+  if (!SbDecodeTargetIsValid(decode_target_)) {
+    std::move(callback).Run(current_frame_);
+    return;
   }
-  std::move(callback).Run(current_frame_);
+
+  auto info = std::make_unique<SbDecodeTargetInfo>();
+  *info = {};
+  if (!SbDecodeTargetGetInfo(decode_target_, info.get())) {
+    LOG(ERROR) << "SbDecodeTargetGetInfo failed";
+    ReleaseDecodeTargetOnGpu(
+        std::exchange(decode_target_, kSbDecodeTargetInvalid));
+    std::move(callback).Run(nullptr);
+    return;
+  }
+
+  VideoPixelFormat format;
+  viz::SharedImageFormat viz_format;
+  std::vector<uint32_t> texture_service_ids;
+  std::vector<uint32_t> texture_targets;
+  int plane_count = SbDecodeTargetNumberOfPlanesForFormat(info.get()->format);
+  DCHECK_GE(plane_count, 1);
+  const SbDecodeTargetInfoPlane& plane = info.get()->planes[0];
+  auto coded_size = gfx::Size(info.get()->width, info.get()->height);
+  auto visible_rect = gfx::Rect(
+      gfx::Point(static_cast<int>(std::round(std::min(
+                     plane.content_region.left, plane.content_region.right))),
+                 static_cast<int>(std::round(std::min(
+                     plane.content_region.top, plane.content_region.bottom)))),
+      gfx::Size(static_cast<int>(std::round(std::abs(
+                    plane.content_region.right - plane.content_region.left))),
+                static_cast<int>(std::round(std::abs(
+                    plane.content_region.top - plane.content_region.bottom)))));
+  auto natural_size = visible_rect.size();
+
+  if (info.get()->format == kSbDecodeTargetFormat1PlaneRGBA) {
+    DCHECK_EQ(static_cast<size_t>(plane_count), 1u);
+    format = PIXEL_FORMAT_ABGR;
+    viz_format = viz::SinglePlaneFormat::kRGBA_8888;
+  } else if (info.get()->format == kSbDecodeTargetFormat3PlaneYUVI420) {
+    DCHECK_EQ(static_cast<size_t>(plane_count), 3u);
+    format = PIXEL_FORMAT_I420;
+    viz_format = viz::MultiPlaneFormat::kI420;
+  } else {
+    LOG(ERROR) << "Unsupported SbDecodeTargetFormat: "
+               << static_cast<int>(info.get()->format);
+    ReleaseDecodeTargetOnGpu(
+        std::exchange(decode_target_, kSbDecodeTargetInvalid));
+    std::move(callback).Run(nullptr);
+    return;
+  }
+
+  for (int plane_index = 0; plane_index < plane_count; plane_index++) {
+    texture_service_ids.push_back(info.get()->planes[plane_index].texture);
+    texture_targets.push_back(
+        info.get()->planes[plane_index].gl_texture_target);
+  }
+  DCHECK_EQ(texture_service_ids.size(), static_cast<size_t>(plane_count));
+  DCHECK_EQ(texture_targets.size(), static_cast<size_t>(plane_count));
+
+  if (current_shared_image_ &&
+      texture_service_ids == last_texture_service_ids_) {
+    ReleaseDecodeTargetOnGpu(
+        std::exchange(decode_target_, kSbDecodeTargetInvalid));
+    std::move(callback).Run(current_frame_);
+    return;
+  }
+
+  auto shared_image_holder =
+      std::make_unique<scoped_refptr<gpu::ClientSharedImage>>();
+  auto* shared_image_ptr = shared_image_holder.get();
+  GetGpuFactory()
+      ->AsyncCall(&StarboardGpuFactory::CreateImageOnGpu)
+      .WithArgs(coded_size, GetRenderer()->color_space(), viz_format,
+                std::ref(*shared_image_ptr), texture_service_ids,
+                texture_targets, reinterpret_cast<uint64_t>(decode_target_),
+#if BUILDFLAG(IS_ANDROID)
+                GetDrDcLock(),
+#endif  // BUILDFLAG(IS_ANDROID)
+                /*done_event=*/nullptr)
+      .Then(base::BindOnce(
+          [](base::WeakPtr<StarboardRendererWrapper> self,
+             std::unique_ptr<scoped_refptr<gpu::ClientSharedImage>> holder,
+             VideoPixelFormat format, gfx::Size coded_size,
+             gfx::Rect visible_rect, gfx::Size natural_size,
+             std::vector<uint32_t> texture_service_ids,
+             GetCurrentVideoFrameCallback callback) {
+            if (!self) {
+              std::move(callback).Run(nullptr);
+              return;
+            }
+            self->OnCreateImageDone(format, coded_size, visible_rect,
+                                    natural_size,
+                                    std::move(texture_service_ids),
+                                    std::move(callback), std::move(*holder));
+          },
+          weak_factory_.GetWeakPtr(), std::move(shared_image_holder), format,
+          coded_size, visible_rect, natural_size,
+          std::move(texture_service_ids), std::move(callback)));
 }
 
 void StarboardRendererWrapper::OnSbWindowHandleReady(
@@ -647,7 +652,26 @@ void StarboardRendererWrapper::GetCurrentDecodeTarget() {
   decode_target_ = GetRenderer()->GetSbDecodeTarget();
 }
 
-void StarboardRendererWrapper::CreateVideoFrame_OnImageReady(
+void StarboardRendererWrapper::OnCreateImageDone(
+    VideoPixelFormat format,
+    const gfx::Size& coded_size,
+    const gfx::Rect& visible_rect,
+    const gfx::Size& natural_size,
+    std::vector<uint32_t> texture_service_ids,
+    GetCurrentVideoFrameCallback callback,
+    scoped_refptr<gpu::ClientSharedImage> shared_image) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  if (shared_image) {
+    current_shared_image_ = shared_image;
+    last_texture_service_ids_ = std::move(texture_service_ids);
+    decode_target_ = kSbDecodeTargetInvalid;
+    UpdateVideoFrameWithSharedImage(format, coded_size, visible_rect,
+                                    natural_size, std::move(shared_image));
+  }
+  std::move(callback).Run(current_frame_);
+}
+
+void StarboardRendererWrapper::UpdateVideoFrameWithSharedImage(
     VideoPixelFormat format,
     const gfx::Size& coded_size,
     const gfx::Rect& visible_rect,

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.cc
@@ -348,40 +348,16 @@ void StarboardRendererWrapper::OnGpuChannelTokenReady(
 void StarboardRendererWrapper::GetCurrentVideoFrame(
     GetCurrentVideoFrameCallback callback) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-  {
-    base::WaitableEvent done_event(
-        base::WaitableEvent::ResetPolicy::MANUAL,
-        base::WaitableEvent::InitialState::NOT_SIGNALED);
-    GetGpuFactory()
-        ->AsyncCall(&StarboardGpuFactory::RunWithGlesContext)
-        .WithArgs(
-            base::BindOnce(&StarboardRendererWrapper::GetCurrentDecodeTarget,
-                           base::Unretained(this)),
-            &done_event);
-    // This call blocks because the underlying Starboard API
-    // (SbPlayerGetCurrentFrame) is synchronous and needs to be executed on the
-    // GPU thread.
-    base::ScopedAllowBaseSyncPrimitivesOutsideBlockingScope allow_wait;
-    done_event.Wait();
-  }
+  PostGpuTaskWithGlesContextAndWait(
+      base::BindOnce(&StarboardRendererWrapper::GetCurrentDecodeTarget,
+                     base::Unretained(this)));
   if (SbDecodeTargetIsValid(decode_target_)) {
     auto info = std::make_unique<SbDecodeTargetInfo>();
     *info = {};
     if (!SbDecodeTargetGetInfo(decode_target_, info.get())) {
       LOG(ERROR) << "SbDecodeTargetGetInfo failed";
-      GetGpuFactory()
-          ->AsyncCall(&StarboardGpuFactory::RunWithGlesContext)
-          .WithArgs(base::BindOnce(
-                        [](void* target) {
-                          SbDecodeTarget decode_target =
-                              reinterpret_cast<SbDecodeTarget>(target);
-                          if (SbDecodeTargetIsValid(decode_target)) {
-                            SbDecodeTargetRelease(decode_target);
-                          }
-                        },
-                        reinterpret_cast<void*>(decode_target_)),
-                    /*done_event=*/nullptr);
-      decode_target_ = kSbDecodeTargetInvalid;
+      ReleaseDecodeTargetOnGpu(
+          std::exchange(decode_target_, kSbDecodeTargetInvalid));
       std::move(callback).Run(nullptr);
       return;
     }
@@ -419,19 +395,8 @@ void StarboardRendererWrapper::GetCurrentVideoFrame(
     } else {
       LOG(ERROR) << "Unsupported SbDecodeTargetFormat: "
                  << static_cast<int>(info.get()->format);
-      GetGpuFactory()
-          ->AsyncCall(&StarboardGpuFactory::RunWithGlesContext)
-          .WithArgs(base::BindOnce(
-                        [](void* target) {
-                          SbDecodeTarget decode_target =
-                              reinterpret_cast<SbDecodeTarget>(target);
-                          if (SbDecodeTargetIsValid(decode_target)) {
-                            SbDecodeTargetRelease(decode_target);
-                          }
-                        },
-                        reinterpret_cast<void*>(decode_target_)),
-                    /*done_event=*/nullptr);
-      decode_target_ = kSbDecodeTargetInvalid;
+      ReleaseDecodeTargetOnGpu(
+          std::exchange(decode_target_, kSbDecodeTargetInvalid));
       std::move(callback).Run(nullptr);
       return;
     }
@@ -447,19 +412,8 @@ void StarboardRendererWrapper::GetCurrentVideoFrame(
     if (current_shared_image_ &&
         texture_service_ids == last_texture_service_ids_) {
       shared_image = current_shared_image_;
-      GetGpuFactory()
-          ->AsyncCall(&StarboardGpuFactory::RunWithGlesContext)
-          .WithArgs(base::BindOnce(
-                        [](void* target) {
-                          SbDecodeTarget decode_target =
-                              reinterpret_cast<SbDecodeTarget>(target);
-                          if (SbDecodeTargetIsValid(decode_target)) {
-                            SbDecodeTargetRelease(decode_target);
-                          }
-                        },
-                        reinterpret_cast<void*>(decode_target_)),
-                    /*done_event=*/nullptr);
-      decode_target_ = kSbDecodeTargetInvalid;
+      ReleaseDecodeTargetOnGpu(
+          std::exchange(decode_target_, kSbDecodeTargetInvalid));
     } else {
       base::WaitableEvent done_event(
           base::WaitableEvent::ResetPolicy::MANUAL,
@@ -735,18 +689,46 @@ void StarboardRendererWrapper::GraphicsContextRunner(
     return;
   }
   if (provider->gpu_factory_) {
-    base::WaitableEvent done_event(
-        base::WaitableEvent::ResetPolicy::MANUAL,
-        base::WaitableEvent::InitialState::NOT_SIGNALED);
-    provider->gpu_factory_.AsyncCall(&StarboardGpuFactory::RunWithGlesContext)
-        .WithArgs(base::BindOnce(&CallTargetFunction, target_function,
-                                 target_function_context),
-                  &done_event);
-    // Blocking is okay here to allow SbPlayer to post |target_function|
-    // on gpu thread, and StarboardRenderer waits for the execution.
-    base::ScopedAllowBaseSyncPrimitives allow_wait;
-    done_event.Wait();
+    provider->PostGpuTaskWithGlesContextAndWait(base::BindOnce(
+        &CallTargetFunction, target_function, target_function_context));
   }
+}
+
+void StarboardRendererWrapper::PostGpuTaskWithGlesContext(
+    base::OnceClosure task) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  GetGpuFactory()
+      ->AsyncCall(&StarboardGpuFactory::RunWithGlesContext)
+      .WithArgs(std::move(task), /*done_event=*/nullptr);
+}
+
+void StarboardRendererWrapper::PostGpuTaskWithGlesContextAndWait(
+    base::OnceClosure task) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  base::WaitableEvent done_event(
+      base::WaitableEvent::ResetPolicy::MANUAL,
+      base::WaitableEvent::InitialState::NOT_SIGNALED);
+  GetGpuFactory()
+      ->AsyncCall(&StarboardGpuFactory::RunWithGlesContext)
+      .WithArgs(std::move(task), &done_event);
+  base::ScopedAllowBaseSyncPrimitivesOutsideBlockingScope allow_wait;
+  done_event.Wait();
+}
+
+void StarboardRendererWrapper::ReleaseDecodeTargetOnGpu(
+    SbDecodeTarget decode_target) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  if (!SbDecodeTargetIsValid(decode_target)) {
+    return;
+  }
+  PostGpuTaskWithGlesContext(base::BindOnce(
+      [](uintptr_t target) {
+        SbDecodeTarget decode_target = reinterpret_cast<SbDecodeTarget>(target);
+        if (SbDecodeTargetIsValid(decode_target)) {
+          SbDecodeTargetRelease(decode_target);
+        }
+      },
+      reinterpret_cast<uintptr_t>(decode_target)));
 }
 
 }  // namespace media

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.h
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.h
@@ -153,6 +153,10 @@ class StarboardRendererWrapper
 #if BUILDFLAG(IS_ANDROID)
   void OnRequestOverlayInfoByStarboard(bool restart_for_transitions);
 #endif  // BUILDFLAG(IS_ANDROID)
+  void PostGpuTaskWithGlesContext(base::OnceClosure task);
+  void PostGpuTaskWithGlesContextAndWait(base::OnceClosure task);
+  void ReleaseDecodeTargetOnGpu(SbDecodeTarget decode_target);
+
   SbDecodeTargetGraphicsContextProvider*
   GetSbDecodeTargetGraphicsContextProvider();
   void GetCurrentDecodeTarget();

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.h
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.h
@@ -154,12 +154,12 @@ class StarboardRendererWrapper
   void OnRequestOverlayInfoByStarboard(bool restart_for_transitions);
 #endif  // BUILDFLAG(IS_ANDROID)
   void PostGpuTaskWithGlesContext(base::OnceClosure task);
-  void PostGpuTaskWithGlesContextAndWait(base::OnceClosure task);
   void ReleaseDecodeTargetOnGpu(SbDecodeTarget decode_target);
 
   SbDecodeTargetGraphicsContextProvider*
   GetSbDecodeTargetGraphicsContextProvider();
-  void GetCurrentDecodeTarget();
+  void OnDecodeTargetReady(SbDecodeTarget decode_target,
+                           GetCurrentVideoFrameCallback callback);
   void OnCreateImageDone(VideoPixelFormat format,
                          const gfx::Size& coded_size,
                          const gfx::Rect& visible_rect,

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.h
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.h
@@ -160,7 +160,14 @@ class StarboardRendererWrapper
   SbDecodeTargetGraphicsContextProvider*
   GetSbDecodeTargetGraphicsContextProvider();
   void GetCurrentDecodeTarget();
-  void CreateVideoFrame_OnImageReady(
+  void OnCreateImageDone(VideoPixelFormat format,
+                         const gfx::Size& coded_size,
+                         const gfx::Rect& visible_rect,
+                         const gfx::Size& natural_size,
+                         std::vector<uint32_t> texture_service_ids,
+                         GetCurrentVideoFrameCallback callback,
+                         scoped_refptr<gpu::ClientSharedImage> shared_image);
+  void UpdateVideoFrameWithSharedImage(
       VideoPixelFormat format,
       const gfx::Size& coded_size,
       const gfx::Rect& visible_rect,

--- a/media/mojo/services/starboard/starboard_renderer_wrapper_unittest.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper_unittest.cc
@@ -140,19 +140,12 @@ class MockStarboardGpuFactory : public StarboardGpuFactory {
     std::move(callback).Run();
   }
 
-  void RunSbDecodeTargetFunctionOnGpu(
-      SbDecodeTargetGlesContextRunnerTarget target_function,
-      void* target_function_context,
-      base::WaitableEvent* done_event) override {
-    done_event->Signal();
+  void RunWithGlesContext(base::OnceClosure callback,
+                          base::WaitableEvent* done_event) override {
+    if (done_event) {
+      done_event->Signal();
+    }
   }
-
-  void RunCallbackOnGpu(base::OnceCallback<void()> callback,
-                        base::WaitableEvent* done_event) override {
-    done_event->Signal();
-  }
-
-  void PostCallbackToGpu(base::OnceCallback<void()> callback) override {}
 
   void CreateImageOnGpu(const gfx::Size& coded_size,
                         const gfx::ColorSpace& color_space,

--- a/media/mojo/services/starboard/starboard_renderer_wrapper_unittest.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper_unittest.cc
@@ -142,6 +142,7 @@ class MockStarboardGpuFactory : public StarboardGpuFactory {
 
   void RunWithGlesContext(base::OnceClosure callback,
                           base::WaitableEvent* done_event) override {
+    std::move(callback).Run();
     if (done_event) {
       done_event->Signal();
     }


### PR DESCRIPTION
Merge RunSbDecodeTargetFunctionOnGpu, RunCallbackOnGpu, and
PostCallbackToGpu implementations in StarboardGpuFactoryImpl to reduce
redundancy. By routing these calls through a unified logic path, the
StarboardGpuFactory interface is simplified and the dependency on
decode_target.h is removed.

Bug: 490453801