### PR TITLE
starboard/media: Make video surface cleanup async on Android

### DIFF
--- a/media/mojo/services/starboard/starboard_renderer_wrapper.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.cc
@@ -29,6 +29,10 @@
 #include "ui/gfx/geometry/rect_conversions.h"
 #include "ui/gl/gl_bindings.h"
 
+#if BUILDFLAG(IS_ANDROID)
+#include "starboard/android/shared/video_window.h"
+#endif  // BUILDFLAG(IS_ANDROID)
+
 namespace media {
 
 namespace {
@@ -723,6 +727,19 @@ void StarboardRendererWrapper::GraphicsContextRunner(
   if (!provider || !provider->is_gpu_factory_initialized_) {
     return;
   }
+#if BUILDFLAG(IS_ANDROID)
+  // ClearNativeWindow creates its own temporary EGLContext/EGLSurface directly
+  // on ANativeWindow and does not need Chromium's stub_ context or synchronous
+  // wait.
+  if (target_function == &starboard::ClearNativeWindow) {
+    provider->gpu_task_runner_->PostTask(
+        FROM_HERE, base::BindOnce([](SbDecodeTargetGlesContextRunnerTarget func,
+                                     void* context) { func(context); },
+                                  target_function, target_function_context));
+    return;
+  }
+#endif  // BUILDFLAG(IS_ANDROID)
+
   if (provider->gpu_task_runner_->RunsTasksInCurrentSequence()) {
     // If it is on the gpu thread, post target_function() directly on it.
     target_function(target_function_context);

--- a/starboard/android/shared/video_window.cc
+++ b/starboard/android/shared/video_window.cc
@@ -54,6 +54,20 @@ VideoSurfaceHolder* g_video_surface_holder = nullptr;
 
 void ClearNativeWindow(void* raw_context) {
   ANativeWindow* native_window = static_cast<ANativeWindow*>(raw_context);
+  if (!native_window) {
+    return;
+  }
+
+  // Ensure ANativeWindow is released when done on the GPU thread.
+  struct ScopedNativeWindowRelease {
+    ANativeWindow* window;
+    ~ScopedNativeWindowRelease() {
+      if (window) {
+        ANativeWindow_release(window);
+      }
+    }
+  } scoped_release{native_window};
+
   EGLDisplay display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
   if (display == EGL_NO_DISPLAY) {
     SB_LOG(ERROR) << "Found no EGL display in ClearNativeWindow";
@@ -206,9 +220,12 @@ void VideoSurfaceHolder::CleanUpVideoSurface(
   }
 
   SB_CHECK(gpu_provider);
+  // Acquire an additional reference so g_native_video_window remains valid
+  // if cleared asynchronously on the GPU thread.
+  ANativeWindow_acquire(g_native_video_window);
   gpu_provider->gles_context_runner(gpu_provider, &ClearNativeWindow,
                                     g_native_video_window);
-  SB_LOG(INFO) << "Video surface has been cleared.";
+  SB_LOG(INFO) << "Video surface cleanup task dispatched.";
 }
 
 void VideoSurfaceHolder::ResetVideoSurface() {

--- a/starboard/android/shared/video_window.h
+++ b/starboard/android/shared/video_window.h
@@ -23,6 +23,10 @@
 
 namespace starboard {
 
+// Clears the native window by drawing a black rectangle using a temporary EGL
+// context.
+void ClearNativeWindow(void* raw_context);
+
 class VideoSurfaceHolder {
  public:
   // Return true only if the video surface is available.


### PR DESCRIPTION
- In VideoSurfaceHolder::CleanUpVideoSurface, acquire an additional reference to g_native_video_window before invoking gles_context_runner, and release it upon completion of ClearNativeWindow on the GPU thread.
- In StarboardRendererWrapper::GraphicsContextRunner, detect ClearNativeWindow on Android and dispatch it directly and asynchronously to gpu_task_runner_. This eliminates the blocking WaitableEvent wait on player teardown and avoids unnecessary MakeContextCurrent calls for a function that manages its own temporary EGLContext.