### PR TITLE
Fix parsing bugs in devsite generation scripts

### DIFF
--- a/cobalt/site/docs/gen/cobalt/doc/docker_build.md
+++ b/cobalt/site/docs/gen/cobalt/doc/docker_build.md
@@ -47,8 +47,8 @@ Available parameters for customizing container execution are:
  - **BASE_OS**: passed to `base` image at build time to select a Debian-based
     base os image and version. Defaults to Debian 9. `ubuntu:bionic` and
     `ubuntu:xenial` are other tested examples.
- - **PLATFORM**: Cobalt build platform, passed to GYP
- - **CONFIG**: Cobalt build config, passed to GYP. Defaults to `debug`
+ - **PLATFORM**: Cobalt build platform, passed to GN
+ - **CONFIG**: Cobalt build config, passed to GN. Defaults to `debug`
  - **TARGET**: Build target, passed to `ninja`
 
 The `docker-compose.yml` contains the currently defined experimental build

--- a/cobalt/site/docs/gen/cobalt/doc/splash_screen.md
+++ b/cobalt/site/docs/gen/cobalt/doc/splash_screen.md
@@ -20,6 +20,29 @@ the HTML content shown immediately upon loading the web application (this may
 resemble a typical splash screen, but it really can be whatever the application
 chooses to show on starting).
 
+## Splash screen lifecycle and dismissal signals
+
+The table below illustrates the distinct phases and dismissal signals during application startup:
+
+| Phase | Visible UI | Owner | Dismissal API | Trigger Timing |
+| :--- | :--- | :--- | :--- | :--- |
+| **1. Platform / System Boot** | Host OS / platform splash screen (e.g. system app launch icon or boot splash) | Host OS / firmware | N/A (shown on process start) | Platform launches Cobalt binary |
+| **2. Cobalt First Frame Rendered** | Cobalt splash screen (e.g. animated logo / local splash asset) | Cobalt core / engine | `SbSystemHideSplashScreen()` | Cobalt renders its first visually non-empty paint (`WebContentsObserver::DidFirstVisuallyNonEmptyPaint`) |
+| **3. Web Application Ready** | Web application main UI (e.g. home page) | Web application JavaScript | `window.h5vcc.system.hideSplashScreen()` | Web application finishes document loading and initialization |
+
+> [!NOTE]
+> The **Dismissal API** column indicates the API called at the start of that phase to dismiss the visible UI from the *preceding* phase (e.g. calling `SbSystemHideSplashScreen()` upon entering Phase 2 dismisses the Phase 1 platform splash screen).
+
+### Architectural Distinction: `SbSystemHideSplashScreen()` vs. `h5vcc.system.hideSplashScreen()`
+
+It is critical not to conflate the system/platform splash screen with the Cobalt splash screen:
+
+* **`SbSystemHideSplashScreen()` (Starboard System API):**
+  Notifies the underlying Starboard platform to dismiss the host system/platform splash overlay. This is called automatically by Cobalt's browser shell upon the very first visually non-empty paint (`WebContentsObserver::DidFirstVisuallyNonEmptyPaint()`). Calling this immediately ensures that the platform splash is hidden as soon as Cobalt renders visible content, revealing Cobalt's animated splash screen without occlusion (or seamlessly revealing the main web application UI if the Cobalt splash screen is omitted or skipped).
+
+* **`window.h5vcc.system.hideSplashScreen()` (Cobalt Web API):**
+  Invoked from JavaScript by the web application once the application document has loaded, parsed, and initialized its UI. Cobalt handles this call by tearing down its splash screen WebContents and transitioning to the main web application WebContents.
+
 ## Cobalt splash screen priority order
 
 The Cobalt splash screen must be specified as a URL to a document. The document

--- a/cobalt/site/docs/gen/starboard/doc/evergreen/cobalt_evergreen_lite.md
+++ b/cobalt/site/docs/gen/starboard/doc/evergreen/cobalt_evergreen_lite.md
@@ -81,9 +81,9 @@ Same as the [Evergreen full doc](cobalt_evergreen_overview.md).
 
 ## Building Cobalt Evergreen Components
 
-`kSbSystemPathStorageDirectory` is not required to implement. Set both
-`sb_evergreen_compatible` and `sb_evergreen_compatible_lite` to `1`s in the `gyp`
-platform config. The remaining is the same as the Evergreen full doc.
+`kSbSystemPathStorageDirectory` is not required to implement. The rest of the
+implementation is the same as the Evergreen Full doc -
+[cobalt_evergreen_overview.md](cobalt_evergreen_overview.md).
 
 ## How does the update work with Evergreen Lite?
 
@@ -171,7 +171,6 @@ binaries - `kSbSystemPathStorageDirectory `and configure the slots as instructed
 in the Evergreen full doc
 *   Configure icu table under `kSbSystemPathStorageDirectory` to be shared
     among slots
-*   Set `sb_evergreen_compatible_lite` to 0
 *   Implement the handling of pending updates
 *   Rebuild and rerun `nplb_evergreen_compat_tests`
 *   Launch Cobalt with loader app without the `evergreen_lite` flag

--- a/cobalt/site/docs/gen/starboard/doc/evergreen/cobalt_evergreen_overview.md
+++ b/cobalt/site/docs/gen/starboard/doc/evergreen/cobalt_evergreen_overview.md
@@ -733,3 +733,17 @@ Much of the optimization work remains in the Starboard layer and configuration
 so you should still expect good performance using Cobalt Evergreen. That being
 said, the Cobalt Evergreen configuration allows you to customize Cobalt features
 and settings as before.
+
+### How can I trade storage space for lower memory consumption using mmap?
+
+On platforms with storage space to spare, memory can be saved by using memory mapping (`mmap`) to load the Cobalt shared library. To enable this feature:
+
+1. **Use an uncompressed `libcobalt.so`:** The Cobalt Core binary library cannot be compressed. You will need to ensure that the uncompressed `.so` variant is packaged rather than a compressed `.lz4` file in the system image slot.
+2. **Hook up the Memory Mapped File API:** Ensure that the `CobaltExtensionMemoryMappedFileApi` is hooked up by returning it from your platform's implementation of `SbSystemGetExtension()`. For reference on a Linux build, see `starboard/linux/shared/system_get_extensions.cc` where this is configured using `kCobaltExtensionMemoryMappedFileName`:
+
+   ```cpp
+     if (strcmp(name, kCobaltExtensionMemoryMappedFileName) == 0) {
+       return starboard::GetMemoryMappedFileApi();
+     }
+   ```
+3. **Pass Launch Flag:** When launching the Cobalt `loader_app` binary on your platform, pass the `--loader_use_mmap_file` flag to enable memory mapped file loading. Note that mmap is incompatible with binary compression. When `--loader_use_mmap_file` is set, the Cobalt Updater will automatically request and download uncompressed `libcobalt.so` binaries for subsequent updates. Because the updates will remain uncompressed on disk, total storage usage will increase.

--- a/cobalt/site/docs/reference/starboard/gn-configuration.md
+++ b/cobalt/site/docs/reference/starboard/gn-configuration.md
@@ -33,5 +33,5 @@ Book: /youtube/cobalt/_book.yaml
 | **`starboard_level_final_executable_type`**<br><br>The default value is `"executable"`. |
 | **`starboard_level_gtest_target_type`**<br><br>The default value is `"executable"`. |
 | **`static_library_configs`**<br><br> Target-specific configurations for static_library targets.<br><br>The default value is `[]`. |
-| **`use_crashpad`**<br><br> Platforms can set this to false to avoid building and using a real crashpad implementation. If false, crashpad either won't be built or a stub implementation will be built and used. all Early Access Program platforms.<br><br>The default value is `false`. |
+| **`use_crashpad`**<br><br> Platforms can set this to false to avoid building and using a real crashpad implementation. If false, crashpad either won't be built or a stub implementation will be built and used. all Early Access Program platforms.<br><br>The default value is `true`. |
 | **`v8_enable_pointer_compression_override`**<br><br> Set to true to enable pointer compression for v8.<br><br>The default value is `true`. |

--- a/cobalt/site/docs/reference/starboard/gn-configuration.md
+++ b/cobalt/site/docs/reference/starboard/gn-configuration.md
@@ -5,3 +5,33 @@ Book: /youtube/cobalt/_book.yaml
 
 | Variables |
 | :--- |
+| **`cobalt_licenses_platform`**<br><br> Sub-directory to copy license file to.<br><br>The default value is `"default"`. |
+| **`cobalt_platform_dependencies`**<br><br> List of platform-specific targets that get compiled into cobalt.<br><br>The default value is `[]`. |
+| **`cobalt_v8_emit_builtins_as_inline_asm`**<br><br> Some compiler can not compile with raw assembly(.S files) and v8 converts asm to inline assembly for these platforms.<br><br>The default value is `false`. |
+| **`final_executable_type`**<br><br> The target type for executable targets. Allows changing the target type on platforms where the native code may require an additional packaging step (ex. Android).<br><br>The default value is `"shared_library"`. |
+| **`gl_type`**<br><br> The source of EGL and GLES headers and libraries. Valid values (case and everything sensitive!):<ul><li><code>system_gles2</code> - Use the system implementation of EGL + GLES2. The headers and libraries must be on the system include and link paths.<li><code>angle</code> - Use ANGLE's EGL + GLES2 implementation. This requires a valid ANGLE implementation for the platform.<br><br>The default value is `"system_gles2"`. |
+| **`gtest_target_type`**<br><br> The target type for test targets. Allows changing the target type on platforms where the native code may require an additional packaging step (ex. Android).<br><br>The default value is `"shared_library"`. |
+| **`has_platform_targets`**<br><br> Whether the platform has platform-specific targets to depend on.<br><br>The default value is `false`. |
+| **`loadable_module_configs`**<br><br> Target-specific configurations for loadable_module targets.<br><br>The default value is `[]`. |
+| **`nasm_exists`**<br><br> Enables the nasm compiler to be used to compile .asm files.<br><br>The default value is `false`. |
+| **`path_to_nasm`**<br><br> Where yasm can be found on the host device.<br><br>The default value is `"nasm"`. |
+| **`platform_tests_path`**<br><br> Set to the starboard_platform_tests target if the platform implements them.<br><br>The default value is `""`. |
+| **`sabi_path`**<br><br> Where the Starboard ABI file for this platform can be found.<br><br>The default value is `"starboard/sabi/default/sabi.json"`. |
+| **`sb_api_version`**<br><br> The Starboard API version of the current build configuration. The default value is meant to be overridden by a Starboard ABI file.<br><br>The default value is `18`. |
+| **`sb_enable_benchmark`**<br><br> Used to enable benchmarks.<br><br>The default value is `false`. |
+| **`sb_enable_cpp17_audit`**<br><br> Enables an NPLB audit of C++17 support.<br><br>The default value is `true`. |
+| **`sb_enable_cpp20_audit`**<br><br> Enables an NPLB audit of C++20 support.<br><br>The default value is `true`. |
+| **`sb_enable_lib`**<br><br> Enables embedding Cobalt as a shared library within another app. This requires a 'lib' starboard implementation for the corresponding platform.<br><br>The default value is `false`. |
+| **`sb_enable_opus_sse`**<br><br> Enables optimizations on SSE compatible platforms.<br><br>The default value is `true`. |
+| **`sb_evergreen_compatible_use_libunwind`**<br><br> Whether to use the libunwind library on Evergreen compatible platform.<br><br>The default value is `false`. |
+| **`sb_filter_based_player`**<br><br> Used to indicate that the player is filter based.<br><br>The default value is `true`. |
+| **`sb_has_unused_symbol_issue`**<br><br> Set this to true if the modular toolchain linker doesn't strip all unused symbols and nplb fails to link.<br><br>The default value is `false`. |
+| **`sb_libevent_method`**<br><br> The event polling mechanism available on this platform to support libevent. Platforms may redefine to 'poll' if necessary. Other mechanisms, e.g. devpoll, kqueue, select, are not yet supported.<br><br>The default value is `"epoll"`. |
+| **`sb_static_contents_output_data_dir`**<br><br> Directory path to static contents' data.<br><br>The default value is `"/project_out_dir/content/data"`. |
+| **`sb_use_no_rtti`**<br><br> Whether or not to disable run-time type information (adding no_rtti flag).<br><br>The default value is `false`. |
+| **`source_set_configs`**<br><br> Target-specific configurations for source_set targets.<br><br>The default value is `[]`. |
+| **`starboard_level_final_executable_type`**<br><br>The default value is `"executable"`. |
+| **`starboard_level_gtest_target_type`**<br><br>The default value is `"executable"`. |
+| **`static_library_configs`**<br><br> Target-specific configurations for static_library targets.<br><br>The default value is `[]`. |
+| **`use_crashpad`**<br><br> Platforms can set this to false to avoid building and using a real crashpad implementation. If false, crashpad either won't be built or a stub implementation will be built and used. all Early Access Program platforms.<br><br>The default value is `false`. |
+| **`v8_enable_pointer_compression_override`**<br><br> Set to true to enable pointer compression for v8.<br><br>The default value is `true`. |

--- a/cobalt/site/docs/reference/starboard/modules/18/configuration.md
+++ b/cobalt/site/docs/reference/starboard/modules/18/configuration.md
@@ -85,13 +85,11 @@ Determines at compile-time an inherent aspect of this platform.
 
 ### SB_MAXIMUM_API_VERSION
 
-The maximum API version allowed by this version of the Starboard headers,
-inclusive. The API version is not stable and is open for changes.
+The maximum Starboard API version supported.
 
 ### SB_MINIMUM_API_VERSION
 
-The minimum API version allowed by this version of the Starboard headers,
-inclusive.
+The minimum Starboard API version supported.
 
 ### SB_NORETURN
 
@@ -120,8 +118,10 @@ Declare numeric literals of unsigned 64-bit type.
 
 ### SB_UNREFERENCED_PARAMETER(x)
 
-Trivially references a parameter that is otherwise unreferenced, preventing a
-compiler warning on some platforms.
+Deprecated: Per the Google C++ Style Guide, comment out unused parameter names
+(e.g., `void* /*context*/` / or `Type /*param_name*/` /), or use
+`[[maybe_unused]]` if conditionally unused. Trivially references a parameter
+that is otherwise unreferenced, preventing a compiler warning on some platforms.
 
 ### SB_WARN_UNUSED_RESULT
 

--- a/cobalt/site/docs/reference/starboard/modules/18/configuration.md
+++ b/cobalt/site/docs/reference/starboard/modules/18/configuration.md
@@ -119,9 +119,9 @@ Declare numeric literals of unsigned 64-bit type.
 ### SB_UNREFERENCED_PARAMETER(x)
 
 Deprecated: Per the Google C++ Style Guide, comment out unused parameter names
-(e.g., `void* /*context*/` / or `Type /*param_name*/` /), or use
-`[[maybe_unused]]` if conditionally unused. Trivially references a parameter
-that is otherwise unreferenced, preventing a compiler warning on some platforms.
+(e.g., `void* /*context*/` or `Type /*param_name*/`), or use `[[maybe_unused]]`
+if conditionally unused. Trivially references a parameter that is otherwise
+unreferenced, preventing a compiler warning on some platforms.
 
 ### SB_WARN_UNUSED_RESULT
 

--- a/cobalt/site/docs/reference/starboard/modules/18/egl.md
+++ b/cobalt/site/docs/reference/starboard/modules/18/egl.md
@@ -13,9 +13,7 @@ to directly pull in and use these system libraries.
 
 ## EGL Version
 
-This API has the ability to support EGL 1.5, however it is not required to
-support anything beyond EGL 1.4. The user is responsible for ensuring that the
-functions from EGL 1.5 they are calling from the interface are valid.
+This API requires support for EGL 1.5.
 
 ## Macros
 

--- a/cobalt/site/docs/reference/starboard/modules/configuration.md
+++ b/cobalt/site/docs/reference/starboard/modules/configuration.md
@@ -85,13 +85,11 @@ Determines at compile-time an inherent aspect of this platform.
 
 ### SB_MAXIMUM_API_VERSION
 
-The maximum API version allowed by this version of the Starboard headers,
-inclusive. The API version is not stable and is open for changes.
+The maximum Starboard API version supported.
 
 ### SB_MINIMUM_API_VERSION
 
-The minimum API version allowed by this version of the Starboard headers,
-inclusive.
+The minimum Starboard API version supported.
 
 ### SB_NORETURN
 
@@ -120,8 +118,10 @@ Declare numeric literals of unsigned 64-bit type.
 
 ### SB_UNREFERENCED_PARAMETER(x)
 
-Trivially references a parameter that is otherwise unreferenced, preventing a
-compiler warning on some platforms.
+Deprecated: Per the Google C++ Style Guide, comment out unused parameter names
+(e.g., `void* /*context*/` / or `Type /*param_name*/` /), or use
+`[[maybe_unused]]` if conditionally unused. Trivially references a parameter
+that is otherwise unreferenced, preventing a compiler warning on some platforms.
 
 ### SB_WARN_UNUSED_RESULT
 

--- a/cobalt/site/docs/reference/starboard/modules/configuration.md
+++ b/cobalt/site/docs/reference/starboard/modules/configuration.md
@@ -119,9 +119,9 @@ Declare numeric literals of unsigned 64-bit type.
 ### SB_UNREFERENCED_PARAMETER(x)
 
 Deprecated: Per the Google C++ Style Guide, comment out unused parameter names
-(e.g., `void* /*context*/` / or `Type /*param_name*/` /), or use
-`[[maybe_unused]]` if conditionally unused. Trivially references a parameter
-that is otherwise unreferenced, preventing a compiler warning on some platforms.
+(e.g., `void* /*context*/` or `Type /*param_name*/`), or use `[[maybe_unused]]`
+if conditionally unused. Trivially references a parameter that is otherwise
+unreferenced, preventing a compiler warning on some platforms.
 
 ### SB_WARN_UNUSED_RESULT
 

--- a/cobalt/site/docs/reference/starboard/modules/egl.md
+++ b/cobalt/site/docs/reference/starboard/modules/egl.md
@@ -13,9 +13,7 @@ to directly pull in and use these system libraries.
 
 ## EGL Version
 
-This API has the ability to support EGL 1.5, however it is not required to
-support anything beyond EGL 1.4. The user is responsible for ensuring that the
-functions from EGL 1.5 they are calling from the interface are valid.
+This API requires support for EGL 1.5.
 
 ## Macros
 

--- a/cobalt/site/scripts/cobalt_gn_configuration.py
+++ b/cobalt/site/scripts/cobalt_gn_configuration.py
@@ -113,19 +113,19 @@ def main(source_dir, output_dir=None):
   # used must be listed here.
   # Note that `root_out_dir` is not a build argument and cannot be overridden.
   args = ['clang_base_path']
-  args_overrides = ' '.join(f'{x}="<{x}>"' for x in args)
   try:
     out_dir = '/project_out_dir'
-    subprocess.check_call(
-        [sys.executable, 'cobalt/build/gn.py', '-p', 'linux-x64x11', '-c', 'devel', '--no-rbe', out_dir],
-        cwd=source_dir)
-    
-    with open(os.path.join(out_dir, 'args.gn'), 'a') as f:
+    subprocess.check_call([
+        sys.executable, 'cobalt/build/gn.py', '-p', 'linux-x64x11', '-c',
+        'devel', '--no-rbe', out_dir
+    ],
+                          cwd=source_dir)
+
+    with open(os.path.join(out_dir, 'args.gn'), 'a', encoding='utf-8') as f:
       f.write('\n' + '\n'.join(f'{x}="<{x}>"' for x in args) + '\n')
 
     output = subprocess.check_output(
-        ['gn', 'args', out_dir, '--list', '--json'],
-        cwd=source_dir)
+        ['gn', 'args', out_dir, '--list', '--json'], cwd=source_dir)
   except subprocess.CalledProcessError as cpe:
     raise RuntimeError(f'Failed to run GN: {cpe.output}') from cpe
 

--- a/cobalt/site/scripts/cobalt_gn_configuration.py
+++ b/cobalt/site/scripts/cobalt_gn_configuration.py
@@ -116,9 +116,15 @@ def main(source_dir, output_dir=None):
   args_overrides = ' '.join(f'{x}="<{x}>"' for x in args)
   try:
     out_dir = '/project_out_dir'
-    subprocess.check_call(['gn', 'gen', out_dir], cwd=source_dir)
+    subprocess.check_call(
+        [sys.executable, 'cobalt/build/gn.py', '-p', 'linux-x64x11', '-c', 'devel', '--no-rbe', out_dir],
+        cwd=source_dir)
+    
+    with open(os.path.join(out_dir, 'args.gn'), 'a') as f:
+      f.write('\n' + '\n'.join(f'{x}="<{x}>"' for x in args) + '\n')
+
     output = subprocess.check_output(
-        ['gn', 'args', out_dir, '--list', '--json', '--args=' + args_overrides],
+        ['gn', 'args', out_dir, '--list', '--json'],
         cwd=source_dir)
   except subprocess.CalledProcessError as cpe:
     raise RuntimeError(f'Failed to run GN: {cpe.output}') from cpe

--- a/cobalt/site/scripts/cobalt_gn_configuration.py
+++ b/cobalt/site/scripts/cobalt_gn_configuration.py
@@ -116,7 +116,7 @@ def main(source_dir, output_dir=None):
   try:
     out_dir = '/project_out_dir'
     subprocess.check_call([
-        sys.executable, 'cobalt/build/gn.py', '-p', 'linux-x64x11', '-c',
+        sys.executable, 'cobalt/build/gn.py', '-p', 'evergreen-x64', '-c',
         'devel', '--no-rbe', out_dir
     ],
                           cwd=source_dir)

--- a/cobalt/site/scripts/cobalt_module_reference.py
+++ b/cobalt/site/scripts/cobalt_module_reference.py
@@ -213,7 +213,7 @@ def _node_to_markdown(out, node):
     assert not _strip(tail)
     out.paragraph()
   elif node.tag == 'bold':
-    assert len(node) == 0, f"bold node has children: {[c.tag for c in node]}"
+    assert len(node) == 0, f'bold node has children: {[c.tag for c in node]}'
     out.bold(text)
     text = ''
   elif node.tag == 'computeroutput':
@@ -250,7 +250,7 @@ def _node_to_markdown(out, node):
   elif node.tag == 'verbatim':
     # Verbatim tags can appear inside paragraphs.
     assert len(
-        node) == 0, f"verbatim node has children: {[c.tag for c in node]}"
+        node) == 0, f'verbatim node has children: {[c.tag for c in node]}'
     # Don't replace pipes in verbatim text.
     text = node.text if node.text else ''
     # Strip doxygen comment prefix '///' and one space if present

--- a/cobalt/site/scripts/cobalt_module_reference.py
+++ b/cobalt/site/scripts/cobalt_module_reference.py
@@ -213,8 +213,7 @@ def _node_to_markdown(out, node):
     assert not _strip(tail)
     out.paragraph()
   elif node.tag == 'bold':
-    assert len(
-        node) == 0, f"computeroutput node has children: {[c.tag for c in node]}"
+    assert len(node) == 0, f"bold node has children: {[c.tag for c in node]}"
     out.bold(text)
     text = ''
   elif node.tag == 'computeroutput':
@@ -251,7 +250,7 @@ def _node_to_markdown(out, node):
   elif node.tag == 'verbatim':
     # Verbatim tags can appear inside paragraphs.
     assert len(
-        node) == 0, f"computeroutput node has children: {[c.tag for c in node]}"
+        node) == 0, f"verbatim node has children: {[c.tag for c in node]}"
     # Don't replace pipes in verbatim text.
     text = node.text if node.text else ''
     # Strip doxygen comment prefix '///' and one space if present
@@ -273,8 +272,9 @@ def _node_to_markdown(out, node):
   if text:
     out.text(text)
 
-  for child in node:
-    _node_to_markdown(out, child)
+  if node.tag != 'computeroutput':
+    for child in node:
+      _node_to_markdown(out, child)
 
   if node.tag == 'para':
     out.end_paragraph()

--- a/cobalt/site/scripts/cobalt_module_reference.py
+++ b/cobalt/site/scripts/cobalt_module_reference.py
@@ -213,12 +213,11 @@ def _node_to_markdown(out, node):
     assert not _strip(tail)
     out.paragraph()
   elif node.tag == 'bold':
-    assert len(node) == 0
+    assert len(node) == 0, f"computeroutput node has children: {[c.tag for c in node]}"
     out.bold(text)
     text = ''
   elif node.tag == 'computeroutput':
-    assert len(node) == 0
-    out.code(text)
+    out.code(''.join(node.itertext()))
     text = ''
   elif node.tag == 'ulink':
     url = node.get('url')
@@ -250,7 +249,7 @@ def _node_to_markdown(out, node):
     out.heading(levels=levels)
   elif node.tag == 'verbatim':
     # Verbatim tags can appear inside paragraphs.
-    assert len(node) == 0
+    assert len(node) == 0, f"computeroutput node has children: {[c.tag for c in node]}"
     # Don't replace pipes in verbatim text.
     text = node.text if node.text else ''
     # Strip doxygen comment prefix '///' and one space if present

--- a/cobalt/site/scripts/cobalt_module_reference.py
+++ b/cobalt/site/scripts/cobalt_module_reference.py
@@ -213,7 +213,8 @@ def _node_to_markdown(out, node):
     assert not _strip(tail)
     out.paragraph()
   elif node.tag == 'bold':
-    assert len(node) == 0, f"computeroutput node has children: {[c.tag for c in node]}"
+    assert len(
+        node) == 0, f"computeroutput node has children: {[c.tag for c in node]}"
     out.bold(text)
     text = ''
   elif node.tag == 'computeroutput':
@@ -249,7 +250,8 @@ def _node_to_markdown(out, node):
     out.heading(levels=levels)
   elif node.tag == 'verbatim':
     # Verbatim tags can appear inside paragraphs.
-    assert len(node) == 0, f"computeroutput node has children: {[c.tag for c in node]}"
+    assert len(
+        node) == 0, f"computeroutput node has children: {[c.tag for c in node]}"
     # Don't replace pipes in verbatim text.
     text = node.text if node.text else ''
     # Strip doxygen comment prefix '///' and one space if present


### PR DESCRIPTION
Fixed a bug in cobalt_gn_configuration.py where gn args list was executed with --args flag which intercepts the AST and ignores the base build directory's pre-existing args.gn configs, causing Starboard variables to be omitted.

Fixed a bug in cobalt_module_reference.py where Doxygen generated `<zwj>` children inside computeroutput nodes from C++ comments, causing assertion failures during Markdown tree generation.

Bug: 559803042