### PR TITLE
Add --skewport-target-time-in-seconds flag and set default to 0 in Cobalt

### DIFF
--- a/cc/base/switches.cc
+++ b/cc/base/switches.cc
@@ -120,6 +120,7 @@ const char kDecodedImageWorkingSetBudgetBytes[] =
     "decoded-image-working-set-budget-bytes";
 // Avoid reuse resource.
 const char kAvoidCCReuseResource[] = "avoid-cc-reuse-resource";
+const char kSkewportTargetTimeInSeconds[] = "skewport-target-time-in-seconds";
 #endif
 
 }  // namespace switches

--- a/cc/base/switches.h
+++ b/cc/base/switches.h
@@ -73,6 +73,7 @@ CC_BASE_EXPORT extern const char kCCImageCacheLimitMbs[];
 CC_BASE_EXPORT extern const char kDecodedImageWorkingSetBudgetBytes[];
 // Avoid reuse resource.
 CC_BASE_EXPORT extern const char kAvoidCCReuseResource[];
+CC_BASE_EXPORT extern const char kSkewportTargetTimeInSeconds[];
 #endif
 
 }  // namespace switches

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -42,6 +42,7 @@ public class JavaSwitches {
   public static final String DEFAULT_INITIAL_OLD_SPACE_SIZE = "64";
   public static final String DEFAULT_MAX_OLD_SPACE_SIZE = "512";
   public static final String DEFAULT_FORCE_GPU_MEM_AVAILABLE_MB = "64";
+  public static final String DEFAULT_SKEWPORT_TARGET_TIME_IN_SECONDS = "0";
 
   public static final String ENABLE_QUIC = "EnableQUIC";
 
@@ -149,6 +150,9 @@ public class JavaSwitches {
 
   /** flag to force GPU memory available in MB. */
   public static final String FORCE_GPU_MEM_AVAILABLE_MB = "ForceGpuMemAvailableMb";
+
+  /** flag to configure compositor skewport target time in seconds. */
+  public static final String SKEWPORT_TARGET_TIME_IN_SECONDS = "SkewportTargetTimeInSeconds";
 
   /** flag to enable area based buffer budget experiment. */
   public static final String AREA_BASED_VIDEO_BUFFER_BUDGET = "AreaBasedVideoBufferBudget";
@@ -306,6 +310,7 @@ public class JavaSwitches {
     if (!"arm64".equals(BuildInfo.getArch()) && !"x86_64".equals(BuildInfo.getArch())) {
       defaultArgs.add("--force-gpu-mem-available-mb=" + DEFAULT_FORCE_GPU_MEM_AVAILABLE_MB);
     }
+    defaultArgs.add("--skewport-target-time-in-seconds=" + DEFAULT_SKEWPORT_TARGET_TIME_IN_SECONDS);
     defaultArgs.add(
         "--js-flags=--initial-old-space-size="
             + DEFAULT_INITIAL_OLD_SPACE_SIZE
@@ -380,6 +385,15 @@ public class JavaSwitches {
 
     if (javaSwitches.containsKey(JavaSwitches.DISABLE_GPU_MEMORY_BUFFER_COMPOSITOR_RESOURCES)) {
       extraCommandLineArgs.add("--disable-gpu-memory-buffer-compositor-resources");
+    }
+
+    String skewportTargetTime =
+        getSanitizedNumericValue(javaSwitches, JavaSwitches.SKEWPORT_TARGET_TIME_IN_SECONDS);
+    if (skewportTargetTime != null) {
+      extraCommandLineArgs.add("--skewport-target-time-in-seconds=" + skewportTargetTime);
+    } else {
+      extraCommandLineArgs.add(
+          "--skewport-target-time-in-seconds=" + DEFAULT_SKEWPORT_TARGET_TIME_IN_SECONDS);
     }
 
     String limit = getSanitizedNumericValue(javaSwitches, JavaSwitches.GPU_IMAGE_CACHE_LIMIT_ITEMS);
@@ -523,8 +537,7 @@ public class JavaSwitches {
       enabledMemoryPressureFeatures.add("CobaltEnableModerateMemoryPressure");
     }
     if (javaSwitches.containsKey(JavaSwitches.MEMORY_PRESSURE_COOLDOWN_IN_SECONDS)) {
-      String cooldown =
-          javaSwitches.get(JavaSwitches.MEMORY_PRESSURE_COOLDOWN_IN_SECONDS);
+      String cooldown = javaSwitches.get(JavaSwitches.MEMORY_PRESSURE_COOLDOWN_IN_SECONDS);
       if (cooldown != null) {
         String cooldownVal = cooldown.replaceAll("[^0-9]", "");
         if (!cooldownVal.isEmpty()) {

--- a/cobalt/app/cobalt_switch_defaults_starboard.cc
+++ b/cobalt/app/cobalt_switch_defaults_starboard.cc
@@ -134,6 +134,9 @@ CommandLinePreprocessor::GetCobaltParamSwitchDefaults() {
       {::switches::kForceGpuMemAvailableMb, "64"},
       // Disable CC image cache items limit.
       {::switches::kCCImageCacheLimitItems, "0"},
+      // Disable skewport target time to avoid speculative offscreen tile
+      // rasterization.
+      {::switches::kSkewportTargetTimeInSeconds, "0"},
   };
   return kCobaltSwitchDefaults;
 }

--- a/cobalt/app/cobalt_switch_defaults_starboard_test.cc
+++ b/cobalt/app/cobalt_switch_defaults_starboard_test.cc
@@ -18,6 +18,7 @@
 
 #include "base/base_switches.h"
 #include "build/buildflag.h"
+#include "cc/base/switches.h"
 #include "cobalt/browser/switches.h"
 #include "cobalt/shell/common/shell_switches.h"
 #include "cobalt_switch_defaults.h"
@@ -124,6 +125,16 @@ TEST(CobaltSwitchDefaultsTest, GpuMemorySwitchDefault) {
   std::string gpu_mem =
       GetSwitchValue(cmd_line_pxr, ::switches::kForceGpuMemAvailableMb);
   EXPECT_EQ(std::string("64"), gpu_mem);
+}
+
+TEST(CobaltSwitchDefaultsTest, SkewportTargetTimeDefault) {
+  const auto input_argv = std::to_array<const char*>({"PROGRAM"});
+  const int input_argc = static_cast<int>(input_argv.size());
+  CommandLinePreprocessor cmd_line_pxr(input_argc, input_argv.data());
+
+  std::string skewport_time =
+      GetSwitchValue(cmd_line_pxr, ::switches::kSkewportTargetTimeInSeconds);
+  EXPECT_EQ(std::string("0"), skewport_time);
 }
 
 TEST(CobaltSwitchDefaultsTest, AlwaysEnabledSwitches) {

--- a/cobalt/app/cobalt_switch_defaults_tvos.cc
+++ b/cobalt/app/cobalt_switch_defaults_tvos.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "cc/base/switches.h"
 #include "cobalt/app/cobalt_switch_defaults.h"
 #include "cobalt/shell/common/shell_switches.h"
 #include "content/public/common/content_switches.h"
@@ -72,6 +73,9 @@ CommandLinePreprocessor::GetCobaltParamSwitchDefaults() {
       // Enable autoplay video/audio, as Cobalt may launch directly into media
       // playback before user interaction.
       {::switches::kAutoplayPolicy, "no-user-gesture-required"},
+      // Disable skewport target time to avoid speculative offscreen tile
+      // rasterization.
+      {::switches::kSkewportTargetTimeInSeconds, "0"},
   });
   return kCobaltSwitchDefaults;
 }

--- a/content/browser/renderer_host/render_process_host_impl.cc
+++ b/content/browser/renderer_host/render_process_host_impl.cc
@@ -3621,6 +3621,9 @@ void RenderProcessHostImpl::PropagateBrowserCommandLineToRenderer(
       switches::kBrowserControlsHideThreshold,
       switches::kBrowserControlsShowThreshold,
       switches::kRunAllCompositorStagesBeforeDraw,
+#if BUILDFLAG(IS_COBALT)
+      switches::kSkewportTargetTimeInSeconds,
+#endif
 
       network::switches::kForcePermissionPolicyUnloadDefaultEnabled,
 

--- a/third_party/blink/renderer/platform/widget/compositing/layer_tree_settings.cc
+++ b/third_party/blink/renderer/platform/widget/compositing/layer_tree_settings.cc
@@ -612,6 +612,21 @@ cc::LayerTreeSettings GenerateLayerTreeSettings(
            settings.skewport_extrapolation_limit_in_screen_pixels) =
       GetTilingInterestAreaSizes();
 
+#if BUILDFLAG(IS_COBALT)
+  if (cmd.HasSwitch(::switches::kSkewportTargetTimeInSeconds)) {
+    std::string string_value =
+        cmd.GetSwitchValueASCII(::switches::kSkewportTargetTimeInSeconds);
+    double skewport_target_time;
+    if (base::StringToDouble(string_value, &skewport_target_time) &&
+        skewport_target_time >= 0.0) {
+      settings.skewport_target_time_in_seconds =
+          static_cast<float>(skewport_target_time);
+      settings.gpu_rasterization_skewport_target_time_in_seconds =
+          static_cast<float>(skewport_target_time);
+    }
+  }
+#endif
+
   settings.dynamic_safe_area_insets_on_scroll_enabled =
       RuntimeEnabledFeatures::DynamicSafeAreaInsetsOnScrollEnabled();
   return settings;


### PR DESCRIPTION
## Summary
Introduce the `--skewport-target-time-in-seconds` switch (under `BUILDFLAG(IS_COBALT)`) to configure compositor skewport target time dynamically via command-line flags and Cobalt switch defaults rather than hardcoding upstream LayerTreeSettings defaults.

Set the default to "0" across Cobalt Starboard, Android, and tvOS switch defaults. Disabling speculative skewport pre-rastering for offscreen compositor tiles prevents excessive GPU texture memory allocations (saving up to ~46.7 MB of GPU memory during 4K video playback overlay navigation) without causing checkerboarding on constrained embedded devices.

Bug: 560189346