### PR TITLE
Restore NetworkContextTrustTokenMethodsReturnEmpty

### DIFF
--- a/cobalt/testing/filters/evergreen-arm-hardfp-rdk/cobalt_browsertests_loader_filter.json
+++ b/cobalt/testing/filters/evergreen-arm-hardfp-rdk/cobalt_browsertests_loader_filter.json
@@ -14,7 +14,6 @@
     "PrivacySandboxDisabledBrowserTest.VerifyPrivacySandboxApisDisabled",
     "PrivacySandboxDisabledBrowserTest.FetchWithPrivateTokenParamIgnored",
     "PrivacySandboxDisabledBrowserTest.FedCmAndCredentialApisNotExposed",
-    "PrivacySandboxDisabledBrowserTest.NetworkContextTrustTokenMethodsReturnEmpty",
     "H5vccSchemeURLLoaderFactoryBrowserTest.*",
     "H5vccSchemeURLLoaderFactoryCacheBrowserTest.*",
     "H5vccRuntimeBrowserTest.*",


### PR DESCRIPTION
Try NetworkContextTrustTokenMethodsReturnEmpty test in CI, as I could not reproduce the failure in my local RDK.

Bug: 559322671