### PR TITLE
blink: Run compositor presentation callbacks on failure in Cobalt to prevent queue overflow

### DIFF
--- a/third_party/blink/renderer/platform/widget/compositing/layer_tree_view.cc
+++ b/third_party/blink/renderer/platform/widget/compositing/layer_tree_view.cc
@@ -453,10 +453,19 @@ void LayerTreeView::DidPresentCompositorFrame(
   DCHECK(layer_tree_host_->GetTaskRunnerProvider()
              ->MainThreadTaskRunner()
              ->RunsTasksInCurrentSequence());
+#if !BUILDFLAG(IS_COBALT)
   // Only run callbacks on successful presentations.
   if (frame_timing_details.presentation_feedback.failed()) {
     return;
   }
+#else
+  // Cobalt: Run presentation callbacks even if presentation feedback indicates a
+  // failure. This prevents callbacks from leaking in presentation_callbacks_
+  // when frames are dropped or discarded, avoiding subsequent DCHECK crashes
+  // when callbacks.size() exceeds kMaxBufferSize (b/524768105).
+  // Note: Callbacks registered by Blink (e.g., RunCallbackAfterPresentation)
+  // already handle invalid/failed presentation timestamps by falling back to swap_time.
+#endif
   while (!presentation_callbacks_.empty()) {
     const auto& front = presentation_callbacks_.begin();
     if (viz::FrameTokenGT(front->first, frame_token))


### PR DESCRIPTION
Ensure that compositor presentation callbacks are executed even if the
presentation feedback indicates a failure. In Cobalt, dropped or
discarded frames could otherwise cause these callbacks to accumulate in
the presentation_callbacks_ queue.

This prevents the queue from exceeding kMaxBufferSize and triggering
subsequent DCHECK crashes. Blink callbacks are designed to handle
failed presentation timestamps by falling back to the swap time.

Test: Verified that the fix fixes the runtime crash on evergreen-arm-hardfp-rdk_devel, built the app and played video and dragged progress bar and played with watch next shelf for 10min with no issue.
Bug: 524768105