### PR TITLE
HTTP cache: enable css/wasm and blocklist

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -69,12 +69,6 @@ public class JavaSwitches {
   /** flag to enable deferred V8 bytecode serialization in background/idle */
   public static final String DEFER_V8_CODE_CACHE_WRITE = "DeferV8CodeCacheWrite";
 
-  /** flag to allow caching CSS and WebAssembly resources in the HTTP disk cache. */
-  public static final String ENABLE_CSS_AND_WASM_FOR_HTTP_CACHE = "EnableCssAndWasmForHttpCache";
-
-  /** flag to enable aggressive HTTP disk cache and V8 generated code cache tuning exclusions. */
-  public static final String ENABLE_HTTP_AND_V8_CACHE_TUNING = "EnableHttpAndV8CacheTuning";
-
   /** flag to re-enable freeze and resume events */
   public static final String ENABLE_FREEZE = "EnableFreeze";
 
@@ -462,14 +456,6 @@ public class JavaSwitches {
       extraCommandLineArgs.add("--max-http-cache-size=" + maxHttpCacheSize);
     }
 
-    if (javaSwitches.containsKey(JavaSwitches.ENABLE_CSS_AND_WASM_FOR_HTTP_CACHE)) {
-      extraCommandLineArgs.add("--enable-css-and-wasm-for-http-cache");
-    }
-
-    if (javaSwitches.containsKey(JavaSwitches.ENABLE_HTTP_AND_V8_CACHE_TUNING)) {
-      extraCommandLineArgs.add("--enable-http-and-v8-cache-tuning");
-    }
-
     if (jsFlags.length() > 0) {
       extraCommandLineArgs.add("--js-flags=" + jsFlags.toString());
     }
@@ -523,8 +509,7 @@ public class JavaSwitches {
       enabledMemoryPressureFeatures.add("CobaltEnableModerateMemoryPressure");
     }
     if (javaSwitches.containsKey(JavaSwitches.MEMORY_PRESSURE_COOLDOWN_IN_SECONDS)) {
-      String cooldown =
-          javaSwitches.get(JavaSwitches.MEMORY_PRESSURE_COOLDOWN_IN_SECONDS);
+      String cooldown = javaSwitches.get(JavaSwitches.MEMORY_PRESSURE_COOLDOWN_IN_SECONDS);
       if (cooldown != null) {
         String cooldownVal = cooldown.replaceAll("[^0-9]", "");
         if (!cooldownVal.isEmpty()) {

--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/util/JavaSwitchesTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/util/JavaSwitchesTest.java
@@ -241,8 +241,6 @@ public class JavaSwitchesTest {
     switches.put(JavaSwitches.DEFER_V8_CODE_CACHE_WRITE, "1");
     switches.put(JavaSwitches.ENABLE_GPU_SHADER_DISK_CACHE, "1");
     switches.put(JavaSwitches.MAX_HTTP_CACHE_SIZE, "50000000");
-    switches.put(JavaSwitches.ENABLE_CSS_AND_WASM_FOR_HTTP_CACHE, "1");
-    switches.put(JavaSwitches.ENABLE_HTTP_AND_V8_CACHE_TUNING, "1");
     switches.put(JavaSwitches.AVOID_CC_REUSE_RESOURCE, "1");
     switches.put(JavaSwitches.COBALT_BYPASS_RESOURCE_LOAD_SCHEDULER, "1");
     switches.put(JavaSwitches.COBALT_BYPASS_HTML_PRELOAD_SCANNER, "1");
@@ -274,8 +272,6 @@ public class JavaSwitchesTest {
     assertThat(args).contains("--defer-v8-code-cache-write");
     assertThat(args).contains("--enable-gpu-shader-disk-cache");
     assertThat(args).contains("--max-http-cache-size=50000000");
-    assertThat(args).contains("--enable-css-and-wasm-for-http-cache");
-    assertThat(args).contains("--enable-http-and-v8-cache-tuning");
     assertThat(args).contains("--avoid-cc-reuse-resource");
     assertThat(args).contains("--enable-features=CobaltBypassResourceLoadScheduler");
     assertThat(args).contains("--enable-features=CobaltBypassHTMLPreloadScanner");
@@ -328,8 +324,6 @@ public class JavaSwitchesTest {
     switches.put(JavaSwitches.DEFER_V8_CODE_CACHE_WRITE, "1");
     switches.put(JavaSwitches.ENABLE_GPU_SHADER_DISK_CACHE, "1");
     switches.put(JavaSwitches.MAX_HTTP_CACHE_SIZE, "50000000");
-    switches.put(JavaSwitches.ENABLE_CSS_AND_WASM_FOR_HTTP_CACHE, "1");
-    switches.put(JavaSwitches.ENABLE_HTTP_AND_V8_CACHE_TUNING, "1");
     switches.put(JavaSwitches.AVOID_CC_REUSE_RESOURCE, "1");
     switches.put(JavaSwitches.COBALT_BYPASS_RESOURCE_LOAD_SCHEDULER, "1");
     switches.put(JavaSwitches.COBALT_BYPASS_HTML_PRELOAD_SCANNER, "1");
@@ -358,8 +352,6 @@ public class JavaSwitchesTest {
     assertThat(args).doesNotContain("--defer-v8-code-cache-write");
     assertThat(args).doesNotContain("--enable-gpu-shader-disk-cache");
     assertThat(args).doesNotContain("--max-http-cache-size=50000000");
-    assertThat(args).doesNotContain("--enable-css-and-wasm-for-http-cache");
-    assertThat(args).doesNotContain("--enable-http-and-v8-cache-tuning");
     assertThat(args).doesNotContain("--avoid-cc-reuse-resource");
     assertThat(args).doesNotContain("--use-surface-view-for-ui");
     assertThat(args).doesNotContain("--allow-critical-memory-pressure-handling-in-foreground");

--- a/content/browser/code_cache/generated_code_cache.cc
+++ b/content/browser/code_cache/generated_code_cache.cc
@@ -481,16 +481,9 @@ void GeneratedCodeCache::WriteEntry(const GURL& url,
 
 #if BUILDFLAG(IS_COBALT)
   if (cache_type_ == CodeCacheType::kJavaScript) {
-    // We skip caching below experimental thresholds (16KB) to preserve
-    // cache slots for heavy core bundles. Cache switch evaluations statically
-    // once per runtime process to avoid redundant map lookups.
-    static const size_t kMinBytecodeSize = [] {
-      auto* command_line = base::CommandLine::ForCurrentProcess();
-      if (command_line->HasSwitch("enable-http-and-v8-cache-tuning")) {
-        return 16384;
-      }
-      return 1024;
-    }();
+    // We skip caching below experimental thresholds to preserve
+    // cache slots for heavy core bundles.
+    constexpr size_t kMinBytecodeSize = 1024;
     if (data.size() < kMinBytecodeSize) {
       return;
     }

--- a/net/http/http_cache_transaction.cc
+++ b/net/http/http_cache_transaction.cc
@@ -3998,27 +3998,15 @@ bool HttpCache::Transaction::UpdateAndReportCacheability(
     return true;  // Reject unknown MIME types.
   }
 
-  // Cache command line evaluations statically once per process runtime to avoid
-  // redundant map lookups and string comparisons on every transaction.
-  static const bool enable_css_and_wasm_caching =
-      base::CommandLine::ForCurrentProcess()->HasSwitch(
-          "enable-css-and-wasm-for-http-cache");
-  static const bool enable_cache_tuning =
-      base::CommandLine::ForCurrentProcess()->HasSwitch(
-          "enable-http-and-v8-cache-tuning");
-
   // Maintain a consolidated list of accepted asset MIME types (exact or suffix).
   static const base::NoDestructor<std::vector<std::string_view>> accepted_asset_types([] {
-    std::vector<std::string_view> types = {
+    return std::vector<std::string_view>{
         "text/html",
         "javascript",
         "ecmascript",
+        "text/css",
+        "application/wasm",
     };
-    if (enable_css_and_wasm_caching) {
-      types.push_back("text/css");
-      types.push_back("application/wasm");
-    }
-    return types;
   }());
 
   bool is_accepted_mime_type = false;
@@ -4034,25 +4022,23 @@ bool HttpCache::Transaction::UpdateAndReportCacheability(
     return true;  // Do not write to cache / doom existing entry
   }
 
-  if (enable_cache_tuning) {
-    // Exclude Ad Impression Pings & Telemetry reporting endpoints.
-    for (std::string_view excluded :
-         {"/api/stats/ads", "/pagead/", "/ptracking", "eligibility_check"}) {
-      if (request_->url.spec().find(excluded) != std::string::npos) {
-        return true;
-      }
-    }
-
-    // Exclude HTTP error status codes (< 200 or >= 400) and Captive Portals.
-    if (headers.response_code() < 200 || headers.response_code() >= 400) {
+  // Exclude Ad Impression Pings & Telemetry reporting endpoints.
+  for (std::string_view excluded :
+       {"/api/stats/ads", "/pagead/", "/ptracking", "eligibility_check"}) {
+    if (request_->url.spec().find(excluded) != std::string::npos) {
       return true;
     }
+  }
 
-    // Exclude micro-resources (< 512B) where socket read beats eMMC IO overhead.
-    int64_t len = headers.GetContentLength();
-    if (len >= 0 && len < 512) {
-      return true;
-    }
+  // Exclude HTTP error status codes (< 200 or >= 400) and Captive Portals.
+  if (headers.response_code() < 200 || headers.response_code() >= 400) {
+    return true;
+  }
+
+  // Exclude micro-resources (< 512B) where socket read beats eMMC IO overhead.
+  int64_t len = headers.GetContentLength();
+  if (len >= 0 && len < 512) {
+    return true;
   }
 #endif
 

--- a/net/http/http_cache_transaction.cc
+++ b/net/http/http_cache_transaction.cc
@@ -3999,18 +3999,16 @@ bool HttpCache::Transaction::UpdateAndReportCacheability(
   }
 
   // Maintain a consolidated list of accepted asset MIME types (exact or suffix).
-  static const base::NoDestructor<std::vector<std::string_view>> accepted_asset_types([] {
-    return std::vector<std::string_view>{
-        "text/html",
-        "javascript",
-        "ecmascript",
-        "text/css",
-        "application/wasm",
-    };
-  }());
+  static constexpr std::string_view accepted_asset_types[] = {
+      "text/html",
+      "javascript",
+      "ecmascript",
+      "text/css",
+      "application/wasm",
+  };
 
   bool is_accepted_mime_type = false;
-  for (std::string_view type : *accepted_asset_types) {
+  for (std::string_view type : accepted_asset_types) {
     if (mime_type == type ||
         base::EndsWith(mime_type, type, base::CompareCase::SENSITIVE)) {
       is_accepted_mime_type = true;
@@ -4023,8 +4021,9 @@ bool HttpCache::Transaction::UpdateAndReportCacheability(
   }
 
   // Exclude Ad Impression Pings & Telemetry reporting endpoints.
-  for (std::string_view excluded :
-       {"/api/stats/ads", "/pagead/", "/ptracking", "eligibility_check"}) {
+  static constexpr std::string_view kExcludedPaths[] = {
+      "/api/stats/ads", "/pagead/", "/ptracking", "eligibility_check"};
+  for (std::string_view excluded : kExcludedPaths) {
     if (request_->url.spec().find(excluded) != std::string::npos) {
       return true;
     }


### PR DESCRIPTION
This PR removes experimental java switches and enables CSS and WASM caching for the HTTP cache as well as  exclusions such as `/api/stats/ads`, `/pagead/`, `/ptracking`, and `eligibility_check`. This PR removes the experimental 16KB V8 cache script threshold as it regressed Kabuki app start latency. 

See previous PR's: #11695 and #11688

Bug: 542408303
Bug: 542406016