### PR TITLE
cobalt: Route C allocations through PartitionAlloc on Evergreen

### DIFF
--- a/base/allocator/partition_allocator/src/partition_alloc/partition_root.cc
+++ b/base/allocator/partition_allocator/src/partition_alloc/partition_root.cc
@@ -1333,6 +1333,30 @@ PartitionRoot::~PartitionRoot() {
 
 void PartitionRoot::EnableThreadCacheIfSupported() {
 #if PA_CONFIG(THREAD_CACHE_SUPPORTED)
+#if PA_BUILDFLAG(IS_COBALT_HERMETIC_BUILD)
+  // Cobalt hermetic builds are compiled with `-femulated-tls`, so the first
+  // access to a `thread_local` on a thread calls `malloc()`. Since
+  // PartitionAlloc provides `malloc()`, `ThreadCache::Create()` below reenters
+  // this root. That is safe while only `thread_cache_construction_lock` is
+  // held: as `MaybeInitThreadCache()` describes, the reentrant allocation fails
+  // to acquire it and simply skips the thread cache. It is not safe while the
+  // global `lock_` is held, which deadlocks, or trips the reentrancy
+  // `PA_CHECK`. Take `lock_` only for the `with_thread_cache` check-and-set it
+  // actually protects. Every other platform keeps the ordering below.
+  {
+    ::partition_alloc::internal::ScopedGuard construction_guard{
+        thread_cache_construction_lock};
+
+    ThreadCache::Init(this);
+    // Create thread cache for this thread so that we can start using it right
+    // after.
+    ThreadCache::Create(this);
+  }
+
+  ::partition_alloc::internal::ScopedGuard guard{lock_};
+  PA_CHECK(!settings.with_thread_cache);
+  settings.with_thread_cache = true;
+#else
   ::partition_alloc::internal::ScopedGuard guard{lock_};
   PA_CHECK(!settings.with_thread_cache);
   // By the time we get there, there may be multiple threads created in the
@@ -1352,6 +1376,7 @@ void PartitionRoot::EnableThreadCacheIfSupported() {
   }
 
   settings.with_thread_cache = true;
+#endif  // PA_BUILDFLAG(IS_COBALT_HERMETIC_BUILD)
 #endif  // PA_CONFIG(THREAD_CACHE_SUPPORTED)
 }
 

--- a/base/allocator/partition_allocator/src/partition_alloc/shim/allocator_shim.cc
+++ b/base/allocator/partition_allocator/src/partition_alloc/shim/allocator_shim.cc
@@ -33,10 +33,20 @@
 #include "partition_alloc/shim/allocator_shim_override_cpp_symbols.h"
 
 #if BUILDFLAG(IS_COBALT_HERMETIC_BUILD)
-// Don't include anything, all includes are already set up in MUSL libc
-#else
-#include "partition_alloc/shim/allocator_shim_override_libc_symbols.h"
+// glibc declares the C allocation functions with __THROW, so upstream the
+// definitions below are decorated to match. musl declares them without any
+// exception specification, so the decoration has to be dropped here or the
+// definitions conflict with the declarations in musl's <malloc.h> and
+// <stdlib.h>.
+//
+// This cannot be handled in allocator_shim_internals.h: libc++ declares the
+// nothrow operator new/delete overloads with _NOEXCEPT, so
+// allocator_shim_override_cpp_symbols.h (included above) needs __THROW to keep
+// expanding to noexcept.
+#undef __THROW
+#define __THROW
 #endif
+#include "partition_alloc/shim/allocator_shim_override_libc_symbols.h"
 
 // Some glibc versions (until commit 6c444ad6e953dbdf9c7be065308a0a777)
 // incorrectly call __libc_memalign() to allocate memory (see elf/dl-tls.c in

--- a/starboard/tools/api_leak_detector/api_leak_detector.py
+++ b/starboard/tools/api_leak_detector/api_leak_detector.py
@@ -83,6 +83,25 @@ _MANIFEST_HEADER = ('# Manifest of Leaking Files\n\n' +
 _UNKNOWN_LIBRARIES = 'unknown_library(ies)'
 _UNKNOWN_SOURCE_FILES = 'unknown_source_file(s)'
 
+# Symbols the Cobalt module must not import, even though exported_symbols.cc
+# still lists them. PartitionAlloc defines the C allocation functions inside the
+# module, so importing them instead would split the heap between PartitionAlloc
+# and the platform allocator: memory obtained from one would be released to the
+# other. The loader keeps exporting them for modules built before that was the
+# case, which is why they cannot simply be dropped from exported_symbols.cc.
+_DENIED_SYMBOLS = frozenset({
+    'aligned_alloc',
+    'calloc',
+    'free',
+    'malloc',
+    'malloc_usable_size',
+    'memalign',
+    'posix_memalign',
+    'pvalloc',
+    'realloc',
+    'valloc',
+})
+
 
 def DiffWithManifest(leaked_symbols, manifest_path):
   manifest_symbols = LoadManifest(manifest_path)
@@ -267,8 +286,17 @@ def FindLeakLocations(leaked_symbols, config_path, only_grep, use_ripgrep):
     # we just assume those are matches.
     leaking_files[_UNKNOWN_LIBRARIES][symbol] = set()
     for obj_file in obj_files_to_check:
-      if os.path.splitext(obj_file)[1] == '.rlib' or symbol in ProcessNmOutput(
-          RunCommand(['nm', '-u', '-C', obj_file])):
+      if os.path.splitext(obj_file)[1] == '.rlib':
+        leaking_files[_UNKNOWN_LIBRARIES][symbol].add(
+            '//' + os.path.relpath(obj_file, paths.REPOSITORY_ROOT))
+        continue
+
+      # grep matches any file containing the symbol name, including text files
+      # such as ninja depfiles, which nm cannot parse. Treat those as misses
+      # rather than letting nm's failure abort the report.
+      nm_output = RunCommand(['nm', '-u', '-C', obj_file],
+                             valid_exit_codes=[0, 1])
+      if symbol in ProcessNmOutput(nm_output):
         leaking_files[_UNKNOWN_LIBRARIES][symbol].add(
             '//' + os.path.relpath(obj_file, paths.REPOSITORY_ROOT))
 
@@ -507,7 +535,16 @@ def main():
   # Starboard functions and extern configuration variables filtered out.
   allowed_symbols = LoadExportedSymbols()
 
+  # The denied symbols only apply to the Cobalt module, which is the one that
+  # bundles PartitionAlloc. Other modules, such as nplb, do not, and so
+  # legitimately use the allocator the loader exports.
+  denied_symbols = _DENIED_SYMBOLS if args.target == _DEFAULT_TARGET \
+      else frozenset()
+
   def IsAllowedSymbol(symbol):
+    if symbol in denied_symbols:
+      return False
+
     if symbol in allowed_symbols:
       return True
 


### PR DESCRIPTION
Evergreen (hermetic) builds excluded `allocator_shim_override_libc_symbols.h`
under `BUILDFLAG(IS_COBALT_HERMETIC_BUILD)`, so only C++ `new`/`delete` were
routed to PartitionAlloc. The C allocation functions (`malloc`, `free`,
`calloc`, `realloc`, `memalign`, `aligned_alloc`, `posix_memalign`,
`malloc_usable_size`) were left undefined inside `libcobalt.so` and were bound
at load time by the ELF loader to the platform's libc allocator via
`starboard/elf_loader/exported_symbols.cc`.

The result was two heaps in one process: PartitionAlloc for C++ objects, and
the vendor libc heap for every C allocation. This change includes the header
unconditionally so all allocations go through PartitionAlloc.

The comment this replaces ("all includes are already set up in MUSL libc") was
misleading: musl provides no allocator here at all. `third_party/musl/BUILD.gn`
does not compile any of `src/malloc/*.c`, so those symbols were resolving
across the Evergreen ABI boundary to the platform's libc.

### The `__THROW` handling

Dropping the `#if` on its own does not compile. `allocator_shim_internals.h`
skips `<sys/cdefs.h>` on hermetic builds and then falls through to libc++'s
`_NOEXCEPT`, so `__THROW` expands to `noexcept`. glibc declares these functions
with `__THROW` so upstream they match, but musl declares them bare
(`void *malloc (size_t);`), producing nine `exception specification in
declaration does not match previous declaration` errors.

`__THROW` is redefined to nothing immediately before the libc override header
rather than in `allocator_shim_internals.h`, because libc++ declares the
nothrow `operator new`/`delete` overloads with `_NOEXCEPT` — the C++ override
header still needs `__THROW` to expand to `noexcept`. Fixing it in the shared
header breaks those four declarations instead.

### Verification

Built `evergreen-x64 devel` locally.

### Measurements

Lab results on RDK reported in the bug showed reduced fragmentation in the
PartitionAlloc roots and improvements on `browseBenchmark`,
`browseWatchNext1080pSdr60` and `browseWatchNext4k`.

### Known risk

Evergreen has a cross-ABI pointer-ownership boundary. Memory allocated by the
platform side and freed inside `libcobalt.so` (for example the buffer returned
by `realpath`, which is imported from the loader rather than compiled in) now
reaches PartitionAlloc's `free`. The `IsManagedByPartitionAlloc` fallback in
`allocator_shim_default_dispatch_to_partition_alloc.cc` is compiled only on
Apple (plus a `__real_free` path on Cast Android), so such a pointer is not
handled gracefully. CI cannot detect this class of bug; it needs an audit of
every exported symbol that returns or consumes heap memory across the ABI.

Bug: 558848944
TAG=agy
CONV=25f8cf9f-fe64-4e2c-91c0-3ef0f7b79739
