### PR TITLE
ci: Add 'CI / All Pass' uber status check for GHA rulesets

### DIFF
--- a/.github/workflows/ci_shepherd.yml
+++ b/.github/workflows/ci_shepherd.yml
@@ -138,6 +138,9 @@ jobs:
             -f description="${desc}" \
             -f context="CI / ${WORKFLOW_NAME}"
 
+          pr_number=$(gh pr list --repo "${REPO}" --search "${HEAD_SHA}" --json number --jq '.[0].number // ""')
+          echo "pr_number=${pr_number}" >> "${GITHUB_OUTPUT}"
+
           # Query commit statuses and update overall CI commit status (CI / All Pass) for rulesets.
           status_json=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/status" 2>/dev/null || echo "{}")
           IFS=$'\t' read -r overall_state overall_desc < <(echo "${status_json}" | jq -r '
@@ -147,14 +150,16 @@ jobs:
             else "pending\tChecks are running" end
           ') || true
 
+          all_pass_url="https://github.com/${REPO}/commit/${HEAD_SHA}"
+          if [[ -n "${pr_number}" ]]; then
+            all_pass_url="https://github.com/${REPO}/pull/${pr_number}"
+          fi
+
           gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
             -f state="${overall_state:-pending}" \
-            -f target_url="${GITHUB_SERVER_URL}/${REPO}/actions/runs/${GITHUB_RUN_ID}" \
+            -f target_url="${all_pass_url}" \
             -f description="${overall_desc:-Checks are running}" \
             -f context="CI / All Pass"
-
-          pr_number=$(gh pr list --repo "${REPO}" --search "${HEAD_SHA}" --json number --jq '.[0].number // ""')
-          echo "pr_number=${pr_number}" >> "${GITHUB_OUTPUT}"
 
   comment-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_shepherd.yml
+++ b/.github/workflows/ci_shepherd.yml
@@ -138,33 +138,19 @@ jobs:
             -f description="${desc}" \
             -f context="CI / ${WORKFLOW_NAME}"
 
-          # Query latest commit statuses and update overall CI commit status (CI / All Pass) for rulesets.
+          # Query commit statuses and update overall CI commit status (CI / All Pass) for rulesets.
           status_json=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/status" 2>/dev/null || echo "{}")
-          IFS=$'\t' read -r overall_state overall_desc < <(echo "${status_json}" | jq -r \
-            --arg current_workflow "${WORKFLOW_NAME}" \
-            --arg current_state "${state}" '
-            ["CI / android", "CI / aosp", "CI / evergreen", "CI / linux", "CI / tvos"] as $required |
-            reduce ([{"context": ("CI / " + $current_workflow), "state": $current_state}] + (.statuses // []))[] as $status_entry ({};
-              if (($status_entry.context // "") | startswith("CI /")) and $status_entry.context != "CI / All Pass" and (.[$status_entry.context] | not) then
-                .[$status_entry.context] = $status_entry.state
-              else . end
-            ) as $by_ctx |
-            if any($by_ctx[]; . == "failure" or . == "error") then
-              "failure\tSome checks failed"
-            elif all($required[]; $by_ctx[.] == "success") and all($by_ctx[]; . == "success") then
-              "success\tAll checks passed"
-            else
-              "pending\tChecks are running"
-            end
+          IFS=$'\t' read -r overall_state overall_desc < <(echo "${status_json}" | jq -r '
+            [.statuses[]? | select(.context | startswith("CI /")?) | select(.context != "CI / All Pass")] |
+            if any(.state == "failure" or .state == "error") then "failure\tSome checks failed"
+            elif length > 0 and all(.state == "success") then "success\tAll checks passed"
+            else "pending\tChecks are running" end
           ') || true
-          overall_state="${overall_state:-pending}"
-          overall_desc="${overall_desc:-Checks are running}"
-          all_pass_url="${GITHUB_SERVER_URL}/${REPO}/actions/runs/${GITHUB_RUN_ID}"
 
           gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
-            -f state="${overall_state}" \
-            -f target_url="${all_pass_url}" \
-            -f description="${overall_desc}" \
+            -f state="${overall_state:-pending}" \
+            -f target_url="${GITHUB_SERVER_URL}/${REPO}/actions/runs/${GITHUB_RUN_ID}" \
+            -f description="${overall_desc:-Checks are running}" \
             -f context="CI / All Pass"
 
           pr_number=$(gh pr list --repo "${REPO}" --search "${HEAD_SHA}" --json number --jq '.[0].number // ""')

--- a/.github/workflows/ci_shepherd.yml
+++ b/.github/workflows/ci_shepherd.yml
@@ -172,7 +172,7 @@ jobs:
             {success: "✅ PASS", pending: "⏳ PENDING"} as $icons |
             ["| Context | State | Description |", "|---|---|---|"] +
             [
-              .statuses // [] | sort_by(.context)[] |
+              .statuses // [] | sort_by(.context)[] | select(.context | startswith("CI /")?) |
               "| [\(.context)](\(.target_url // "")) | \($icons[.state] // "❌ FAIL") | \(.description // "") |"
             ] | join("\n")
           ' > shepherd_report.md

--- a/.github/workflows/ci_shepherd.yml
+++ b/.github/workflows/ci_shepherd.yml
@@ -138,6 +138,35 @@ jobs:
             -f description="${desc}" \
             -f context="CI / ${WORKFLOW_NAME}"
 
+          # Query latest commit statuses and update overall CI commit status (CI / All Pass) for rulesets.
+          status_json=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/status" 2>/dev/null || echo "{}")
+          IFS=$'\t' read -r overall_state overall_desc < <(echo "${status_json}" | jq -r \
+            --arg current_workflow "${WORKFLOW_NAME}" \
+            --arg current_state "${state}" '
+            ["CI / android", "CI / aosp", "CI / evergreen", "CI / linux", "CI / tvos"] as $required |
+            reduce ([{"context": ("CI / " + $current_workflow), "state": $current_state}] + (.statuses // []))[] as $status_entry ({};
+              if (($status_entry.context // "") | startswith("CI /")) and $status_entry.context != "CI / All Pass" and (.[$status_entry.context] | not) then
+                .[$status_entry.context] = $status_entry.state
+              else . end
+            ) as $by_ctx |
+            if any($by_ctx[]; . == "failure" or . == "error") then
+              "failure\tSome checks failed"
+            elif all($required[]; $by_ctx[.] == "success") and all($by_ctx[]; . == "success") then
+              "success\tAll checks passed"
+            else
+              "pending\tChecks are running"
+            end
+          ') || true
+          overall_state="${overall_state:-pending}"
+          overall_desc="${overall_desc:-Checks are running}"
+          all_pass_url="${GITHUB_SERVER_URL}/${REPO}/actions/runs/${GITHUB_RUN_ID}"
+
+          gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
+            -f state="${overall_state}" \
+            -f target_url="${all_pass_url}" \
+            -f description="${overall_desc}" \
+            -f context="CI / All Pass"
+
           pr_number=$(gh pr list --repo "${REPO}" --search "${HEAD_SHA}" --json number --jq '.[0].number // ""')
           echo "pr_number=${pr_number}" >> "${GITHUB_OUTPUT}"
 


### PR DESCRIPTION
Implement an aggregate 'CI / All Pass' commit status check in CI Shepherd for use in GitHub Actions repository rulesets, and filter the sticky comment report to only include 'CI /' entries.

### Key Changes
1. **Aggregate 'CI / All Pass' Status Check (Uber Job)**:
   - Publishes an overall commit status (`CI / All Pass`) dynamically evaluated across all CI platform workflow runs for the commit.
   - Evaluates to `failure` if any CI check fails, `success` once all active CI checks pass, and `pending` while workflows are in progress.
   - Designed as the required status check for GitHub Actions branch rulesets across `main` and release branches without hardcoding workflow names.

2. **Clean Sticky Comment Reporting**:
   - Filters the PR sticky comment table to only include entries matching the `CI /` prefix, preventing external or unrelated commit statuses from cluttering the report.

Tag: agy
Conv: 1e45aaea-595c-4709-8d77-fdf9caa2aee0
Bug: 551996294