### PR TITLE
staging: Unskip RendererImplTest.* on evergreen-x64

### DIFF
--- a/cobalt/testing/filters/evergreen-x64/media_unittests_loader_filter.json
+++ b/cobalt/testing/filters/evergreen-x64/media_unittests_loader_filter.json
@@ -31,7 +31,6 @@
     "MojoDecryptorTest.*",
     "MP4StreamParserTest.*",
     "MPEG1AudioStreamParserTest.*",
-    "RendererImplTest.*",
     "SimpleSources.*",
     "Vp8ParserTest.*",
     "Vp9ParserTest.*",


### PR DESCRIPTION
Unskip the RendererImplTest suite in media_unittests for evergreen-x64.
These tests were previously skipped in 140.7339 roll (PR #12161) because
the RendererImplTest fixture left a dangling pointer to a process-global
media client, causing crashes in subsequent tests like FrameProcessorTest.

Upstream fixed this in https://crrev.com/c/8293641, backported to the
staging branch as PR #12528, so the suite can run again.

Bug: 552827012