### PR TITLE
starboard: Cap platform service message size

### DIFF
--- a/cobalt/browser/h5vcc_platform_service/platform_service_impl.cc
+++ b/cobalt/browser/h5vcc_platform_service/platform_service_impl.cc
@@ -33,6 +33,11 @@ namespace h5vcc_platform_service {
 
 namespace {
 
+// The limit is defined by the platform service extension, so that Cobalt and
+// the platform service implementations agree on it.
+constexpr uint64_t kMaxMessageLength =
+    kCobaltExtensionPlatformServiceMaxMessageLength;
+
 const CobaltExtensionPlatformServiceApi* GetPlatformServiceApi() {
   static const CobaltExtensionPlatformServiceApi* s_api = []() {
     auto api = static_cast<const CobaltExtensionPlatformServiceApi*>(
@@ -74,6 +79,19 @@ void PlatformServiceImpl::StarboardReceiveMessageCallback(void* context,
     LOG(WARNING) << "StarboardReceiveMessageCallback has null context.";
     return;
   }
+
+  if (length > kMaxMessageLength) {
+    LOG(ERROR) << "Dropping a received message of " << length
+               << " bytes, the limit is " << kMaxMessageLength << " bytes.";
+    return;
+  }
+
+  if (length > 0 && !data) {
+    LOG(ERROR) << "Dropping a received message with null data and a length of "
+               << length << " bytes.";
+    return;
+  }
+
   PlatformServiceImpl* instance = static_cast<PlatformServiceImpl*>(context);
 
   const uint8_t* byte_data = static_cast<const uint8_t*>(data);
@@ -133,6 +151,14 @@ bool PlatformServiceImpl::OpenStarboardService() {
 
 void PlatformServiceImpl::Send(base::span<const uint8_t> data,
                                SendCallback callback) {
+  if (data.size() > kMaxMessageLength) {
+    LOG(ERROR) << "Rejecting a message of " << data.size()
+               << " bytes, the limit is " << kMaxMessageLength << " bytes, for "
+               << service_name_;
+    std::move(callback).Run(std::nullopt, "Message too large");
+    return;
+  }
+
   const CobaltExtensionPlatformServiceApi* api = GetPlatformServiceApi();
   if (!api) {
     LOG(WARNING) << "The platform service extension is not implemented on this "

--- a/starboard/extension/platform_service.h
+++ b/starboard/extension/platform_service.h
@@ -34,6 +34,13 @@ typedef CobaltExtensionPlatformServicePrivate* CobaltExtensionPlatformService;
 #define kCobaltExtensionPlatformServiceName \
   "dev.cobalt.extension.PlatformService"
 
+// The maximum length, in bytes, of a message exchanged with a platform
+// service, in either direction. Cobalt rejects larger messages instead of
+// passing them to Send(), and drops larger messages received via
+// ReceiveMessageCallback. Platform service implementations should reject
+// larger messages as well..
+#define kCobaltExtensionPlatformServiceMaxMessageLength (1024ULL * 1024)
+
 // Checks whether a |CobaltExtensionPlatformService| is valid.
 static inline bool CobaltExtensionPlatformServiceIsValid(
     CobaltExtensionPlatformService service) {

--- a/starboard/linux/shared/pre_app_recommendation_service.cc
+++ b/starboard/linux/shared/pre_app_recommendation_service.cc
@@ -14,12 +14,14 @@
 
 #include "starboard/linux/shared/pre_app_recommendation_service.h"
 
+#include <cstdlib>
 #include <memory>
 #include <string>
 
 #include "starboard/common/log.h"
 #include "starboard/common/string.h"
 #include "starboard/configuration.h"
+#include "starboard/extension/platform_service.h"
 #include "starboard/linux/shared/platform_service.h"
 #include "starboard/shared/starboard/application.h"
 
@@ -38,6 +40,9 @@ typedef struct PreAppRecommendationsPlatformServiceImpl
   PreAppRecommendationsPlatformServiceImpl() = default;
 
 } PreAppRecommendationsPlatformServiceImpl;
+
+constexpr uint64_t kMaxMessageLength =
+    kCobaltExtensionPlatformServiceMaxMessageLength;
 
 // Use HTTP status code in response to YouTube application's method recommend
 // call.
@@ -97,6 +102,21 @@ std::string extractJsonValue(const std::string& jsonLikeString,
   return result;
 }
 
+// Copies |response| into a buffer allocated with malloc(), as the caller of
+// Send() in cobalt/browser/h5vcc_platform_service/platform_service_impl.cc
+// frees it. Returns nullptr if the allocation fails.
+void* AllocateResponse(const std::string& response, uint64_t* output_length) {
+  *output_length = response.length();
+  void* ptr = malloc(*output_length);
+  if (ptr == nullptr) {
+    SB_LOG(ERROR) << "Send() failed to allocate " << *output_length
+                  << " bytes for the response.";
+    return nullptr;
+  }
+  response.copy(reinterpret_cast<char*>(ptr), response.length());
+  return ptr;
+}
+
 void* Send(PlatformServiceImpl* service,
            const void* data,
            uint64_t length,
@@ -106,11 +126,16 @@ void* Send(PlatformServiceImpl* service,
   SB_DCHECK(data);
   SB_DCHECK(output_length);
 
-  char message[length + 1];
-  std::memcpy(message, data, length);
-  message[length] = '\0';
-
   std::string response = "";
+
+  if (data == nullptr || length > kMaxMessageLength) {
+    SB_LOG(ERROR) << "Send() rejecting a message of " << length
+                  << " bytes, the limit is " << kMaxMessageLength << " bytes.";
+    response = kBadRequest;
+    return AllocateResponse(response, output_length);
+  }
+
+  const std::string message(static_cast<const char*>(data), length);
 
   // TODO: Replace extractJsonValue function with a robust JSON parsing
   // library for production use. The current implementation has limited
@@ -167,10 +192,7 @@ void* Send(PlatformServiceImpl* service,
     }
   }
 
-  *output_length = response.length();
-  auto ptr = malloc(*output_length);
-  response.copy(reinterpret_cast<char*>(ptr), response.length());
-  return ptr;
+  return AllocateResponse(response, output_length);
 }
 
 const CobaltPlatformServiceApi kGetPreappRecommendationServiceApi = {

--- a/starboard/linux/shared/soft_mic_platform_service.cc
+++ b/starboard/linux/shared/soft_mic_platform_service.cc
@@ -14,6 +14,7 @@
 
 #include "starboard/linux/shared/soft_mic_platform_service.h"
 
+#include <cstdlib>
 #include <memory>
 #include <string>
 
@@ -21,6 +22,7 @@
 #include "starboard/common/log.h"
 #include "starboard/common/string.h"
 #include "starboard/configuration.h"
+#include "starboard/extension/platform_service.h"
 #include "starboard/linux/shared/platform_service.h"
 #include "starboard/shared/starboard/application.h"
 
@@ -38,6 +40,9 @@ typedef struct SoftMicPlatformServiceImpl : public PlatformServiceImpl {
   SoftMicPlatformServiceImpl() = default;
 
 } SoftMicPlatformServiceImpl;
+
+constexpr uint64_t kMaxMessageLength =
+    kCobaltExtensionPlatformServiceMaxMessageLength;
 
 const char kGetMicSupport[] = "\"getMicSupport\"";
 const char kNotifySearchActive[] = "\"notifySearchActive\"";
@@ -83,13 +88,17 @@ void* Send(PlatformServiceImpl* service,
   // failure.
   auto valid_message_received = false;
 
-  char message[length + 1];
-  std::memcpy(message, data, length);
-  message[length] = '\0';
+  std::string message;
+  if (length > kMaxMessageLength) {
+    SB_LOG(ERROR) << "Send() ignoring oversized message of " << length
+                  << " bytes, the limit is " << kMaxMessageLength << ".";
+  } else if (data != nullptr) {
+    message.assign(static_cast<const char*>(data), length);
+  }
 
   SB_LOG(INFO) << "Send() message: " << message;
 
-  if (strcmp(message, kGetMicSupport) == 0) {
+  if (message == kGetMicSupport) {
     // Process "getMicSupport" web app message.
     SB_LOG(INFO) << "Send() kGetMicSupport message received.";
 
@@ -148,11 +157,11 @@ void* Send(PlatformServiceImpl* service,
         response.length());
 
     valid_message_received = true;
-  } else if (strcmp(message, kNotifySearchActive) == 0) {
+  } else if (message == kNotifySearchActive) {
     // Process "notifySearchActive" web app message.
     SB_LOG(INFO) << "Send() kNotifySearchActive message received";
     valid_message_received = true;
-  } else if (strcmp(message, kNotifySearchInactive) == 0) {
+  } else if (message == kNotifySearchInactive) {
     // Process "notifySearchInactive" web app message.
     SB_LOG(INFO) << "Send() kNotifySearchInactive message received";
     valid_message_received = true;
@@ -164,6 +173,11 @@ void* Send(PlatformServiceImpl* service,
   // in cobalt/h5vcc/h5vcc_platform_service.cc Send() uses
   // free().
   bool* ptr = reinterpret_cast<bool*>(malloc(sizeof(bool)));
+  if (ptr == nullptr) {
+    SB_LOG(ERROR) << "Send() failed to allocate the response.";
+    *output_length = 0;
+    return nullptr;
+  }
   *ptr = valid_message_received;
   *output_length = sizeof(bool);
   return static_cast<void*>(ptr);


### PR DESCRIPTION
Implement a 1MB maximum message length for the Pre-App Recommendation
and SoftMic platform services. This prevents potential memory issues
when handling messages from the web application.

Additionally, refactor the message processing logic to use std::string
instead of fixed-length C-style arrays to improve safety and robustness
against malformed input.

Bug: 545795974